### PR TITLE
VPC options for Elasticsearch

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -676,6 +676,9 @@ elasticsearch:
     volumeType: gp2
     encryptAtRest: false
     automatedSnapshotStartHour: 7
+    securityGroup: (( grab meta.elasticsearch.elasticsearch_security_group ))
+    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
+    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -705,6 +708,9 @@ elasticsearch:
     nodeToNodeEncryption: true
     encryptAtRest: true
     automatedSnapshotStartHour: 6
+    securityGroup: (( grab meta.elasticsearch.elasticsearch_security_group ))
+    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
+    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -734,6 +740,9 @@ elasticsearch:
     nodeToNodeEncryption: true
     encryptAtRest: true
     automatedSnapshotStartHour: 6
+    securityGroup: (( grab meta.elasticsearch.elasticsearch_security_group ))
+    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
+    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -157,6 +157,9 @@ type ElasticsearchPlan struct {
 	NodeToNodeEncryption       bool              `yaml:"nodeToNodeEncryption" json:"-"`
 	EncryptAtRest              bool              `yaml:"encryptAtRest" json:"-"`
 	AutomatedSnapshotStartHour string            `yaml:"automatedSnapshotStartHour" json:"-"`
+	SubnetIDAZ1                string            `yaml:"subnetIDaz1" json:"-" validate:"required"`
+	SubnetIDAZ2                string            `yaml:"subnetIDaz2" json:"-" validate:"required"`
+	SecurityGroup              string            `yaml:"securityGroup" json:"-" validate:"required"`
 }
 
 // Catalog struct holds a collections of services

--- a/ci/build-manifest.sh
+++ b/ci/build-manifest.sh
@@ -41,6 +41,10 @@ meta:
   redis: 
     subnet_group: `terraform output -state stack.tfstate elasticache_subnet_group`
     security_group: `terraform output -state stack.tfstate elasticache_redis_security_group`
+  elasticsearch:
+    subnet_id_az1: `terraform output -state stack.tfstate elasticsearch_subnet_az1`
+    subnet_id_az2: `terraform output -state stack.tfstate elasticsearch_subnet_az2`
+    security_group: `terraform output -state stack.tfstate elasticsearch_security_group`
 EOF
 
 # Merge secrets into templates

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -175,6 +175,17 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 	encryptionAtRestOptions := &elasticsearchservice.EncryptionAtRestOptions{
 		Enabled: aws.Bool(i.EncryptAtRest),
 	}
+
+	VPCOptions := &elasticsearchservice.VPCOptions{
+		SecurityGroupIds: []*string{
+			&i.SecGroup,
+		},
+		SubnetIds: []*string{
+			&i.SubnetIDAZ1,
+			&i.SubnetIDAZ2,
+		},
+	}
+
 	//Standard Parameters
 	params := &elasticsearchservice.CreateElasticsearchDomainInput{
 		DomainName:                  aws.String(i.Domain),
@@ -185,6 +196,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		NodeToNodeEncryptionOptions: nodeOptions,
 		DomainEndpointOptions:       domainOptions,
 		EncryptionAtRestOptions:     encryptionAtRestOptions,
+		VPCOptions:                  VPCOptions,
 	}
 
 	params.SetAccessPolicies(accessControlPolicy)

--- a/services/elasticsearch/elasticsearchinstance.go
+++ b/services/elasticsearch/elasticsearchinstance.go
@@ -49,9 +49,10 @@ type ElasticsearchInstance struct {
 	Domain string `sql:"size(255)"`
 	ARN    string `sql:"size(255)"`
 
-	Tags          map[string]string `sql:"-"`
-	DbSubnetGroup string            `sql:"-"`
-	SecGroup      string            `sql:"-"`
+	Tags        map[string]string `sql:"-"`
+	SubnetIDAZ1 string            `sql:"-"`
+	SubnetIDAZ2 string            `sql:"-"`
+	SecGroup    string            `sql:"-"`
 }
 
 func (i *ElasticsearchInstance) setPassword(password, key string) error {
@@ -157,6 +158,9 @@ func (i *ElasticsearchInstance) init(uuid string,
 	i.NodeToNodeEncryption = plan.NodeToNodeEncryption
 	i.EncryptAtRest = plan.EncryptAtRest
 	i.AutomatedSnapshotStartHour, _ = strconv.Atoi(plan.AutomatedSnapshotStartHour)
+	i.SecGroup = plan.SecurityGroup
+	i.SubnetIDAZ1 = plan.SubnetIDAZ1
+	i.SubnetIDAZ2 = plan.SubnetIDAZ2
 
 	// Tag instance with broker details
 	i.Tags["Instance GUID"] = uuid


### PR DESCRIPTION
## Changes proposed in this pull request:
- This enables VPC Options for Elasticsearch and used the new subnets + Security Groups for Elasticsearch


## Security considerations
Locks down AWS Elasticsearch to VPC only
