### PR TITLE
Update redis broker with cluster id as service id

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -86,6 +86,7 @@ jobs:
       current_app_name: aws-broker
       environment_variables:
         DB_PREFIX: ((development-db-name-prefix))
+        DB_SHORTHAND_PREFIX: dev
         AUTH_PASS: ((development-auth-pass))
         AUTH_USER: ((development-auth-user))
         AWS_DEFAULT_REGION: ((development-aws-default-region))
@@ -312,6 +313,7 @@ jobs:
       current_app_name: aws-broker
       environment_variables:
         DB_PREFIX: ((staging-db-name-prefix))
+        DB_SHORTHAND_PREFIX: stg
         AUTH_PASS: ((staging-auth-pass))
         AUTH_USER: ((staging-auth-user))
         AWS_DEFAULT_REGION: ((staging-aws-default-region))
@@ -591,6 +593,7 @@ jobs:
       current_app_name: aws-broker
       environment_variables:
         DB_PREFIX: ((prod-db-name-prefix))
+        DB_SHORTHAND_PREFIX: prd
         AUTH_PASS: ((prod-auth-pass))
         AUTH_USER: ((prod-auth-user))
         AWS_DEFAULT_REGION: ((prod-aws-default-region))

--- a/config/settings.go
+++ b/config/settings.go
@@ -13,6 +13,7 @@ import (
 type Settings struct {
 	EncryptionKey             string
 	DbNamePrefix              string
+	DbShorthandPrefix         string
 	MaxAllocatedStorage       int64
 	DbConfig                  *common.DBConfig
 	Environment               string
@@ -65,6 +66,11 @@ func (s *Settings) LoadFromEnv() error {
 	s.DbNamePrefix = os.Getenv("DB_PREFIX")
 	if s.DbNamePrefix == "" {
 		s.DbNamePrefix = "db"
+	}
+
+	s.DbShorthandPrefix = os.Getenv("DB_SHORTHAND_PREFIX")
+	if s.DbShorthandPrefix == "" {
+		s.DbShorthandPrefix = "db"
 	}
 
 	// Set env to production

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -50,6 +50,8 @@ const PgroupPrefix = "cg-redis-broker-"
 
 func (d *dedicatedRedisAdapter) createRedis(i *RedisInstance, password string) (base.InstanceState, error) {
 	svc := elasticache.New(session.New(), aws.NewConfig().WithRegion(d.settings.Region))
+
+	// Elasticache Redis does not currently support custom tags (possibly in the future)
 	var redisTags []*elasticache.Tag
 
 	for k, v := range i.Tags {

--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -112,7 +112,7 @@ func (i *RedisInstance) init(uuid string,
 	i.Tags = plan.Tags
 	i.Description = plan.Description
 
-	i.ClusterID = s.DbNamePrefix + "-redis-" + helpers.RandStr(12)
+	i.ClusterID = s.DbShorthandPrefix + "-" + serviceID
 	i.Salt = helpers.GenerateSalt(aes.BlockSize)
 	password := helpers.RandStr(25)
 	if err := i.setPassword(password, s.EncryptionKey); err != nil {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update `ClusterId` of AWS Redis to use the `<env>-<ServiceId>`

## Security considerations

None