### PR TITLE
Update AWS broker catalog for RDS instances

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -75,7 +75,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant burstable micro RDS PostgreSQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t3.micro
       allocatedStorage: 10
@@ -103,7 +103,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated burstable small RDS PostgreSQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t3.small
       allocatedStorage: 10
@@ -131,7 +131,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant burstable small RDS PostgreSQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t3.small
       allocatedStorage: 10
@@ -159,7 +159,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated burstable medium RDS PostgreSQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t3.medium
       allocatedStorage: 10
@@ -187,7 +187,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant burstable medium RDS PostgreSQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t3.medium
       allocatedStorage: 10
@@ -434,7 +434,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant burstable small RDS MySQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t2.small
       allocatedStorage: 10
@@ -463,7 +463,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated burstable medium RDS MySQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t2.medium
       allocatedStorage: 10
@@ -492,7 +492,7 @@ rds:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant burstable medium RDS MySQL DB instance"
-      free: true
+      free: false
       adapter: dedicated
       instanceClass: db.t2.medium
       allocatedStorage: 10

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -47,7 +47,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.022
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated micro PostgreSQL"
       free: true
@@ -57,6 +57,36 @@ rds:
       dbType: postgres
       plan_updateable: true
       redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    -
+      id: "ad7201d4-cfb1-4f19-a2ef-e7d88e331a76"
+      name: "micro-psql-redundant"
+      description: "Dedicated redundant micro RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated redundant RDS instance"
+          - "PostgreSQL instance"
+        costs:
+          -
+            amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated redundant micro PostgreSQL"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t3.micro
+      allocatedStorage: 10
+      dbType: postgres
+      plan_updateable: true
+      redundant: true
       encrypted: true
       storage_type: gp2
       backup_retention_period: 14
@@ -76,7 +106,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.115
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated medium PostgreSQL"
       free: false
@@ -105,7 +135,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.230
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant medium PostgreSQL"
       free: false
@@ -134,7 +164,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.218
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated large PostgreSQL"
       free: false
@@ -163,7 +193,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.436
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant large PostgreSQL"
       free: false
@@ -192,7 +222,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.436
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated x-large PostgreSQL"
       free: false
@@ -221,7 +251,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.872
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant x-large PostgreSQL"
       free: false
@@ -272,7 +302,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.041
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated small MySQL"
       free: true
@@ -292,6 +322,36 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
+    - id: "ae0d673d-f213-4125-8ca7-e57968aa792d"
+      name: "small-mysql-redundant"
+      description: "Dedicated redundant small RDS MySQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated redundant RDS instance"
+          - "MySQL instance"
+        costs:
+          -
+            amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated redundant small MySQL"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t2.small
+      allocatedStorage: 10
+      dbType: mysql
+      plan_updateable: true
+      dbVersion: &mysql-version "5.7.21"
+      redundant: true
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.mysql_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
     - id: "2ba54329-8264-486f-85bf-50c9f24085a9"
       name: "medium-mysql"
       description: "Dedicated medium RDS MySQL DB instance"
@@ -302,7 +362,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.110
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated medium MySQL"
       free: false
@@ -332,7 +392,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.220
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant medium MySQL"
       free: false
@@ -362,7 +422,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.210
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated large MySQL"
       free: false
@@ -392,7 +452,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.420
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant large MySQL"
       free: false
@@ -422,7 +482,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.420
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated x-large MySQL"
       free: false
@@ -452,7 +512,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.840
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant x-large MySQL"
       free: false
@@ -482,7 +542,7 @@ rds:
         - "License Included"
         costs:
         - amount:
-            usd: 0.162
+            usd: 0
           unit: "HOURLY"
         displayName: "Dedicated medium Oracle SE2"
       free: false
@@ -511,7 +571,7 @@ rds:
         - "License Included"
         costs:
         - amount:
-            usd: 1.002
+            usd: 0
         unit: "HOURLY"
         displayName: "Dedicated large SQL Server SE"
       free: false

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -22,8 +22,7 @@ rds:
           - "Shared RDS instance"
           - "PostgreSQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "MONTHLY"
         displayName: "Free shared plan"
@@ -36,20 +35,18 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    -
-      id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
+    - id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
       name: "micro-psql"
-      description: "Dedicated micro RDS PostgreSQL DB instance"
+      description: "Dedicated burstable micro RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated burstable micro RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated micro PostgreSQL"
+        displayName: "Dedicated burstable micro RDS PostgreSQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
@@ -66,20 +63,18 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    -
-      id: "ad7201d4-cfb1-4f19-a2ef-e7d88e331a76"
+    - id: "ad7201d4-cfb1-4f19-a2ef-e7d88e331a76"
       name: "micro-psql-redundant"
-      description: "Dedicated redundant micro RDS PostgreSQL DB instance"
+      description: "Dedicated redundant burstable micro RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated redundant burstable micro RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant micro PostgreSQL"
+        displayName: "Dedicated redundant burstable micro RDS PostgreSQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
@@ -96,19 +91,130 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    - id: "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
-      name: "medium-psql"
-      description: "Dedicated medium RDS PostgreSQL DB instance"
+    - id: "e185e3be-07c7-48d6-9117-a85bc5ff1889"
+      name: "small-psql"
+      description: "Dedicated burstable small RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated burstable small RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated medium PostgreSQL"
+        displayName: "Dedicated burstable small RDS PostgreSQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t3.small
+      allocatedStorage: 10
+      dbType: postgres
+      plan_updateable: true
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "92c946bf-26d0-41d2-85a3-ea96f8f6da41"
+      name: "small-psql-redundant"
+      description: "Dedicated redundant burstable small RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated redundant burstable small RDS instance"
+          - "PostgreSQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated redundant burstable small RDS PostgreSQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t3.small
+      allocatedStorage: 10
+      dbType: postgres
+      plan_updateable: true
+      redundant: true
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "6b0c7dc6-5628-4447-9867-5574bc4def20"
+      name: "medium-psql"
+      description: "Dedicated burstable medium RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated burstable medium RDS instance"
+          - "PostgreSQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated burstable medium RDS PostgreSQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      allocatedStorage: 10
+      dbType: postgres
+      plan_updateable: true
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "6c750aec-3eb9-4b4d-b70c-5811777110af"
+      name: "medium-psql-redundant"
+      description: "Dedicated redundant burstable medium RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated redundant burstable medium RDS instance"
+          - "PostgreSQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated redundant burstable medium RDS PostgreSQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      allocatedStorage: 10
+      dbType: postgres
+      plan_updateable: true
+      redundant: true
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
+      name: "medium-gp-psql"
+      description: "Dedicated general purpose medium RDS PostgreSQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated general purpose medium RDS instance"
+          - "PostgreSQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated general purpose medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -126,18 +232,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "ee75aef3-7697-4906-9330-fb1f83d719be"
-      name: "medium-psql-redundant"
-      description: "Dedicated redundant medium RDS PostgreSQL DB instance"
+      name: "medium-gp-psql-redundant"
+      description: "Dedicated redundant general purpose medium RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated redundant general purpose medium RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant medium PostgreSQL"
+        displayName: "Dedicated redundant general purpose medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -155,18 +260,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "0201f24a-8e6d-4864-a597-f4752a2834f4"
-      name: "large-psql"
-      description: "Dedicated large RDS PostgreSQL DB instance"
+      name: "large-gp-psql"
+      description: "Dedicated general purpose large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated general purpose large RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated large PostgreSQL"
+        displayName: "Dedicated general purpose large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -184,18 +288,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "d81ef27e-a49e-465e-b3bb-ea8a4a2f5571"
-      name: "large-psql-redundant"
-      description: "Dedicated redundant large RDS PostgreSQL DB instance"
+      name: "large-gp-psql-redundant"
+      description: "Dedicated redundant general purpose large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated redundant general purpose large RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant large PostgreSQL"
+        displayName: "Dedicated redundant general purpose large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -213,18 +316,18 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "520b2cbf-588f-4324-bb34-474ea57304bb"
-      name: "xlarge-psql"
-      description: "Dedicated x-large RDS PostgreSQL DB instance"
+      name: "xlarge-pg-psql"
+      description: "Dedicated general purpose x-large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated general purpose x-large RDS instance"
+          - "PostgreSQL DB instance"
         costs:
           -
             amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated x-large PostgreSQL"
+        displayName: "Dedicated general purpose x-large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -246,14 +349,13 @@ rds:
       description: "Dedicated redundant x-large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "PostgreSQL instance"
+          - "Dedicated redundant x-large RDS instance"
+          - "PostgreSQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant x-large PostgreSQL"
+        displayName: "Dedicated redundant x-large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -278,8 +380,7 @@ rds:
           - "Shared RDS instance"
           - "MySQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "MONTHLY"
         displayName: "Free shared plan"
@@ -294,17 +395,16 @@ rds:
         service: "aws-broker"
     - id: "0af67edb-30d8-4bb3-81c7-324c18d3efb2"
       name: "small-mysql"
-      description: "Dedicated small RDS MySQL DB instance"
+      description: "Dedicated burstable small RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "MySQL instance"
+          - "Dedicated burstable small RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated small MySQL"
+        displayName: "Dedicated burstable small RDS MySQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t2.small
@@ -324,17 +424,16 @@ rds:
         service: "aws-broker"
     - id: "ae0d673d-f213-4125-8ca7-e57968aa792d"
       name: "small-mysql-redundant"
-      description: "Dedicated redundant small RDS MySQL DB instance"
+      description: "Dedicated redundant burstable small RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "MySQL instance"
+          - "Dedicated redundant burstable small RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant small MySQL"
+        displayName: "Dedicated redundant burstable small RDS MySQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t2.small
@@ -352,19 +451,76 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    - id: "2ba54329-8264-486f-85bf-50c9f24085a9"
+    - id: "beec33b2-9033-4639-9a22-368fff996030"
       name: "medium-mysql"
-      description: "Dedicated medium RDS MySQL DB instance"
+      description: "Dedicated burstable medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "MySQL instance"
+          - "Dedicated burstable medium RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated medium MySQL"
+        displayName: "Dedicated burstable medium RDS MySQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t2.medium
+      allocatedStorage: 10
+      dbType: mysql
+      plan_updateable: true
+      dbVersion: &mysql-version "5.7.21"
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.mysql_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "434f504b-f65b-4694-aa25-ba300bb3e1ec"
+      name: "medium-mysql-redundant"
+      description: "Dedicated redundant burstable medium RDS MySQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated redundant burstable medium RDS instance"
+          - "MySQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated redundant burstable medium RDS MySQL DB instance"
+      free: true
+      adapter: dedicated
+      instanceClass: db.t2.medium
+      allocatedStorage: 10
+      dbType: mysql
+      plan_updateable: true
+      dbVersion: &mysql-version "5.7.21"
+      redundant: true
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.mysql_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
+    - id: "2ba54329-8264-486f-85bf-50c9f24085a9"
+      name: "medium-gp-mysql"
+      description: "Dedicated general purpose medium RDS MySQL DB instance"
+      metadata:
+        bullets:
+          - "Dedicated general purpose medium RDS instance"
+          - "MySQL DB instance"
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: "Dedicated general purpose medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -383,18 +539,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "30e19cab-8d4e-492a-ac2c-33dd59d436d8"
-      name: "medium-mysql-redundant"
-      description: "Dedicated redundant medium RDS MySQL DB instance"
+      name: "medium-gp-mysql-redundant"
+      description: "Dedicated redundant general purpose medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "MySQL instance"
+          - "Dedicated redundant general purpose medium RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant medium MySQL"
+        displayName: "Dedicated redundant general purpose medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -413,18 +568,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "29cc73ed-f9c9-4901-b12b-bd4890aedf30"
-      name: "large-mysql"
-      description: "Dedicated large RDS MySQL DB instance"
+      name: "large-gp-mysql"
+      description: "Dedicated general purpose large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "MySQL instance"
+          - "Dedicated general purpose large RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated large MySQL"
+        displayName: "Dedicated general purpose large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -443,18 +597,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "a0246f47-aeae-4c08-ba22-1d188bb51554"
-      name: "large-mysql-redundant"
-      description: "Dedicated redundant large RDS MySQL DB instance"
+      name: "large-gp-mysql-redundant"
+      description: "Dedicated redundant general purpose large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "MySQL instance"
+          - "Dedicated redundant general purpose RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant large MySQL"
+        displayName: "Dedicated redundant general purpose large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -473,18 +626,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "9e056262-33fe-4236-a200-30e2d435d583"
-      name: "xlarge-mysql"
-      description: "Dedicated x-large RDS MySQL DB instance"
+      name: "xlarge-gp-mysql"
+      description: "Dedicated general purpose x-large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated RDS instance"
-          - "MySQL instance"
+          - "Dedicated general purpose x-large RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated x-large MySQL"
+        displayName: "Dedicated general purpose x-large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -503,18 +655,17 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "e5da0850-0f48-4309-9b5f-dfe279fcd179"
-      name: "xlarge-mysql-redundant"
-      description: "Dedicated redundant x-large RDS MySQL DB instance"
+      name: "xlarge-gp-mysql-redundant"
+      description: "Dedicated redundant general purpose x-large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant RDS instance"
-          - "MySQL instance"
+          - "Dedicated redundant general purpose x-large RDS instance"
+          - "MySQL DB instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant x-large MySQL"
+        displayName: "Dedicated redundant general purpose x-large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -534,17 +685,17 @@ rds:
         service: "aws-broker"
     - id: "e7d65895-4fc3-4a66-8c61-68da4944c69b"
       name: "medium-oracle-se2"
-      description: "Dedicated medium RDS Oracle SE2 DB instance"
+      description: "Dedicated burstable medium RDS Oracle SE2 DB instance"
       metadata:
         bullets:
-        - "Dedicated RDS instance"
-        - "Oracle Standard Edition 2 instance"
+        - "Dedicated burstable medium RDS instance"
+        - "Oracle Standard Edition 2 DB instance"
         - "License Included"
         costs:
         - amount:
             usd: 0
           unit: "HOURLY"
-        displayName: "Dedicated medium Oracle SE2"
+        displayName: "Dedicated burstable medium RDS Oracle SE2 DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
@@ -562,18 +713,18 @@ rds:
         client: "paas-cf"
         service: "aws-broker"
     - id: "43b6954b-46c3-4a45-9ca3-995e552ef558"
-      name: "large-sqlserver-se"
-      description: "Dedicated large RDS SQL Server SE DB instance"
+      name: "large-gp-sqlserver-se"
+      description: "Dedicated general purpose large RDS SQL Server SE DB instance"
       metadata:
         bullets:
-        - "Dedicated RDS instance"
-        - "SQL Server Standard Edition instance"
+        - "Dedicated general purpose large RDS instance"
+        - "SQL Server Standard Edition DB instance"
         - "License Included"
         costs:
         - amount:
             usd: 0
         unit: "HOURLY"
-        displayName: "Dedicated large SQL Server SE"
+        displayName: "Dedicated general purpose large RDS SQL Server SE DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m5.large

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -37,16 +37,16 @@ rds:
         service: "aws-broker"
     - id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
       name: "micro-psql"
-      description: "Dedicated burstable micro RDS PostgreSQL DB instance"
+      description: "Dedicated recommended micro RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated burstable micro RDS instance"
+          - "Dedicated recommended micro RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated burstable micro RDS PostgreSQL DB instance"
+        displayName: "Dedicated recommended micro RDS PostgreSQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
@@ -65,16 +65,16 @@ rds:
         service: "aws-broker"
     - id: "ad7201d4-cfb1-4f19-a2ef-e7d88e331a76"
       name: "micro-psql-redundant"
-      description: "Dedicated redundant burstable micro RDS PostgreSQL DB instance"
+      description: "Dedicated redundant recommended micro RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant burstable micro RDS instance"
+          - "Dedicated redundant recommended micro RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant burstable micro RDS PostgreSQL DB instance"
+        displayName: "Dedicated redundant recommended micro RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.micro
@@ -93,16 +93,16 @@ rds:
         service: "aws-broker"
     - id: "e185e3be-07c7-48d6-9117-a85bc5ff1889"
       name: "small-psql"
-      description: "Dedicated burstable small RDS PostgreSQL DB instance"
+      description: "Dedicated recommended small RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated burstable small RDS instance"
+          - "Dedicated recommended small RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated burstable small RDS PostgreSQL DB instance"
+        displayName: "Dedicated recommended small RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.small
@@ -121,16 +121,16 @@ rds:
         service: "aws-broker"
     - id: "92c946bf-26d0-41d2-85a3-ea96f8f6da41"
       name: "small-psql-redundant"
-      description: "Dedicated redundant burstable small RDS PostgreSQL DB instance"
+      description: "Dedicated redundant recommended small RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant burstable small RDS instance"
+          - "Dedicated redundant recommended small RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant burstable small RDS PostgreSQL DB instance"
+        displayName: "Dedicated redundant recommended small RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.small
@@ -149,16 +149,16 @@ rds:
         service: "aws-broker"
     - id: "6b0c7dc6-5628-4447-9867-5574bc4def20"
       name: "medium-psql"
-      description: "Dedicated burstable medium RDS PostgreSQL DB instance"
+      description: "Dedicated recommended medium RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated burstable medium RDS instance"
+          - "Dedicated recommended medium RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated burstable medium RDS PostgreSQL DB instance"
+        displayName: "Dedicated recommended medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
@@ -177,16 +177,16 @@ rds:
         service: "aws-broker"
     - id: "6c750aec-3eb9-4b4d-b70c-5811777110af"
       name: "medium-psql-redundant"
-      description: "Dedicated redundant burstable medium RDS PostgreSQL DB instance"
+      description: "Dedicated redundant recommended medium RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant burstable medium RDS instance"
+          - "Dedicated redundant recommended medium RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant burstable medium RDS PostgreSQL DB instance"
+        displayName: "Dedicated redundant recommended medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
@@ -205,16 +205,16 @@ rds:
         service: "aws-broker"
     - id: "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
       name: "medium-gp-psql"
-      description: "Dedicated general purpose medium RDS PostgreSQL DB instance"
+      description: "Dedicated higher workload medium RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose medium RDS instance"
+          - "Dedicated higher workload medium RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose medium RDS PostgreSQL DB instance"
+        displayName: "Dedicated higher workload medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -233,16 +233,16 @@ rds:
         service: "aws-broker"
     - id: "ee75aef3-7697-4906-9330-fb1f83d719be"
       name: "medium-gp-psql-redundant"
-      description: "Dedicated redundant general purpose medium RDS PostgreSQL DB instance"
+      description: "Dedicated redundant higher workload medium RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant general purpose medium RDS instance"
+          - "Dedicated redundant higher workload medium RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant general purpose medium RDS PostgreSQL DB instance"
+        displayName: "Dedicated redundant higher workload medium RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -261,16 +261,16 @@ rds:
         service: "aws-broker"
     - id: "0201f24a-8e6d-4864-a597-f4752a2834f4"
       name: "large-gp-psql"
-      description: "Dedicated general purpose large RDS PostgreSQL DB instance"
+      description: "Dedicated higher workload large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose large RDS instance"
+          - "Dedicated higher workload large RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose large RDS PostgreSQL DB instance"
+        displayName: "Dedicated higher workload large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -289,16 +289,16 @@ rds:
         service: "aws-broker"
     - id: "d81ef27e-a49e-465e-b3bb-ea8a4a2f5571"
       name: "large-gp-psql-redundant"
-      description: "Dedicated redundant general purpose large RDS PostgreSQL DB instance"
+      description: "Dedicated redundant higher workload large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant general purpose large RDS instance"
+          - "Dedicated redundant higher workload large RDS instance"
           - "PostgreSQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant general purpose large RDS PostgreSQL DB instance"
+        displayName: "Dedicated redundant higher workload large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -317,17 +317,17 @@ rds:
         service: "aws-broker"
     - id: "520b2cbf-588f-4324-bb34-474ea57304bb"
       name: "xlarge-pg-psql"
-      description: "Dedicated general purpose x-large RDS PostgreSQL DB instance"
+      description: "Dedicated higher workload x-large RDS PostgreSQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose x-large RDS instance"
+          - "Dedicated higher workload x-large RDS instance"
           - "PostgreSQL DB instance"
         costs:
           -
             amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose x-large RDS PostgreSQL DB instance"
+        displayName: "Dedicated higher workload x-large RDS PostgreSQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -395,16 +395,16 @@ rds:
         service: "aws-broker"
     - id: "0af67edb-30d8-4bb3-81c7-324c18d3efb2"
       name: "small-mysql"
-      description: "Dedicated burstable small RDS MySQL DB instance"
+      description: "Dedicated recommended small RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated burstable small RDS instance"
+          - "Dedicated recommended small RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated burstable small RDS MySQL DB instance"
+        displayName: "Dedicated recommended small RDS MySQL DB instance"
       free: true
       adapter: dedicated
       instanceClass: db.t2.small
@@ -424,16 +424,16 @@ rds:
         service: "aws-broker"
     - id: "ae0d673d-f213-4125-8ca7-e57968aa792d"
       name: "small-mysql-redundant"
-      description: "Dedicated redundant burstable small RDS MySQL DB instance"
+      description: "Dedicated redundant recommended small RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant burstable small RDS instance"
+          - "Dedicated redundant recommended small RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant burstable small RDS MySQL DB instance"
+        displayName: "Dedicated redundant recommended small RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t2.small
@@ -453,16 +453,16 @@ rds:
         service: "aws-broker"
     - id: "beec33b2-9033-4639-9a22-368fff996030"
       name: "medium-mysql"
-      description: "Dedicated burstable medium RDS MySQL DB instance"
+      description: "Dedicated recommended medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated burstable medium RDS instance"
+          - "Dedicated recommended medium RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated burstable medium RDS MySQL DB instance"
+        displayName: "Dedicated recommended medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t2.medium
@@ -482,16 +482,16 @@ rds:
         service: "aws-broker"
     - id: "434f504b-f65b-4694-aa25-ba300bb3e1ec"
       name: "medium-mysql-redundant"
-      description: "Dedicated redundant burstable medium RDS MySQL DB instance"
+      description: "Dedicated redundant recommended medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant burstable medium RDS instance"
+          - "Dedicated redundant recommended medium RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant burstable medium RDS MySQL DB instance"
+        displayName: "Dedicated redundant recommended medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t2.medium
@@ -511,16 +511,16 @@ rds:
         service: "aws-broker"
     - id: "2ba54329-8264-486f-85bf-50c9f24085a9"
       name: "medium-gp-mysql"
-      description: "Dedicated general purpose medium RDS MySQL DB instance"
+      description: "Dedicated higher workload medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose medium RDS instance"
+          - "Dedicated higher workload medium RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose medium RDS MySQL DB instance"
+        displayName: "Dedicated higher workload medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -540,16 +540,16 @@ rds:
         service: "aws-broker"
     - id: "30e19cab-8d4e-492a-ac2c-33dd59d436d8"
       name: "medium-gp-mysql-redundant"
-      description: "Dedicated redundant general purpose medium RDS MySQL DB instance"
+      description: "Dedicated redundant higher workload medium RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant general purpose medium RDS instance"
+          - "Dedicated redundant higher workload medium RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant general purpose medium RDS MySQL DB instance"
+        displayName: "Dedicated redundant higher workload medium RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
@@ -569,16 +569,16 @@ rds:
         service: "aws-broker"
     - id: "29cc73ed-f9c9-4901-b12b-bd4890aedf30"
       name: "large-gp-mysql"
-      description: "Dedicated general purpose large RDS MySQL DB instance"
+      description: "Dedicated higher workload large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose large RDS instance"
+          - "Dedicated higher workload large RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose large RDS MySQL DB instance"
+        displayName: "Dedicated higher workload large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -598,16 +598,16 @@ rds:
         service: "aws-broker"
     - id: "a0246f47-aeae-4c08-ba22-1d188bb51554"
       name: "large-gp-mysql-redundant"
-      description: "Dedicated redundant general purpose large RDS MySQL DB instance"
+      description: "Dedicated redundant higher workload large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant general purpose RDS instance"
+          - "Dedicated redundant higher workload RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant general purpose large RDS MySQL DB instance"
+        displayName: "Dedicated redundant higher workload large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.large
@@ -627,16 +627,16 @@ rds:
         service: "aws-broker"
     - id: "9e056262-33fe-4236-a200-30e2d435d583"
       name: "xlarge-gp-mysql"
-      description: "Dedicated general purpose x-large RDS MySQL DB instance"
+      description: "Dedicated higher workload x-large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated general purpose x-large RDS instance"
+          - "Dedicated higher workload x-large RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated general purpose x-large RDS MySQL DB instance"
+        displayName: "Dedicated higher workload x-large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -656,16 +656,16 @@ rds:
         service: "aws-broker"
     - id: "e5da0850-0f48-4309-9b5f-dfe279fcd179"
       name: "xlarge-gp-mysql-redundant"
-      description: "Dedicated redundant general purpose x-large RDS MySQL DB instance"
+      description: "Dedicated redundant higher workload x-large RDS MySQL DB instance"
       metadata:
         bullets:
-          - "Dedicated redundant general purpose x-large RDS instance"
+          - "Dedicated redundant higher workload x-large RDS instance"
           - "MySQL DB instance"
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: "Dedicated redundant general purpose x-large RDS MySQL DB instance"
+        displayName: "Dedicated redundant higher workload x-large RDS MySQL DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m4.xlarge
@@ -685,17 +685,17 @@ rds:
         service: "aws-broker"
     - id: "e7d65895-4fc3-4a66-8c61-68da4944c69b"
       name: "medium-oracle-se2"
-      description: "Dedicated burstable medium RDS Oracle SE2 DB instance"
+      description: "Dedicated recommended medium RDS Oracle SE2 DB instance"
       metadata:
         bullets:
-        - "Dedicated burstable medium RDS instance"
+        - "Dedicated recommended medium RDS instance"
         - "Oracle Standard Edition 2 DB instance"
         - "License Included"
         costs:
         - amount:
             usd: 0
           unit: "HOURLY"
-        displayName: "Dedicated burstable medium RDS Oracle SE2 DB instance"
+        displayName: "Dedicated recommended medium RDS Oracle SE2 DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
@@ -714,17 +714,17 @@ rds:
         service: "aws-broker"
     - id: "43b6954b-46c3-4a45-9ca3-995e552ef558"
       name: "large-gp-sqlserver-se"
-      description: "Dedicated general purpose large RDS SQL Server SE DB instance"
+      description: "Dedicated higher workload large RDS SQL Server SE DB instance"
       metadata:
         bullets:
-        - "Dedicated general purpose large RDS instance"
+        - "Dedicated higher workload large RDS instance"
         - "SQL Server Standard Edition DB instance"
         - "License Included"
         costs:
         - amount:
             usd: 0
         unit: "HOURLY"
-        displayName: "Dedicated general purpose large RDS SQL Server SE DB instance"
+        displayName: "Dedicated higher workload large RDS SQL Server SE DB instance"
       free: false
       adapter: dedicated
       instanceClass: db.m5.large

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -164,8 +164,7 @@ rds:
     documentationUrl:
     supportUrl:
   plans:
-    -
-      id: "44d24fc7-f7a4-4ac1-b7a0-de82836e89a3"
+    - id: "44d24fc7-f7a4-4ac1-b7a0-de82836e89a3"
       name: "shared-psql"
       description: "Shared infrastructure for Postgres DB"
       metadata:
@@ -173,8 +172,7 @@ rds:
           - "Shared RDS Instance"
           - "Postgres instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "MONTHLY"
         displayName: "Free Shared Plan"
@@ -187,8 +185,7 @@ rds:
         environment: "cf-env"
         client: "the client"
         service: "aws-broker"
-    -
-      id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
+    - id: "da91e15c-98c9-46a9-b114-02b8d28062c6"
       name: "micro-psql"
       description: "Dedicated micro RDS PostgreSQL DB instance"
       metadata:
@@ -196,8 +193,7 @@ rds:
           - "Dedicated RDS instance"
           - "PostgreSQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated micro PostgreSQL"
@@ -225,8 +221,7 @@ rds:
           - "Dedicated RDS instance"
           - "PostgreSQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated medium PostgreSQL"
@@ -254,8 +249,7 @@ rds:
           - "Dedicated redundant RDS instance"
           - "PostgreSQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant medium PostgreSQL"
@@ -274,8 +268,7 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    -
-      id: "44d24fc7-f7a4-4ac1-b7a0-de82836e89a4"
+    - id: "44d24fc7-f7a4-4ac1-b7a0-de82836e89a4"
       name: "shared-mysql"
       description: "Shared infrastructure for MySQL DB"
       metadata:
@@ -283,8 +276,7 @@ rds:
           - "Shared RDS Instance"
           - "MySQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "MONTHLY"
         displayName: "Free Shared Plan"
@@ -297,8 +289,7 @@ rds:
         environment: "cf-env"
         client: "the client"
         service: "aws-broker"
-    -
-      id: "da91e15c-98c9-46a9-b114-02b8d28062c7"
+    - id: "da91e15c-98c9-46a9-b114-02b8d28062c7"
       name: "small-mysql"
       description: "Dedicated small RDS MySQL DB Instance"
       metadata:
@@ -306,8 +297,7 @@ rds:
           - "Dedicated RDS Instance"
           - "MySQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated small MySQL"
@@ -324,8 +314,7 @@ rds:
         environment: "cf-env"
         client: "the client"
         service: "aws-broker"
-    -
-      id: "332e0168-6969-4bd7-b07f-29f08c4bf78d"
+    - id: "332e0168-6969-4bd7-b07f-29f08c4bf78d"
       name: "medium-mysql"
       description: "Dedicated Medium RDS MySQL DB Instance"
       metadata:
@@ -333,8 +322,7 @@ rds:
           - "Dedicated RDS Instance"
           - "MySQL instance"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated Medium MySQL"
@@ -351,8 +339,7 @@ rds:
         environment: "cf-env"
         client: "the client"
         service: "aws-broker"
-    -
-      id: "332e0168-6969-4bd7-b07f-29f08c4bf78f"
+    - id: "332e0168-6969-4bd7-b07f-29f08c4bf78f"
       name: "medium-oracle-se2"
       description: "Dedicated Medium RDS Oracle Standard Edition 2 DB Instance"
       metadata:
@@ -361,8 +348,7 @@ rds:
           - "Oracle DB instance"
           - "Oracle Standard Edition 2"
         costs:
-          -
-            amount:
+          - amount:
               usd: 0
             unit: "HOURLY"
         displayName: "Dedicated Medium Oracle SE2"

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -198,7 +198,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.022
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated micro PostgreSQL"
       free: true
@@ -227,7 +227,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.115
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated medium PostgreSQL"
       free: false
@@ -256,7 +256,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.230
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated redundant medium PostgreSQL"
       free: false
@@ -308,7 +308,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.041
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated small MySQL"
       free: true
@@ -335,7 +335,7 @@ rds:
         costs:
           -
             amount:
-              usd: 0.19
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated Medium MySQL"
       free: false
@@ -363,7 +363,7 @@ rds:
         costs:
           -
             amount:
-              usd: 19.19
+              usd: 0
             unit: "HOURLY"
         displayName: "Dedicated Medium Oracle SE2"
       free: false


### PR DESCRIPTION
**NOTE:** Please don't merge until @RonWilliams has a chance to see the new plans to make sure we're okay with those becoming available.

This changeset updates our AWS broker catalog to account for the following:

- We are not currently charging for any RDS instances (or any other service instances)
- We have added redundant versions of our new `micro-psql` and `small-mysql` plans
- We have added small and medium size burstable plan options (`db.t3.*`) for PostgreSQL (redundant and non-redundant)
- We have added medium size burstable plan options (`db.t2.*`) for MySQL (redundant and non-redundant)

TODO:
- [x] Update the names and descriptions with plain language to make it clearer what the differences are and to help guide customers to better choices

Our pricing will change again in FY21, but until that time there is no reason to display pricing information as we are not currently charging for the instances themselves ([only extra storage above 1TB](https://cloud.gov/pricing/#all-use-of-cloud-gov-includes)).  The existing pricing information is flowing through to the customer dashboard, which causes confusion about our billing.  Setting this to `0` should help alleviate that discrepancy.

Note that the new redundant plans (and all existing plans) are not set to free; free plans are available in sandboxes, and only the non-redundant `micro-psql` and `small-mysql` plans (as well as the shared versions for the time being) should be available for sandboxes.

## Changes proposed in this pull request:

- Update pricing of all service instances in our catalog to be `0` to reflect our current state
- Add redundant versions of our `micro-psql` and `small-mysql` plans
- Add new `small-psql` and `medium-psql` plans, including redundant versions
- Add new `medium-mysql` plan, including redundant version
- Rename existing plans and update all RDS plan descriptions to differentiate them better
- A bit of YAML formatting cleanup

## Security considerations

None: this is only expanding customer service offerings of existing public services and modifying our prices.