### PR TITLE
Update RDS instances for AWS broker

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,8 +31,8 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 9.5.15
-      TF_VAR_rds_internal_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_internal_db_engine_version: 11.1
+      TF_VAR_rds_internal_db_parameter_group_family: postgres11
       TF_VAR_rds_internal_username: ((development-rds-internal-username))
       TF_VAR_rds_internal_password: ((development-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -42,16 +42,19 @@ jobs:
       TF_VAR_rds_shared_mysql_db_size: 100
       TF_VAR_rds_shared_mysql_db_name: ((development-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
-      TF_VAR_rds_shared_mysql_db_engine_version: 5.6.41
+      TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
+      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
       TF_VAR_rds_shared_mysql_username: ((development-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((development-rds-shared-mysql-password))
+      TF_VAR_rds_shared_mysql_apply_immediately: "true"
+      TF_VAR_rds_shared_mysql_allow_major_version_upgrade: "true"
 
       TF_VAR_rds_shared_postgres_instance_type: db.m4.large
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((development-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 9.5.15
-      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_shared_postgres_db_engine_version: 11.1
+      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres11
       TF_VAR_rds_shared_postgres_username: ((development-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((development-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"
@@ -327,8 +330,8 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 9.5.15
-      TF_VAR_rds_internal_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_internal_db_engine_version: 11.1
+      TF_VAR_rds_internal_db_parameter_group_family: postgres11
       TF_VAR_rds_internal_username: ((staging-rds-internal-username))
       TF_VAR_rds_internal_password: ((staging-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -338,16 +341,19 @@ jobs:
       TF_VAR_rds_shared_mysql_db_size: 100
       TF_VAR_rds_shared_mysql_db_name: ((staging-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
-      TF_VAR_rds_shared_mysql_db_engine_version: 5.6.41
+      TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
+      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
       TF_VAR_rds_shared_mysql_username: ((staging-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((staging-rds-shared-mysql-password))
+      TF_VAR_rds_shared_mysql_apply_immediately: "true"
+      TF_VAR_rds_shared_mysql_allow_major_version_upgrade: "true"
 
       TF_VAR_rds_shared_postgres_instance_type: db.m4.large
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((staging-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 9.5.15
-      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_shared_postgres_db_engine_version: 11.1
+      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres11
       TF_VAR_rds_shared_postgres_username: ((staging-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((staging-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"
@@ -633,8 +639,11 @@ jobs:
       TF_VAR_rds_shared_mysql_db_name: ((prod-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.6.41
+      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.6
       TF_VAR_rds_shared_mysql_username: ((prod-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((prod-rds-shared-mysql-password))
+      TF_VAR_rds_shared_mysql_apply_immediately: "true"
+      TF_VAR_rds_shared_mysql_allow_major_version_upgrade: "true"
 
       TF_VAR_rds_shared_postgres_instance_type: db.m4.large
       TF_VAR_rds_shared_postgres_db_size: 100

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -14,5 +14,7 @@ module "rds_shared_mysql" {
   rds_db_engine_version         = "${var.rds_shared_mysql_db_engine_version}"
   rds_username                  = "${var.rds_shared_mysql_username}"
   rds_password                  = "${var.rds_shared_mysql_password}"
-  rds_parameter_group_family    = "mysql5.6"
+  rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
+  apply_immediately             = "${var.rds_shared_mysql_apply_immediately}"
+  allow_major_version_upgrade   = "${var.rds_shared_mysql_allow_major_version_upgrade}"
 }

--- a/ci/terraform/rds_module/variables.tf
+++ b/ci/terraform/rds_module/variables.tf
@@ -23,7 +23,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.15"
+  default = "11.1"
 }
 
 variable "rds_username" {}
@@ -45,7 +45,7 @@ variable "rds_parameter_group_name" {
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres9.6"
+  default = "postgres11"
 }
 
 variable "rds_multi_az" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,8 +18,11 @@ variable "rds_shared_mysql_db_size" {}
 variable "rds_shared_mysql_db_name" {}
 variable "rds_shared_mysql_db_engine" {}
 variable "rds_shared_mysql_db_engine_version" {}
+variable "rds_shared_mysql_db_parameter_group_family" {}
 variable "rds_shared_mysql_username" {}
 variable "rds_shared_mysql_password" {}
+variable "rds_shared_mysql_apply_immediately" {}
+variable "rds_shared_mysql_allow_major_version_upgrade" {}
 
 variable "rds_shared_postgres_instance_type" {}
 variable "rds_shared_postgres_db_size" {}


### PR DESCRIPTION
This changeset is a part of multiple steps that are intended to update our AWS broker RDS instances to more current versions for their respective DB engines and reduce the instance class sizes of the dev and staging environment instances.  The steps are as follows:

- Update the DB versions for dev and staging to latest available versions (this commit)
- Update the instance class sizes for dev and staging
- Update the DB versions for production to latest available

These changes also introduce a few improvements to bring more parity between the management of the MySQL and PostgreSQL instances, particularly around the parameter group family names.

## Changes proposed in this pull request:
- Update MySQL and PostgreSQL versions to the latest possible (may require multiple steps)
- Make management of parameter group families consistent
- Add ability to apply changes immediately to MySQL instances

## Security considerations
- Updates our DB instances to newer versions to patch security vulnerabilities and incorporate bug fixes