### PR TITLE
use c5.2xlarge.elasticsearch

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1196,8 +1196,8 @@ elasticsearch:
     elasticsearchVersion: 7.4
     masterCount: 3
     dataCount: 2
-    instanceType: c6g.2xlarge.elasticsearch
-    masterInstanceType: c6g.2xlarge.elasticsearch
+    instanceType: c5.2xlarge.elasticsearch
+    masterInstanceType: c5.2xlarge.elasticsearch
     volumeSize: 30
     volumeType: gp2
     masterEnabled: true
@@ -1228,8 +1228,8 @@ elasticsearch:
     elasticsearchVersion: 7.4
     masterCount: 3
     dataCount: 4
-    instanceType: c6g.2xlarge.elasticsearch
-    masterInstanceType: c6g.2xlarge.elasticsearch
+    instanceType: c5.2xlarge.elasticsearch
+    masterInstanceType: c5.2xlarge.elasticsearch
     volumeSize: 30
     volumeType: gp2
     masterEnabled: true


### PR DESCRIPTION


## Changes proposed in this pull request:

- We can't use c6g without switching to opensearch, and we haven't done any research on that, so we'll use c5 for now


## Security considerations

None