### PR TITLE
ES Manual Snapshots to S3

### DIFF
--- a/base/broker.go
+++ b/base/broker.go
@@ -15,7 +15,7 @@ type Broker interface {
 	// LastOperation uses the catalog and parsed request to get an instance status for the particular type of service.
 	LastOperation(*catalog.Catalog, string, Instance) response.Response
 	// BindInstance takes the existing instance and binds it to an app.
-	BindInstance(*catalog.Catalog, string, Instance) response.Response
+	BindInstance(*catalog.Catalog, string, request.Request, Instance) response.Response
 	// DeleteInstance deletes the existing instance.
 	DeleteInstance(*catalog.Catalog, string, Instance) response.Response
 }

--- a/manager.go
+++ b/manager.go
@@ -113,6 +113,12 @@ func lastOperation(req *http.Request, c *catalog.Catalog, brokerDb *gorm.DB, id 
 }
 
 func bindInstance(req *http.Request, c *catalog.Catalog, brokerDb *gorm.DB, id string, settings *config.Settings) response.Response {
+	// Extract the request information.
+	bindRequest, err := request.ExtractRequest(req)
+	if err != nil {
+		return err
+	}
+
 	instance, resp := base.FindBaseInstance(brokerDb, id)
 	if resp != nil {
 		return resp
@@ -122,7 +128,7 @@ func bindInstance(req *http.Request, c *catalog.Catalog, brokerDb *gorm.DB, id s
 		return resp
 	}
 
-	return broker.BindInstance(c, id, instance)
+	return broker.BindInstance(c, id, bindRequest, instance)
 }
 
 func deleteInstance(req *http.Request, c *catalog.Catalog, brokerDb *gorm.DB, id string, settings *config.Settings) response.Response {

--- a/services/elasticsearch/elasticsearchinstance.go
+++ b/services/elasticsearch/elasticsearchinstance.go
@@ -39,6 +39,10 @@ type ElasticsearchInstance struct {
 	NodeToNodeEncryption       bool   `sql:"size(255)"`
 	EncryptAtRest              bool   `sql:"size(255)"`
 	AutomatedSnapshotStartHour int    `sql:"size(255)"`
+	Bucket                     string `sql:"size(255)"`
+	SnapshotARN                string `sql:"size(255)"`
+	SnapshotPolicyARN          string `sql:"size(255)"`
+	IamPassRolePolicyARN       string `sql:"size(255)"`
 
 	ClearPassword string `sql:"-"`
 
@@ -89,15 +93,32 @@ func (i *ElasticsearchInstance) getCredentials(password string) (map[string]stri
 	uri := fmt.Sprintf("https://%s:443",
 		i.Host)
 
-	credentials = map[string]string{
-		"uri":                           uri,
-		"access_key":                    i.AccessKey,
-		"secret_key":                    i.SecretKey,
-		"host":                          i.Host,
-		"port":                          strconv.FormatInt(i.Port, 10),
-		"current_elasticsearch_version": i.CurrentESVersion,
+	if len(i.Bucket) > 0 {
+		credentials = map[string]string{
+			"uri":                           uri,
+			"access_key":                    i.AccessKey,
+			"secret_key":                    i.SecretKey,
+			"host":                          i.Host,
+			"current_elasticsearch_version": i.CurrentESVersion,
+			"bucket":                        i.Bucket,
+			"snapshotRoleARN":               i.SnapshotARN,
+		}
+	} else {
+		credentials = map[string]string{
+			"uri":                           uri,
+			"access_key":                    i.AccessKey,
+			"secret_key":                    i.SecretKey,
+			"host":                          i.Host,
+			"current_elasticsearch_version": i.CurrentESVersion,
+		}
 	}
 	return credentials, nil
+}
+
+func (i *ElasticsearchInstance) setBucket(bucket string) error {
+	i.Bucket = bucket
+
+	return nil
 }
 
 func (i *ElasticsearchInstance) init(uuid string,

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -275,7 +275,7 @@ func (broker *rdsBroker) LastOperation(c *catalog.Catalog, id string, baseInstan
 	return response.NewSuccessLastOperation(state, "The service instance status is "+state)
 }
 
-func (broker *rdsBroker) BindInstance(c *catalog.Catalog, id string, baseInstance base.Instance) response.Response {
+func (broker *rdsBroker) BindInstance(c *catalog.Catalog, id string, bindRequest request.Request, baseInstance base.Instance) response.Response {
 	existingInstance := RDSInstance{}
 
 	var count int64

--- a/services/redis/broker.go
+++ b/services/redis/broker.go
@@ -152,7 +152,7 @@ func (broker *redisBroker) LastOperation(c *catalog.Catalog, id string, baseInst
 	return response.NewSuccessLastOperation(state, "The service instance status is "+state)
 }
 
-func (broker *redisBroker) BindInstance(c *catalog.Catalog, id string, baseInstance base.Instance) response.Response {
+func (broker *redisBroker) BindInstance(c *catalog.Catalog, id string, bindRequest request.Request, baseInstance base.Instance) response.Response {
 	existingInstance := RedisInstance{}
 
 	var count int64


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables "-c" to binding APIs so it can be used for configs
- ES's Bind Service/Service Key can take bucket in config to give ES permissions to do snapshots to S3
- Cleaned up binding credentials to provide info based off config


## Security considerations
None because the new Role permissions were added in cg-provision
