### PR TITLE
increasing BETA ES disk to account for cluster overhead so users get …

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -654,7 +654,7 @@ elasticsearch:
     elasticsearchVersion: 7.4
     dataCount: 1
     instanceType: t2.small.elasticsearch
-    volumeSize: 10
+    volumeSize: 15
     volumeType: gp2
     encryptAtRest: false
     automatedSnapshotStartHour: 7
@@ -681,7 +681,7 @@ elasticsearch:
     dataCount: 2
     instanceType: c5.large.elasticsearch
     masterInstanceType: c5.large.elasticsearch
-    volumeSize: 10
+    volumeSize: 15
     volumeType: gp2
     masterEnabled: true
     nodeToNodeEncryption: true
@@ -710,7 +710,7 @@ elasticsearch:
     dataCount: 4
     instanceType: c5.large.elasticsearch
     masterInstanceType: c5.large.elasticsearch
-    volumeSize: 10
+    volumeSize: 15
     volumeType: gp2
     masterEnabled: true
     nodeToNodeEncryption: true


### PR DESCRIPTION
…10 GB of storage

## Changes proposed in this pull request:

- Up from 10 to 15 GB so after cluster overhead users get 10 GB of storage

## Security considerations

NA
