### PR TITLE
Reduced cluster id because prefix for stage is too long

### DIFF
--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -107,7 +107,7 @@ func (i *RedisInstance) init(uuid string,
 	i.Tags = plan.Tags
 	i.Description = plan.Description
 
-	i.ClusterID = s.DbNamePrefix + "-redis-" + helpers.RandStr(15)
+	i.ClusterID = s.DbNamePrefix + "-redis-" + helpers.RandStr(12)
 	i.Salt = helpers.GenerateSalt(aes.BlockSize)
 	password := helpers.RandStr(25)
 	if err := i.setPassword(password, s.EncryptionKey); err != nil {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Made Cluster-ID shorter because we went over length

## Security considerations
- None
