### PR TITLE
Provide the database name under an additional key

### DIFF
--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -110,6 +110,7 @@ func (i *RDSInstance) getCredentials(password string) (map[string]string, error)
 		"host":     i.Host,
 		"port":     strconv.FormatInt(i.Port, 10),
 		"db_name":  i.FormatDBName(),
+		"name":     i.FormatDBName(),
 	}
 	return credentials, nil
 }


### PR DESCRIPTION
Fixes #87

## Changes proposed in this pull request:
- The name of the actual database in the RDS instance is provided a second time, under the `name` key (in addition to `db_name`). This ensures that community code written with the Pivotal- or AWS-provided DB brokers that expects to find the name in that field will work with this broker (and hence cloud.gov) without modification/forking.

## Security considerations

None, the DB name was already being provided in the client credentials.