### PR TITLE
Set micro/small RDS service plans to be free

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -50,7 +50,7 @@ rds:
               usd: 0.022
             unit: "HOURLY"
         displayName: "Dedicated micro PostgreSQL"
-      free: false
+      free: true
       adapter: dedicated
       instanceClass: db.t3.micro
       allocatedStorage: 10
@@ -275,7 +275,7 @@ rds:
               usd: 0.041
             unit: "HOURLY"
         displayName: "Dedicated small MySQL"
-      free: false
+      free: true
       adapter: dedicated
       instanceClass: db.t2.small
       allocatedStorage: 10

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -503,17 +503,17 @@ rds:
         service: "aws-broker"
     - id: "43b6954b-46c3-4a45-9ca3-995e552ef558"
       name: "large-sqlserver-se"
-      description: "Dedicated large RDS SQL Server 2016 SE DB instance"
+      description: "Dedicated large RDS SQL Server SE DB instance"
       metadata:
         bullets:
         - "Dedicated RDS instance"
-        - "SQL Server 2016 Standard Edition instance"
+        - "SQL Server Standard Edition instance"
         - "License Included"
         costs:
         - amount:
             usd: 1.002
         unit: "HOURLY"
-        displayName: "Dedicated large SQL Server 2016 SE"
+        displayName: "Dedicated large SQL Server SE"
       free: false
       adapter: dedicated
       instanceClass: db.m5.large

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -195,7 +195,7 @@ rds:
               usd: 0.022
             unit: "HOURLY"
         displayName: "Dedicated micro PostgreSQL"
-      free: false
+      free: true
       adapter: dedicated
       instanceClass: db.t3.micro
       allocatedStorage: 10
@@ -305,7 +305,7 @@ rds:
               usd: 0.041
             unit: "HOURLY"
         displayName: "Dedicated small MySQL"
-      free: false
+      free: true
       adapter: dedicated
       instanceClass: db.t2.small
       dbType: mysql


### PR DESCRIPTION
Part of https://github.com/cloud-gov/product/issues/1400

This changeset switches the pricing for the `micro-psql` and `small-mysql` service plans to be `free` instead of `paid`.  This will enable both of these plans to become available to all sandbox users.

## Changes proposed in this pull request:
- Update the service plan catalog files with this free pricing switch

## Security considerations
None
