### PR TITLE
Remove extra parameters for pipeline test

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_name: ((development-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
-      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
+      #TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
       TF_VAR_rds_shared_mysql_username: ((development-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((development-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -14,7 +14,7 @@ module "rds_shared_mysql" {
   rds_db_engine_version         = "${var.rds_shared_mysql_db_engine_version}"
   rds_username                  = "${var.rds_shared_mysql_username}"
   rds_password                  = "${var.rds_shared_mysql_password}"
-  rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
+  //rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
   apply_immediately             = "${var.rds_shared_mysql_apply_immediately}"
   allow_major_version_upgrade   = "${var.rds_shared_mysql_allow_major_version_upgrade}"
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "rds_shared_mysql_db_size" {}
 variable "rds_shared_mysql_db_name" {}
 variable "rds_shared_mysql_db_engine" {}
 variable "rds_shared_mysql_db_engine_version" {}
-variable "rds_shared_mysql_db_parameter_group_family" {}
+//variable "rds_shared_mysql_db_parameter_group_family" {}
 variable "rds_shared_mysql_username" {}
 variable "rds_shared_mysql_password" {}
 variable "rds_shared_mysql_apply_immediately" {}


### PR DESCRIPTION
It turns out that it was not a simple thing to add the extra parameters.  This changeset removes the parameter group family name from the shared MySQL definition to test if RDS picks up the default group we are expecting and allows the Concourse job to run.

## Changes proposed in this pull request:
- Comment out `rds_shared_mysql_db_parameter_group_family` to test if the job works

## Security considerations
- None; RDS should use the default parameter group family with the new version.