### PR TITLE
Switched from Service ID to UUID

### DIFF
--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -112,7 +112,7 @@ func (i *RedisInstance) init(uuid string,
 	i.Tags = plan.Tags
 	i.Description = plan.Description
 
-	i.ClusterID = s.DbShorthandPrefix + "-" + serviceID
+	i.ClusterID = s.DbShorthandPrefix + "-" + uuid
 	i.Salt = helpers.GenerateSalt(aes.BlockSize)
 	password := helpers.RandStr(25)
 	if err := i.setPassword(password, s.EncryptionKey); err != nil {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Mistakenly used wrong id for the cluster id so it's now using actual uuid and not uuid for service. 

## Security considerations
None