### PR TITLE
Flipping BETA to GA and adding costs for EC and ES

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -755,12 +755,12 @@ redis:
     imageUrl: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIyOHB4IiB2aWV3Qm94PSIwIDAgMzIgMjgiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+ICAgICAgICA8dGl0bGU+cmVkaXM8L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iLWJsb2Nrcy9pY29ucyIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+ICAgICAgICA8ZyBpZD0icmVkaXMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuMDAwMDAwLCAtMC4wMDAwMDApIj4gICAgICAgICAgICA8ZyBpZD0iR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuMTI1NDIxLCAwLjE2NTAzMykiPiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMzAuNDY4ODM3MiwyMC45Mzc2NzQ0IEMyOC43Nzk5MDcsMjEuODE4MDQ2NSAyMC4wMzA1MTE2LDI1LjQxNTQ0MTkgMTguMTY3ODE0LDI2LjM4NjQxODYgQzE2LjMwNTExNjMsMjcuMzU3NzY3NCAxNS4yNzAzMjU2LDI3LjM0ODI3OTEgMTMuNzk4ODgzNywyNi42NDQ4MzcyIEMxMi4zMjc0NDE5LDI1Ljk0MTM5NTMgMy4wMTY1NTgxNCwyMi4xODA0NjUxIDEuMzM5MzQ4ODQsMjEuMzc4NzkwNyBDMC41MDEwMjMyNTYsMjAuOTc4MDQ2NSAwLjA2MDI3OTA2OTgsMjAuNjQgMC4wNjAyNzkwNjk4LDIwLjMyMDU1ODEgTDAuMDYwMjc5MDY5OCwxNy4xMjE0ODg0IEMwLjA2MDI3OTA2OTgsMTcuMTIxNDg4NCAxMi4xODE3Njc0LDE0LjQ4MjYwNDcgMTQuMTM4NzkwNywxMy43ODA2NTEyIEMxNi4wOTU2Mjc5LDEzLjA3ODUxMTYgMTYuNzc0NTExNiwxMy4wNTMyMDkzIDE4LjQzOTgxNCwxMy42NjMyNTU4IEMyMC4xMDUzMDIzLDE0LjI3MzMwMjMgMzAuMDYyODgzNywxNi4wNjk5NTM1IDMxLjcwODgzNzIsMTYuNjcyNzQ0MiBDMzEuNzA4ODM3MiwxNi42NzI3NDQyIDMxLjcwODA5MywxOS41Mjk4NjA1IDMxLjcwODA5MywxOS44MjY0MTg2IEMzMS43MDgyNzkxLDIwLjE0MjY5NzcgMzEuMzI4NTU4MSwyMC40ODk2NzQ0IDMwLjQ2ODgzNzIsMjAuOTM3Njc0NCBMMzAuNDY4ODM3MiwyMC45Mzc2NzQ0IFoiIGlkPSJTaGFwZSIgZmlsbD0iI0E0MUUxMSI+PC9wYXRoPiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMzAuNDY4ODM3MiwxNy43Mzc2NzQ0IEMyOC43Nzk5MDcsMTguNjE3Njc0NCAyMC4wMzA1MTE2LDIyLjIxNTQ0MTkgMTguMTY3ODE0LDIzLjE4NjQxODYgQzE2LjMwNTExNjMsMjQuMTU3NzY3NCAxNS4yNzAzMjU2LDI0LjE0ODI3OTEgMTMuNzk4ODgzNywyMy40NDQ4MzcyIEMxMi4zMjcyNTU4LDIyLjc0MTc2NzQgMy4wMTY1NTgxNCwxOC45ODAwOTMgMS4zMzkzNDg4NCwxOC4xNzg3OTA3IEMtMC4zMzc4NjA0NjUsMTcuMzc3MTE2MyAtMC4zNzMwMjMyNTYsMTYuODI1MzAyMyAxLjI3NDYwNDY1LDE2LjE4MDI3OTEgQzIuOTIyMDQ2NTEsMTUuNTM0ODgzNyAxMi4xODE3Njc0LDExLjkwMTk1MzUgMTQuMTM4OTc2NywxMS4xOTk4MTQgQzE2LjA5NTgxNCwxMC40OTgwNDY1IDE2Ljc3NDY5NzcsMTAuNDcyMzcyMSAxOC40NCwxMS4wODI2MDQ3IEMyMC4xMDU0ODg0LDExLjY5MjY1MTIgMjguODAyNjA0NywxNS4xNTQ0MTg2IDMwLjQ0ODM3MjEsMTUuNzU3MjA5MyBDMzIuMDk0NTExNiwxNi4zNjA1NTgxIDMyLjE1Nzc2NzQsMTYuODU3MzAyMyAzMC40Njg4MzcyLDE3LjczNzY3NDQgTDMwLjQ2ODgzNzIsMTcuNzM3Njc0NCBaIiBpZD0iU2hhcGUiIGZpbGw9IiNEODJDMjAiPjwvcGF0aD4gICAgICAgICAgICAgICAgPHBhdGggZD0iTTMwLjQ2ODgzNzIsMTUuNzIwOTMwMiBDMjguNzc5OTA3LDE2LjYwMTMwMjMgMjAuMDMwNTExNiwyMC4xOTg2OTc3IDE4LjE2NzgxNCwyMS4xNzAwNDY1IEMxNi4zMDUxMTYzLDIyLjE0MTAyMzMgMTUuMjcwMzI1NiwyMi4xMzE1MzQ5IDEzLjc5ODg4MzcsMjEuNDI4MDkzIEMxMi4zMjcyNTU4LDIwLjcyNTAyMzMgMy4wMTY1NTgxNCwxNi45NjM3MjA5IDEuMzM5MzQ4ODQsMTYuMTYyMDQ2NSBDMC41MDEwMjMyNTYsMTUuNzYxMzAyMyAwLjA2MDI3OTA2OTgsMTUuNDIzNjI3OSAwLjA2MDI3OTA2OTgsMTUuMTA0MTg2IEwwLjA2MDI3OTA2OTgsMTEuOTA0NzQ0MiBDMC4wNjAyNzkwNjk4LDExLjkwNDc0NDIgMTIuMTgxNzY3NCw5LjI2NjA0NjUxIDE0LjEzODc5MDcsOC41NjM5MDY5OCBDMTYuMDk1NjI3OSw3Ljg2MTk1MzQ5IDE2Ljc3NDUxMTYsNy44MzY0NjUxMiAxOC40Mzk4MTQsOC40NDY1MTE2MyBDMjAuMTA1MzAyMyw5LjA1NjU1ODE0IDMwLjA2Mjg4MzcsMTAuODUyODM3MiAzMS43MDg4MzcyLDExLjQ1NTgxNCBDMzEuNzA4ODM3MiwxMS40NTU4MTQgMzEuNzA4MDkzLDE0LjMxMjkzMDIgMzEuNzA4MDkzLDE0LjYwOTg2MDUgQzMxLjcwODI3OTEsMTQuOTI1OTUzNSAzMS4zMjg1NTgxLDE1LjI3MjkzMDIgMzAuNDY4ODM3MiwxNS43MjA5MzAyIEwzMC40Njg4MzcyLDE1LjcyMDkzMDIgWiIgaWQ9IlNoYXBlIiBmaWxsPSIjQTQxRTExIj48L3BhdGg+ICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0zMC40Njg4MzcyLDEyLjUyMDkzMDIgQzI4Ljc3OTkwNywxMy40MDEzMDIzIDIwLjAzMDUxMTYsMTYuOTk4Njk3NyAxOC4xNjc4MTQsMTcuOTcwMDQ2NSBDMTYuMzA1MTE2MywxOC45NDEwMjMzIDE1LjI3MDMyNTYsMTguOTMxNTM0OSAxMy43OTg4ODM3LDE4LjIyODA5MyBDMTIuMzI3MjU1OCwxNy41MjUwMjMzIDMuMDE2NTU4MTQsMTMuNzYzNTM0OSAxLjMzOTM0ODg0LDEyLjk2MjA0NjUgQy0wLjMzNzg2MDQ2NSwxMi4xNjA1NTgxIC0wLjM3MzAyMzI1NiwxMS42MDg3NDQyIDEuMjc0NjA0NjUsMTAuOTYzMzQ4OCBDMi45MjIwNDY1MSwxMC4zMTgzMjU2IDEyLjE4MTc2NzQsNi42ODUyMDkzIDE0LjEzODk3NjcsNS45ODMyNTU4MSBDMTYuMDk1ODE0LDUuMjgxMzAyMzMgMTYuNzc0Njk3Nyw1LjI1NTgxMzk1IDE4LjQ0LDUuODY1ODYwNDcgQzIwLjEwNTQ4ODQsNi40NzU5MDY5OCAyOC44MDI2MDQ3LDkuOTM3NDg4MzcgMzAuNDQ4MzcyMSwxMC41NDA0NjUxIEMzMi4wOTQ1MTE2LDExLjE0MzYyNzkgMzIuMTU3NzY3NCwxMS42NDA1NTgxIDMwLjQ2ODgzNzIsMTIuNTIwOTMwMiBMMzAuNDY4ODM3MiwxMi41MjA5MzAyIFoiIGlkPSJTaGFwZSIgZmlsbD0iI0Q4MkMyMCI+PC9wYXRoPiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMzAuNDY4ODM3MiwxMC4zMTA2OTc3IEMyOC43Nzk5MDcsMTEuMTkxMDY5OCAyMC4wMzA1MTE2LDE0Ljc4ODY1MTIgMTguMTY3ODE0LDE1Ljc2IEMxNi4zMDUxMTYzLDE2LjczMDk3NjcgMTUuMjcwMzI1NiwxNi43MjE0ODg0IDEzLjc5ODg4MzcsMTYuMDE4MDQ2NSBDMTIuMzI3MjU1OCwxNS4zMTQ5NzY3IDMuMDE2NTU4MTQsMTEuNTUzNDg4NCAxLjMzOTM0ODg0LDEwLjc1MiBDMC41MDEwMjMyNTYsMTAuMzUxMjU1OCAwLjA2MDI3OTA2OTgsMTAuMDEzMzk1MyAwLjA2MDI3OTA2OTgsOS42OTQxMzk1MyBMMC4wNjAyNzkwNjk4LDYuNDk0Njk3NjcgQzAuMDYwMjc5MDY5OCw2LjQ5NDY5NzY3IDEyLjE4MTc2NzQsMy44NTYgMTQuMTM4NzkwNywzLjE1NDA0NjUxIEMxNi4wOTU2Mjc5LDIuNDUxOTA2OTggMTYuNzc0NTExNiwyLjQyNjYwNDY1IDE4LjQzOTgxNCwzLjAzNjY1MTE2IEMyMC4xMDUzMDIzLDMuNjQ2Njk3NjcgMzAuMDYyODgzNyw1LjQ0Mjk3Njc0IDMxLjcwODgzNzIsNi4wNDU5NTM0OSBDMzEuNzA4ODM3Miw2LjA0NTk1MzQ5IDMxLjcwODA5Myw4LjkwMzA2OTc3IDMxLjcwODA5Myw5LjE5OTgxMzk1IEMzMS43MDgyNzkxLDkuNTE1NzIwOTMgMzEuMzI4NTU4MSw5Ljg2MjY5NzY3IDMwLjQ2ODgzNzIsMTAuMzEwNjk3NyBMMzAuNDY4ODM3MiwxMC4zMTA2OTc3IFoiIGlkPSJTaGFwZSIgZmlsbD0iI0E0MUUxMSI+PC9wYXRoPiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMzAuNDY4ODM3Miw3LjExMDY5NzY3IEMyOC43Nzk5MDcsNy45OTEwNjk3NyAyMC4wMzA1MTE2LDExLjU4ODY1MTIgMTguMTY3ODE0LDEyLjU1OTgxNCBDMTYuMzA1MTE2MywxMy41MzA3OTA3IDE1LjI3MDMyNTYsMTMuNTIxMzAyMyAxMy43OTg4ODM3LDEyLjgxODA0NjUgQzEyLjMyNzQ0MTksMTIuMTE0NzkwNyAzLjAxNjU1ODE0LDguMzUzNDg4MzcgMS4zMzkzNDg4NCw3LjU1MiBDLTAuMzM3ODYwNDY1LDYuNzUwNTExNjMgLTAuMzczMDIzMjU2LDYuMTk4NTExNjMgMS4yNzQ2MDQ2NSw1LjU1MzMwMjMzIEMyLjkyMjA0NjUxLDQuOTA4MDkzMDIgMTIuMTgxNzY3NCwxLjI3NTM0ODg0IDE0LjEzODk3NjcsMC41NzMyMDkzMDIgQzE2LjA5NTgxNCwtMC4xMjg5MzAyMzMgMTYuNzc0Njk3NywtMC4xNTQyMzI1NTggMTguNDQsMC40NTYgQzIwLjEwNTQ4ODQsMS4wNjYwNDY1MSAyOC44MDI2MDQ3LDQuNTI3NjI3OTEgMzAuNDQ4MzcyMSw1LjEzMDYwNDY1IEMzMi4wOTQ1MTE2LDUuNzMzMzk1MzUgMzIuMTU3NzY3NCw2LjIzMDUxMTYzIDMwLjQ2ODgzNzIsNy4xMTA2OTc2NyBaIiBpZD0iU2hhcGUiIGZpbGw9IiNEODJDMjAiPjwvcGF0aD4gICAgICAgICAgICAgICAgPHBvbHlnb24gaWQ9IlNoYXBlIiBmaWxsPSIjRkZGRkZGIiBwb2ludHM9IjIwLjAzMTYyNzkgNC4wMjk3Njc0NCAxNy4yODkzMDIzIDQuMzE0NDE4NiAxNi42NzUzNDg4IDUuNzkxNjI3OTEgMTUuNjgzNzIwOSA0LjE0MzI1NTgxIDEyLjUxNzIwOTMgMy44NTg2MDQ2NSAxNC44OCAzLjAwNjUxMTYzIDE0LjE3MTE2MjggMS42OTg2MDQ2NSAxNi4zODMyNTU4IDIuNTYzNzIwOTMgMTguNDY4ODM3MiAxLjg4MDkzMDIzIDE3LjkwNTExNjMgMy4yMzM0ODgzNyI+PC9wb2x5Z29uPiAgICAgICAgICAgICAgICA8cG9seWdvbiBpZD0iU2hhcGUiIGZpbGw9IiNGRkZGRkYiIHBvaW50cz0iMTYuNTExNjI3OSAxMS4xOTYyNzkxIDExLjM5MzQ4ODQgOS4wNzM0ODgzNyAxOC43Mjc0NDE5IDcuOTQ3OTA2OTgiPjwvcG9seWdvbj4gICAgICAgICAgICAgICAgPGVsbGlwc2UgaWQ9Ik92YWwiIGZpbGw9IiNGRkZGRkYiIGN4PSI5LjQxNTgxMzk1IiBjeT0iNi4zNzAyMzI1NiIgcng9IjMuOTE5ODEzOTUiIHJ5PSIxLjUxOTQ0MTg2Ij48L2VsbGlwc2U+ICAgICAgICAgICAgICAgIDxwb2x5Z29uIGlkPSJTaGFwZSIgZmlsbD0iIzdBMEMwMCIgcG9pbnRzPSIyMy4yNzI1NTgxIDQuNDMzNDg4MzcgMjcuNjEzMDIzMyA2LjE0ODgzNzIxIDIzLjI3NjI3OTEgNy44NjIzMjU1OCI+PC9wb2x5Z29uPiAgICAgICAgICAgICAgICA8cG9seWdvbiBpZD0iU2hhcGUiIGZpbGw9IiNBRDIxMTUiIHBvaW50cz0iMTguNDcwNjk3NyA2LjMzMzAyMzI2IDIzLjI3MjU1ODEgNC40MzM0ODgzNyAyMy4yNzYyNzkxIDcuODYyMzI1NTggMjIuODA1NTgxNCA4LjA0NjUxMTYzIj48L3BvbHlnb24+ICAgICAgICAgICAgPC9nPiAgICAgICAgPC9nPiAgICA8L2c+PC9zdmc+"
     longDescription:
     providerDisplayName: AWS Elasticache Redis
-    documentationUrl: "https://cloud.gov/docs/services/aws-elasticacheBETA/"
+    documentationUrl: "https://cloud.gov/docs/services/aws-elasticache/"
     supportUrl:
   plans:
     - id: "475e36bf-387f-44c1-9b81-575fec2ee443"
-      name: "BETA-redis-dev"
-      description: "BETA AWS Elasticache Redis 5.0.6 Single node non-prod use only"
+      name: "redis-dev"
+      description: "AWS Elasticache Redis 5.0.6 Single node non-prod use only"
       metadata:
         bullets:
           - "Elasticache"
@@ -771,10 +771,10 @@ redis:
         costs:
           -
             amount:
-              usd: 0
+              usd: 20.0
             unit: "MONTHLY"
         displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
-      free: true
+      free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 5.0.6
       numberCluster: 1
@@ -790,8 +790,8 @@ redis:
         client: "paas-cf"
         service: "aws-broker"
     - id: "3nd336bf-387f-44c1-9b81-575fel966443"
-      name: "BETA-redis-3node"
-      description: "BETA AWS Elasticache Redis 5.0.6 Three node"
+      name: "redis-3node"
+      description: "AWS Elasticache Redis 5.0.6 Three node"
       metadata:
         bullets:
           - "Elasticache"
@@ -801,10 +801,10 @@ redis:
         costs:
           -
             amount:
-              usd: 0
+              usd: 60.0
             unit: "MONTHLY"
         displayName: "3 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
-      free: true
+      free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 5.0.6
       numberCluster: 3
@@ -820,8 +820,8 @@ redis:
         client: "paas-cf"
         service: "aws-broker"
     - id: "5nd336bf-0k7f-44c1-9b81-575fp3k764r6"
-      name: "BETA-redis-5node"
-      description: "BETA AWS Elasticache Redis 5.0.6 Five node"
+      name: "redis-5node"
+      description: "AWS Elasticache Redis 5.0.6 Five node"
       metadata:
         bullets:
           - "Elasticache"
@@ -831,10 +831,10 @@ redis:
         costs:
           -
             amount:
-              usd: 0
+              usd: 100.0
             unit: "MONTHLY"
         displayName: "5 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
-      free: true
+      free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 5.0.6
       numberCluster: 5
@@ -862,12 +862,12 @@ elasticsearch:
     imageUrl: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiB2aWV3Qm94PSIwIDAgMzIgMzIiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+ICAgICAgICA8dGl0bGU+ZWxhc3RpY3NlYXJjaDwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSItYmxvY2tzL2ljb25zIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4gICAgICAgIDxnIGlkPSJlbGFzdGljc2VhcmNoIj4gICAgICAgICAgICA8cGF0aCBkPSJNNC4zNTI1MzU4LDIxLjU5MjU5MTcgQzQuMjQ0NTQyMjYsMjIuMTM2OTAxMSA0LjE4NzkxOTQ2LDIyLjY5OTY0ODkgNC4xODc5MTk0NiwyMy4yNzU1OTM5IEM0LjE4NzkxOTQ2LDI4LjAzNDY0NDYgOC4wNTM5OTEyOCwzMS44OTI2MTc0IDEyLjgyMzAzMjUsMzEuODkyNjE3NCBDMTUuODA2MDM4OCwzMS44OTI2MTc0IDE4LjQzNTc2NDksMzAuMzgzMjE0IDE5Ljk4NzA4MDgsMjguMDg4MDE4MSBMMjEuMjYxMTU4MSwyMS41MzM0NTg5IEwxOS41NDM5NjA5LDE4LjMwMzg4MDcgTDExLjg4MjY2OTQsMTQuODEyNDI5IEw0LjM1MjUzNTgsMjEuNTkyNTkxNyBaIiBpZD0iQ29tYmluZWQtU2hhcGUtQ29weSIgZmlsbD0iIzM0QkVCMCI+PC9wYXRoPiAgICAgICAgICAgIDxwYXRoIGQ9Ik0yNy42NDc3OTkyLDEwLjI0NzA4OTIgQzI3Ljc1NTU3NSw5LjcwNjA0MTQ3IDI3LjgxMjA4MDUsOS4xNDY2OTMzMyAyNy44MTIwODA1LDguNTc0MjQyNTIgQzI3LjgxMjA4MDUsMy44Mzg4MTkxMyAyMy45NDU0NTI0LDAgMTkuMTc1NzI0OCwwIEMxNi4xOTcxODUsMCAxMy41NzA4MTc2LDEuNDk2OTg0NSAxMi4wMTgyOTI0LDMuNzc0NDczODQgTDEwLjczOTkyMzIsMTAuMzUxMTEzNSBMMTIuMTk1NDAyMywxMy40NzIzOTg1IEwxOS44OTg5MTUsMTYuOTgzMDkxNSBMMjcuNjQ3Nzk5MiwxMC4yNDcwODkyIFoiIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTIiIGZpbGw9IiNGNUJEMTUiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNMy42MzQ5OTkxNywyMC41MDgxMDU5IEMxLjUwNDE2MzYxLDE5LjY0OTI5NTQgMCwxNy41NTk5NDY1IDAsMTUuMTE4Nzg2NiBDMCwxMi42MTM3ODE0IDEuNTgzODcxMzQsMTAuNDc5MjMwMSAzLjgwMzQ1NzA3LDkuNjY0NjI0OTMgTDkuNTkzNzkxMTIsMTEuMDAxNDI4OSBMMTAuOTUzODgyMywxMy45MTgxNTM5IEwzLjYzNDk5OTE3LDIwLjUwODEwNTkgWiIgaWQ9IkNvbWJpbmVkLVNoYXBlLUNvcHktMyIgZmlsbD0iIzJCNDc5MCI+PC9wYXRoPiAgICAgICAgICAgIDxwYXRoIGQ9Ik0yOC4zNjA0OTc3LDExLjM4OTM1NjUgQzMwLjQ5MTM5MjEsMTIuMjMwMTkzNiAzMiwxNC4zMTU4MzkzIDMyLDE2Ljc1NTU4NCBDMzIsMTkuMzA1MTY1OCAzMC4zNTI0OTk1LDIxLjQ2ODA0ODEgMjguMDY4OTk2NiwyMi4yMjc3MjQ2IEwyMi40MTU4Nzc3LDIwLjkyMjU5OTMgTDIwLjgyODM3MTQsMTcuOTM2OTM0MSBMMjguMzYwNDk3NywxMS4zODkzNTY1IFoiIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTQiIGZpbGw9IiMxNzY3NTYiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNMTAuNjI0MzkwNywzLjcyMDI3ODY1IEM5Ljk0MDc5NDk3LDMuMjA0Nzk5MjkgOS4wOTA5Nzc3MSwyLjg5OTMyODg2IDguMTcwMDY0ODMsMi44OTkzMjg4NiBDNS45MTE0ODA5MywyLjg5OTMyODg2IDQuMDgwNTM2OTEsNC43MzY3MzIzNiA0LjA4MDUzNjkxLDcuMDAzMjg0NDQgQzQuMDgwNTM2OTEsNy41MjI0OTc1IDQuMTc2NjE3MzMsOC4wMTkxOTA2MSA0LjM1MTkwOTA4LDguNDc2NDM1MTcgTDkuNDcwMTk4MDIsOS42NTgwODUyOCBMMTAuNjI0MzkwNywzLjcyMDI3ODY1IFoiIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTUiIGZpbGw9IiNFQTQ4OEMiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNMjcuNTU2NTM4OCwyMy40MjYzMTMzIEMyNy43MjE3ODA0LDIzLjg3NDI4NCAyNy44MTIwODA1LDI0LjM1ODk5NjMgMjcuODEyMDgwNSwyNC44NjQ5Njg0IEMyNy44MTIwODA1LDI3LjE0NDk3NjcgMjUuOTc4NDY0OCwyOC45OTMyODg2IDIzLjcxNjU4NTMsMjguOTkzMjg4NiBDMjIuNzk5OTA4OSwyOC45OTMyODg2IDIxLjk1MzU3MjgsMjguNjg5NzExOSAyMS4yNzExMjMxLDI4LjE3Njg1NDIgTDIyLjQyNDgyNjYsMjIuMjQxNTY0MiBMMjcuNTU2NTM4OCwyMy40MjYzMTMzIFoiIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTYiIGZpbGw9IiM5NEM3M0YiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg=="
     longDescription:
     providerDisplayName: aws-elasticsearch
-    documentationUrl: "https://cloud.gov/docs/services/aws-elasticsearchBETA/"
+    documentationUrl: "https://cloud.gov/docs/services/aws-elasticsearch/"
     supportUrl:
   plans:
   - id: "20567994-6028-4629-9761-92ebd3fc330f"
-    name: "BETA-es-dev-6.8-migration"
-    description: "BETA AWS Elasticsearch 6.8 MIGRATION - Single node non-prod use only"
+    name: "es-dev-6.8-migration"
+    description: "AWS Elasticsearch 6.8 MIGRATION - Single node non-prod use only"
     metadata:
       bullets:
       - "elasticsearch"
@@ -876,10 +876,10 @@ elasticsearch:
       - "non-prod"
       costs:
       - amount:
-          usd: 0
+          usd: 200.0
         unit: "MONTHLY"
-      displayName: "non-prod single node elasticsearch 7.4"
-    free: true
+      displayName: "non-prod single node elasticsearch 6.8"
+    free: false
     elasticsearchVersion: 6.8
     dataCount: 1
     instanceType: t2.small.elasticsearch
@@ -895,8 +895,8 @@ elasticsearch:
       client: "the client"
       service: "aws-broker"
   - id: "162ffae8-9cf8-4806-80e5-a7f92d514198"
-    name: "BETA-es-dev"
-    description: "BETA AWS Elasticsearch 7.4 - Single node non-prod use only"
+    name: "es-dev"
+    description: "AWS Elasticsearch 7.4 - Single node non-prod use only"
     metadata:
       bullets:
       - "elasticsearch"
@@ -905,10 +905,10 @@ elasticsearch:
       - "non-prod"
       costs:
       - amount:
-          usd: 0
+          usd: 200.0
         unit: "MONTHLY"
       displayName: "non-prod single node elasticsearch 7.4"
-    free: true
+    free: false
     elasticsearchVersion: 7.4
     dataCount: 1
     instanceType: t2.small.elasticsearch
@@ -924,8 +924,8 @@ elasticsearch:
       client: "the client"
       service: "aws-broker"
   - id: "55b529cf-639e-4673-94fd-ad0a5dafe0ad"
-    name: "BETA-es-medium"
-    description: "BETA AWS Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    name: "es-medium"
+    description: "AWS Elasticsearch 7.4 - 3 node master with 2 data nodes"
     metadata:
       bullets:
       - "elasticsearch"
@@ -933,10 +933,10 @@ elasticsearch:
       - "2 data nodes"
       costs:
       - amount:
-          usd: 0
+          usd: 1000.0
         unit: "MONTHLY"
       displayName: "es cluster 3 master 2 data based on elasticsearch 7.4"
-    free: true
+    free: false
     elasticsearchVersion: 7.4
     masterCount: 3
     dataCount: 2
@@ -956,8 +956,8 @@ elasticsearch:
       client: "the client"
       service: "aws-broker"
   - id: "95b528cf-743e-2996-32yt-mc0a5vnf87cg"
-    name: "BETA-es-medium-ha"
-    description: "BETA AWS Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    name: "es-medium-ha"
+    description: "AWS Elasticsearch 7.4 - 3 node master with 4 data nodes"
     metadata:
       bullets:
       - "elasticsearch"
@@ -965,10 +965,10 @@ elasticsearch:
       - "4 data nodes"
       costs:
       - amount:
-          usd: 0
+          usd: 1400.0
         unit: "MONTHLY"
       displayName: "es cluster 3 master 4 data based on elasticsearch 7.4"
-    free: true
+    free: false
     elasticsearchVersion: 7.4
     masterCount: 3
     dataCount: 4

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -133,7 +133,7 @@ jobs:
       BROKER_NAME: ((development-broker-name))
       AUTH_USER: ((development-auth-user))
       AUTH_PASS: ((development-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:-es-medium-ha
+      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -790,7 +790,7 @@ jobs:
       BROKER_NAME: ((prod-broker-name))
       AUTH_USER: ((prod-auth-user))
       AUTH_PASS: ((prod-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:-es-medium-ha
+      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -133,7 +133,7 @@ jobs:
       BROKER_NAME: ((development-broker-name))
       AUTH_USER: ((development-auth-user))
       AUTH_PASS: ((development-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:BETA-redis-dev aws-elasticache-redis:BETA-redis-3node aws-elasticache-redis:BETA-redis-5node aws-elasticsearch:BETA-es-dev aws-elasticsearch:BETA-es-medium aws-elasticsearch:BETA-es-medium-ha
+      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:-es-medium-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -272,7 +272,7 @@ jobs:
           CF_ORGANIZATION: ((development-cf-organization))
           CF_SPACE: ((development-cf-space))
           SERVICE_NAME: aws-elasticache-redis
-          SERVICE_PLAN: BETA-redis-dev
+          SERVICE_PLAN: redis-dev
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
@@ -283,7 +283,7 @@ jobs:
           CF_ORGANIZATION: ((development-cf-organization))
           CF_SPACE: ((development-cf-space))
           SERVICE_NAME: aws-elasticsearch
-          SERVICE_PLAN: BETA-es-dev
+          SERVICE_PLAN: es-dev
   on_success:
     put: slack
     params:
@@ -435,7 +435,7 @@ jobs:
       BROKER_NAME: ((staging-broker-name))
       AUTH_USER: ((staging-auth-user))
       AUTH_PASS: ((staging-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:BETA-redis-dev aws-elasticache-redis:BETA-redis-3node aws-elasticache-redis:BETA-redis-5node aws-elasticsearch:BETA-es-dev aws-elasticsearch:BETA-es-medium aws-elasticsearch:BETA-es-medium-ha
+      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -572,7 +572,7 @@ jobs:
           CF_ORGANIZATION: ((staging-cf-organization))
           CF_SPACE: ((staging-cf-space))
           SERVICE_NAME: aws-elasticache-redis
-          SERVICE_PLAN: BETA-redis-dev
+          SERVICE_PLAN: redis-dev
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
@@ -583,7 +583,7 @@ jobs:
           CF_ORGANIZATION: ((staging-cf-organization))
           CF_SPACE: ((staging-cf-space))
           SERVICE_NAME: aws-elasticsearch
-          SERVICE_PLAN: BETA-es-dev
+          SERVICE_PLAN: es-dev
   on_success:
     put: slack
     params:
@@ -790,7 +790,7 @@ jobs:
       BROKER_NAME: ((prod-broker-name))
       AUTH_USER: ((prod-auth-user))
       AUTH_PASS: ((prod-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2
+      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:-es-medium-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -927,7 +927,7 @@ jobs:
           CF_ORGANIZATION: ((prod-cf-organization))
           CF_SPACE: ((prod-cf-space))
           SERVICE_NAME: aws-elasticache-redis
-          SERVICE_PLAN: BETA-redis-dev
+          SERVICE_PLAN: redis-dev
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
@@ -938,7 +938,7 @@ jobs:
           CF_ORGANIZATION: ((prod-cf-organization))
           CF_SPACE: ((prod-cf-space))
           SERVICE_NAME: aws-elasticsearch
-          SERVICE_PLAN: BETA-es-dev
+          SERVICE_PLAN: es-dev
   on_success:
     put: slack
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removed beta from plan names and descriptions
- Moved EC and ES services to paid
- Moved all but ES 6.8 migration plan into all org access

## Security considerations

n/a
