### PR TITLE
Update parameter group reference

### DIFF
--- a/ci/terraform/rds_module/database.tf
+++ b/ci/terraform/rds_module/database.tf
@@ -34,8 +34,8 @@ resource "aws_db_instance" "rds_database" {
   vpc_security_group_ids = ["${var.rds_security_groups}"]
 
   parameter_group_name = "${var.rds_db_engine == "postgres" ?
-    "${join("", aws_db_parameter_group.recreatable_parameter_group_postgres.*.id)}" :
-    "${join("", aws_db_parameter_group.recreatable_parameter_group_mysql.*.id)}"}"
+    "${join("", aws_db_parameter_group.recreatable_parameter_group_postgres.name)}" :
+    "${join("", aws_db_parameter_group.recreatable_parameter_group_mysql.name)}"}"
 
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   apply_immediately           = "${var.apply_immediately}"


### PR DESCRIPTION
This changeset modifies how we reference the parameter group in the RDS module.  It seems that we should be referencing it by the name property from the resource, not the name directly or any other property. [See this blog post for more information.](https://tech.instacart.com/terraforming-rds-part-3-9d81a7e2047f#48d5)

## Changes proposed in this pull request:
- Update the parameter group name reference

## Security considerations
- None; this doesn't change anything about our existing infrastructure and if anything, should prevent custom parameter groups from being replaced with every deploy