### PR TITLE
Move shared prod TF versions to major only so the pipeline does not n…

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -633,7 +633,7 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((prod-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 9.5.22
+      TF_VAR_rds_internal_db_engine_version: 9.5
       TF_VAR_rds_internal_db_parameter_group_family: postgres9.5
       TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((prod-rds-internal-username))
@@ -657,7 +657,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((prod-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 9.5.22
+      TF_VAR_rds_shared_postgres_db_engine_version: 9.5
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres9.5
       TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((prod-rds-shared-postgres-username))
@@ -694,7 +694,7 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((prod-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 9.5.22
+      TF_VAR_rds_internal_db_engine_version: 9.5
       TF_VAR_rds_internal_db_parameter_group_family: postgres9.5
       TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((prod-rds-internal-username))
@@ -718,7 +718,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((prod-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 9.5.22
+      TF_VAR_rds_shared_postgres_db_engine_version: 9.5
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres9.5
       TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((prod-rds-shared-postgres-username))


### PR DESCRIPTION
…eed to follow minor version changes

## Changes proposed in this pull request:

- Changed TF provision plan and set steps to not include minor version - this allows AWS to perform the maintenance which revs minor versions and for CG staff to not track that minor version in the pipeline to keep TF from  throwing an error on minor mismatch.


## Security considerations

n/a
