### PR TITLE
Update staging RDS instance configuration

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -329,37 +329,37 @@ jobs:
       TF_VAR_stack_description: ((staging-stack-name))
       TF_VAR_remote_state_bucket: ((staging-s3-tfstate-bucket))
 
-      TF_VAR_rds_internal_instance_type: db.m3.medium
+      TF_VAR_rds_internal_instance_type: db.t3.micro
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12.3
       TF_VAR_rds_internal_db_parameter_group_family: postgres12
-      TF_VAR_rds_internal_multi_az: true
+      TF_VAR_rds_internal_multi_az: false
       TF_VAR_rds_internal_username: ((staging-rds-internal-username))
       TF_VAR_rds_internal_password: ((staging-rds-internal-password))
       TF_VAR_rds_internal_apply_immediately: "true"
       TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
-      TF_VAR_rds_shared_mysql_instance_type: db.m4.large
+      TF_VAR_rds_shared_mysql_instance_type: db.t2.small
       TF_VAR_rds_shared_mysql_db_size: 100
       TF_VAR_rds_shared_mysql_db_name: ((staging-rds-shared-mysql-db-name))
       TF_VAR_rds_shared_mysql_db_engine: mysql
       TF_VAR_rds_shared_mysql_db_engine_version: 5.7.30
       TF_VAR_rds_shared_mysql_db_parameter_group_family: mysql5.7
-      TF_VAR_rds_shared_mysql_multi_az: true
+      TF_VAR_rds_shared_mysql_multi_az: false
       TF_VAR_rds_shared_mysql_username: ((staging-rds-shared-mysql-username))
       TF_VAR_rds_shared_mysql_password: ((staging-rds-shared-mysql-password))
       TF_VAR_rds_shared_mysql_apply_immediately: "true"
       TF_VAR_rds_shared_mysql_allow_major_version_upgrade: "true"
 
-      TF_VAR_rds_shared_postgres_instance_type: db.m4.large
+      TF_VAR_rds_shared_postgres_instance_type: db.t3.micro
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((staging-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
       TF_VAR_rds_shared_postgres_db_engine_version: 12.3
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
-      TF_VAR_rds_shared_postgres_multi_az: true
+      TF_VAR_rds_shared_postgres_multi_az: false
       TF_VAR_rds_shared_postgres_username: ((staging-rds-shared-postgres-username))
       TF_VAR_rds_shared_postgres_password: ((staging-rds-shared-postgres-password))
       TF_VAR_rds_shared_postgres_apply_immediately: "true"


### PR DESCRIPTION
This changeset updates the staging RDS instances to scale down their instance class sizes and shut off multi AZ as it is not needed in our staging environment.  This is the last commit in a series of steps to reconfigure out staging instances for the AWS broker.

## Changes proposed in this pull request:
- Swap staging PostgreSQL instances to `db.t3.micro` instance classes
- Swap MySQL instance to `db.t2.small` instance class
- Remove multi AZ on all instances

## Security considerations
- None; these are just configuration changes for existing RDS instances that are already secured with encryption enabled and within our VPC