### PR TITLE
UTC windows need ddd code for both values of the window

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -496,7 +496,7 @@ redis:
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
       parameterGroup: default.redis5.0
-      preferredMaintenanceWindow: mon07:00-08:00
+      preferredMaintenanceWindow: mon07:00-mon08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
       automaticFailoverEnabled: false
@@ -525,7 +525,7 @@ redis:
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
       parameterGroup: default.redis5.0
-      preferredMaintenanceWindow: mon07:00-08:00
+      preferredMaintenanceWindow: mon07:00-mon08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
       automaticFailoverEnabled: true
@@ -554,7 +554,7 @@ redis:
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
       parameterGroup: default.redis5.0
-      preferredMaintenanceWindow: mon07:00-08:00
+      preferredMaintenanceWindow: mon07:00-mon08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
       automaticFailoverEnabled: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- AWS needs ddd:hh:mm format for both sides of the maintenance window even in with-in the same day

## Security considerations

None
