### PR TITLE
Enable t2/t3 micro instance plans for PostgreSQL and MySQL in AWS RDS

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -255,6 +255,34 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
+    - id: "0af67edb-30d8-4bb3-81c7-324c18d3efb2"
+      name: "micro-mysql"
+      description: "Dedicated micro RDS MySQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated RDS instance"
+          - "MySQL instance"
+        costs:
+          -
+            amount:
+              usd: 0.020
+            unit: "HOURLY"
+        displayName: "Dedicated micro MySQL"
+      free: false
+      adapter: dedicated
+      instanceClass: db.t2.micro
+      allocatedStorage: 10
+      dbType: mysql
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.mysql_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
     - id: "2ba54329-8264-486f-85bf-50c9f24085a9"
       name: "medium-mysql"
       description: "Dedicated medium RDS MySQL DB instance"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -273,6 +273,7 @@ rds:
       instanceClass: db.t2.micro
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: &mysql-version "5.7.21"
       redundant: false
       encrypted: true
       storage_type: gp2

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -36,6 +36,35 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
+    -
+      id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
+      name: "micro-psql"
+      description: "Dedicated micro RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated RDS instance"
+          - "PostgreSQL instance"
+        costs:
+          -
+            amount:
+              usd: 0.022
+            unit: "HOURLY"
+        displayName: "Dedicated micro PostgreSQL"
+      free: false
+      adapter: dedicated
+      instanceClass: db.t3.micro
+      allocatedStorage: 10
+      dbType: postgres
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
     - id: "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
       name: "medium-psql"
       description: "Dedicated medium RDS PostgreSQL DB instance"
@@ -102,7 +131,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.235
+              usd: 0.218
             unit: "HOURLY"
         displayName: "Dedicated large PostgreSQL"
       free: false
@@ -130,7 +159,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.470
+              usd: 0.436
             unit: "HOURLY"
         displayName: "Dedicated redundant large PostgreSQL"
       free: false
@@ -158,7 +187,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.445
+              usd: 0.436
             unit: "HOURLY"
         displayName: "Dedicated x-large PostgreSQL"
       free: false
@@ -186,7 +215,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.890
+              usd: 0.872
             unit: "HOURLY"
         displayName: "Dedicated redundant x-large PostgreSQL"
       free: false

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -439,7 +439,7 @@ rds:
         - "License Included"
         costs:
         - amount:
-            usd: 0.247
+            usd: 0.162
           unit: "HOURLY"
         displayName: "Dedicated medium Oracle SE2"
       free: false
@@ -468,7 +468,7 @@ rds:
         - "License Included"
         costs:
         - amount:
-            usd: 1.061
+            usd: 1.002
         unit: "HOURLY"
         displayName: "Dedicated large SQL Server 2016 SE"
       free: false

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -323,7 +323,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.220
+              usd: 0.210
             unit: "HOURLY"
         displayName: "Dedicated large MySQL"
       free: false
@@ -352,7 +352,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.440
+              usd: 0.420
             unit: "HOURLY"
         displayName: "Dedicated redundant large MySQL"
       free: false
@@ -381,7 +381,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.425
+              usd: 0.420
             unit: "HOURLY"
         displayName: "Dedicated x-large MySQL"
       free: false
@@ -410,7 +410,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.850
+              usd: 0.840
             unit: "HOURLY"
         displayName: "Dedicated redundant x-large MySQL"
       free: false


### PR DESCRIPTION
Add support for new micro instance plans
    
This changeset adds support for choosing micro service instance plans for PostgreSQL and MySQL in AWS RDS.  It also updates the prices associated with each instance to reflect current pricing found at the following for the GovCloud (West) region:
    - https://aws.amazon.com/rds/previous-generation/
    - https://aws.amazon.com/rds/postgresql/pricing/
    - https://aws.amazon.com/rds/mysql/pricing/

## Security considerations
None - this is just enabling two other instance class types for our RDS service offering.
