### PR TITLE
Continue updating the AWS broker RDS instances in dev and staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -333,8 +333,8 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 11.1
-      TF_VAR_rds_internal_db_parameter_group_family: postgres11
+      TF_VAR_rds_internal_db_engine_version: 12.3
+      TF_VAR_rds_internal_db_parameter_group_family: postgres12
       TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((staging-rds-internal-username))
       TF_VAR_rds_internal_password: ((staging-rds-internal-password))
@@ -357,8 +357,8 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((staging-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 11.1
-      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres11
+      TF_VAR_rds_shared_postgres_db_engine_version: 12.3
+      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
       TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((staging-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((staging-rds-shared-postgres-password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12.3
-      TF_VAR_rds_internal_db_parameter_group_family: postgres13
+      TF_VAR_rds_internal_db_parameter_group_family: postgres12
       TF_VAR_rds_internal_multi_az: false
       TF_VAR_rds_internal_username: ((development-rds-internal-username))
       TF_VAR_rds_internal_password: ((development-rds-internal-password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -33,6 +33,7 @@ jobs:
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12.3
       TF_VAR_rds_internal_db_parameter_group_family: postgres13
+      TF_VAR_rds_internal_multi_az: false
       TF_VAR_rds_internal_username: ((development-rds-internal-username))
       TF_VAR_rds_internal_password: ((development-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -44,6 +45,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
       TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
+      TF_VAR_rds_shared_mysql_multi_az: false
       TF_VAR_rds_shared_mysql_username: ((development-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((development-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
@@ -55,6 +57,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_engine: postgres
       TF_VAR_rds_shared_postgres_db_engine_version: 12.3
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
+      TF_VAR_rds_shared_postgres_multi_az: false
       TF_VAR_rds_shared_postgres_username: ((development-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((development-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"
@@ -332,6 +335,7 @@ jobs:
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 11.1
       TF_VAR_rds_internal_db_parameter_group_family: postgres11
+      TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((staging-rds-internal-username))
       TF_VAR_rds_internal_password: ((staging-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -343,6 +347,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
       TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
+      TF_VAR_rds_shared_mysql_multi_az: true
       TF_VAR_rds_shared_mysql_username: ((staging-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((staging-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
@@ -354,6 +359,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_engine: postgres
       TF_VAR_rds_shared_postgres_db_engine_version: 11.1
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres11
+      TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((staging-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((staging-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"
@@ -629,6 +635,7 @@ jobs:
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 9.5.15
       TF_VAR_rds_internal_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((prod-rds-internal-username))
       TF_VAR_rds_internal_password: ((prod-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -640,6 +647,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.6.41
       TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.6
+      TF_VAR_rds_shared_mysql_multi_az: true
       TF_VAR_rds_shared_mysql_username: ((prod-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((prod-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
@@ -651,6 +659,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_engine: postgres
       TF_VAR_rds_shared_postgres_db_engine_version: 9.5.15
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres9.5
+      TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((prod-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((prod-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_name: ((development-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
-      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
+      #TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
       TF_VAR_rds_shared_mysql_username: ((development-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((development-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -27,7 +27,7 @@ jobs:
       TF_VAR_stack_description: ((development-stack-name))
       TF_VAR_remote_state_bucket: ((development-s3-tfstate-bucket))
 
-      TF_VAR_rds_internal_instance_type: db.m3.medium
+      TF_VAR_rds_internal_instance_type: db.t3.micro
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
@@ -38,7 +38,7 @@ jobs:
       TF_VAR_rds_internal_apply_immediately: "true"
       TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
-      TF_VAR_rds_shared_mysql_instance_type: db.m4.large
+      TF_VAR_rds_shared_mysql_instance_type: db.t2.small
       TF_VAR_rds_shared_mysql_db_size: 100
       TF_VAR_rds_shared_mysql_db_name: ((development-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
@@ -49,7 +49,7 @@ jobs:
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
       TF_VAR_rds_shared_mysql_allow_major_version_upgrade: "true"
 
-      TF_VAR_rds_shared_postgres_instance_type: db.m4.large
+      TF_VAR_rds_shared_postgres_instance_type: db.t3.micro
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((development-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,8 +31,8 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 11.1
-      TF_VAR_rds_internal_db_parameter_group_family: postgres11
+      TF_VAR_rds_internal_db_engine_version: 12.3
+      TF_VAR_rds_internal_db_parameter_group_family: postgres13
       TF_VAR_rds_internal_username: ((development-rds-internal-username))
       TF_VAR_rds_internal_password: ((development-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
@@ -43,7 +43,7 @@ jobs:
       TF_VAR_rds_shared_mysql_db_name: ((development-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
-      #TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
+      TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
       TF_VAR_rds_shared_mysql_username: ((development-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((development-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
@@ -53,8 +53,8 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((development-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 11.1
-      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres11
+      TF_VAR_rds_shared_postgres_db_engine_version: 12.3
+      TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
       TF_VAR_rds_shared_postgres_username: ((development-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((development-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"

--- a/ci/terraform/rds-internal.tf
+++ b/ci/terraform/rds-internal.tf
@@ -12,6 +12,7 @@ module "rds_internal" {
   rds_final_snapshot_identifier = "${var.base_stack}-${replace(var.rds_internal_db_name, "_", "-")}"
   rds_db_engine                 = "${var.rds_internal_db_engine}"
   rds_db_engine_version         = "${var.rds_internal_db_engine_version}"
+  rds_multi_az                  = "${var.rds_internal_multi_az}"
   rds_username                  = "${var.rds_internal_username}"
   rds_password                  = "${var.rds_internal_password}"
   rds_parameter_group_family    = "${var.rds_internal_db_parameter_group_family}"

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -14,7 +14,7 @@ module "rds_shared_mysql" {
   rds_db_engine_version         = "${var.rds_shared_mysql_db_engine_version}"
   rds_username                  = "${var.rds_shared_mysql_username}"
   rds_password                  = "${var.rds_shared_mysql_password}"
-  //rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
+  rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
   apply_immediately             = "${var.rds_shared_mysql_apply_immediately}"
   allow_major_version_upgrade   = "${var.rds_shared_mysql_allow_major_version_upgrade}"
 }

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -14,7 +14,7 @@ module "rds_shared_mysql" {
   rds_db_engine_version         = "${var.rds_shared_mysql_db_engine_version}"
   rds_username                  = "${var.rds_shared_mysql_username}"
   rds_password                  = "${var.rds_shared_mysql_password}"
-  rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
+  //rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"
   apply_immediately             = "${var.rds_shared_mysql_apply_immediately}"
   allow_major_version_upgrade   = "${var.rds_shared_mysql_allow_major_version_upgrade}"
 }

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -2,7 +2,6 @@ module "rds_shared_mysql" {
   source            = "rds_module"
   stack_description = "${var.stack_description}"
   rds_subnet_group  = "${data.terraform_remote_state.vpc.rds_subnet_group}"
-  create_db_parameter_group = "${var.rds_parameter_group_name == "" ? "true" : "false"}"
 
   /* TODO: Use database instance type from config */
   rds_security_groups = ["${data.terraform_remote_state.vpc.rds_mysql_security_group}"]

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -2,6 +2,7 @@ module "rds_shared_mysql" {
   source            = "rds_module"
   stack_description = "${var.stack_description}"
   rds_subnet_group  = "${data.terraform_remote_state.vpc.rds_subnet_group}"
+  create_db_parameter_group = "${var.rds_parameter_group_name == "" ? "true" : "false"}"
 
   /* TODO: Use database instance type from config */
   rds_security_groups = ["${data.terraform_remote_state.vpc.rds_mysql_security_group}"]

--- a/ci/terraform/rds-shared-mysql.tf
+++ b/ci/terraform/rds-shared-mysql.tf
@@ -12,6 +12,7 @@ module "rds_shared_mysql" {
   rds_final_snapshot_identifier = "${var.base_stack}-${replace(var.rds_shared_mysql_db_name, "_", "-")}"
   rds_db_engine                 = "${var.rds_shared_mysql_db_engine}"
   rds_db_engine_version         = "${var.rds_shared_mysql_db_engine_version}"
+  rds_multi_az                  = "${var.rds_shared_mysql_multi_az}"
   rds_username                  = "${var.rds_shared_mysql_username}"
   rds_password                  = "${var.rds_shared_mysql_password}"
   rds_parameter_group_family    = "${var.rds_shared_mysql_db_parameter_group_family}"

--- a/ci/terraform/rds-shared-postgres.tf
+++ b/ci/terraform/rds-shared-postgres.tf
@@ -12,6 +12,7 @@ module "rds_shared_postgres" {
   rds_final_snapshot_identifier = "${var.base_stack}-${replace(var.rds_shared_postgres_db_name, "_", "-")}"
   rds_db_engine                 = "${var.rds_shared_postgres_db_engine}"
   rds_db_engine_version         = "${var.rds_shared_postgres_db_engine_version}"
+  rds_multi_az                  = "${var.rds_shared_postgres_multi_az}"
   rds_username                  = "${var.rds_shared_postgres_username}"
   rds_password                  = "${var.rds_shared_postgres_password}"
   rds_parameter_group_family    = "${var.rds_shared_postgres_db_parameter_group_family}"

--- a/ci/terraform/rds_module/parameter_group.tf
+++ b/ci/terraform/rds_module/parameter_group.tf
@@ -45,6 +45,7 @@ resource "aws_db_parameter_group" "recreatable_parameter_group_mysql" {
     var.rds_parameter_group_name :
     "${replace("${var.stack_description}-${var.rds_db_name}", "/[^a-zA-Z-]+/", "-")}"}"
 
+  create_db_parameter_group = "${var.rds_parameter_group_name == "" ? "true" : "false"}"
   family = "${var.rds_parameter_group_family}"
 
   parameter {

--- a/ci/terraform/rds_module/parameter_group.tf
+++ b/ci/terraform/rds_module/parameter_group.tf
@@ -45,7 +45,6 @@ resource "aws_db_parameter_group" "recreatable_parameter_group_mysql" {
     var.rds_parameter_group_name :
     "${replace("${var.stack_description}-${var.rds_db_name}", "/[^a-zA-Z-]+/", "-")}"}"
 
-  create_db_parameter_group = "${var.rds_parameter_group_name == "" ? "true" : "false"}"
   family = "${var.rds_parameter_group_family}"
 
   parameter {

--- a/ci/terraform/rds_module/variables.tf
+++ b/ci/terraform/rds_module/variables.tf
@@ -23,7 +23,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "11.1"
+  default = "12.3"
 }
 
 variable "rds_username" {}
@@ -45,7 +45,7 @@ variable "rds_parameter_group_name" {
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres11"
+  default = "postgres12"
 }
 
 variable "rds_multi_az" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "rds_shared_mysql_db_size" {}
 variable "rds_shared_mysql_db_name" {}
 variable "rds_shared_mysql_db_engine" {}
 variable "rds_shared_mysql_db_engine_version" {}
-//variable "rds_shared_mysql_db_parameter_group_family" {}
+variable "rds_shared_mysql_db_parameter_group_family" {}
 variable "rds_shared_mysql_username" {}
 variable "rds_shared_mysql_password" {}
 variable "rds_shared_mysql_apply_immediately" {}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -8,6 +8,7 @@ variable "rds_internal_db_name" {}
 variable "rds_internal_db_engine" {}
 variable "rds_internal_db_engine_version" {}
 variable "rds_internal_db_parameter_group_family" {}
+variable "rds_internal_multi_az" {}
 variable "rds_internal_username" {}
 variable "rds_internal_password" {}
 variable "rds_internal_apply_immediately" {}
@@ -19,6 +20,7 @@ variable "rds_shared_mysql_db_name" {}
 variable "rds_shared_mysql_db_engine" {}
 variable "rds_shared_mysql_db_engine_version" {}
 variable "rds_shared_mysql_db_parameter_group_family" {}
+variable "rds_shared_mysql_multi_az" {}
 variable "rds_shared_mysql_username" {}
 variable "rds_shared_mysql_password" {}
 variable "rds_shared_mysql_apply_immediately" {}
@@ -28,8 +30,9 @@ variable "rds_shared_postgres_instance_type" {}
 variable "rds_shared_postgres_db_size" {}
 variable "rds_shared_postgres_db_name" {}
 variable "rds_shared_postgres_db_engine" {}
-variable "rds_shared_postgres_db_parameter_group_family" {}
 variable "rds_shared_postgres_db_engine_version" {}
+variable "rds_shared_postgres_db_parameter_group_family" {}
+variable "rds_shared_postgres_multi_az" {}
 variable "rds_shared_postgres_username" {}
 variable "rds_shared_postgres_password" {}
 variable "rds_shared_postgres_apply_immediately" {}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "rds_shared_mysql_db_size" {}
 variable "rds_shared_mysql_db_name" {}
 variable "rds_shared_mysql_db_engine" {}
 variable "rds_shared_mysql_db_engine_version" {}
-variable "rds_shared_mysql_db_parameter_group_family" {}
+//variable "rds_shared_mysql_db_parameter_group_family" {}
 variable "rds_shared_mysql_username" {}
 variable "rds_shared_mysql_password" {}
 variable "rds_shared_mysql_apply_immediately" {}


### PR DESCRIPTION
Contrary to the branch name, this adds extra parameters to support toggling off multi AZ support.  This branch and PR started out as an attempt to fix an issue we were having with Terraform and became the testbed for ironing out the process with the `dev` RDS instances.

**NOTE:** The pipeline changes seen in this PR are already set in Concourse.  This may also require multiple tries in Concourse, as Terraform has been fussy with some of these.

This PR brings everything up to date and in sync, and kicks off the next step in the process to continue updating the staging instances.

To date, here's where we are based on the previous PR, #120:
- Update the DB versions for dev to latest available versions (this PR - already applied)
- Update the instance class sizes and multi AZ toggle for dev (this PR - already applied)
- Update the DB versions for staging to latest available versions (this PR)
- Update the instance class sizes and multi AZ toggle for staging
- Update the DB versions for production to latest available

All of the changes for the `dev` instances have already been finished as we were testing the pipeline changes.  The only change that will go through with this PR is updating the PostgreSQL versions to the latest available for staging.

## Changes proposed in this pull request:
- Updated pipeline to reflect `dev` instances new state of new DB engine versions and parameter groups, new instance class size, and multi AZ shut off
- Added support to toggle multi AZ in each environment
- Bumps staging PostgreSQL version numbers to 12.3 to kick off the next step in our updates

## Security considerations
- Updates our DB instances to newer versions to patch security vulnerabilities and incorporate bug fixes