### PR TITLE
Apply golangci_lint linting suggestions

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -163,7 +163,10 @@ func (i *IAMUser) CreatePolicy(policyName, iamPath, policyTemplate string, resou
 			for idx, resource := range resources {
 				resourcePaths[idx] = resource + suffix
 			}
-			marshaled, _ := json.Marshal(resourcePaths)
+			marshaled, err := json.Marshal(resourcePaths)
+			if err != nil {
+				panic(err)
+			}
 			return string(marshaled)
 		},
 	}).Parse(policyTemplate)

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -14,8 +14,17 @@ var rdsMySQLTestPlanID = "da91e15c-98c9-46a9-b114-02b8d28062c7"
 var rdsMySQLValidVersion = "8.0"
 var rdsMySQLInvalidVersion = "5.6"
 
+// Helper function to call os.Getwd with error checking
+func checkedGetwd(t *testing.T) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error calling os.Getwd(): %s", err)
+	}
+	return wd
+}
+
 func TestInitCatalog(t *testing.T) {
-	wd, _ := os.Getwd()
+	wd := checkedGetwd(t)
 	path := filepath.Join(wd, "..")
 	catalog := InitCatalog(path)
 	if catalog == nil {
@@ -24,7 +33,7 @@ func TestInitCatalog(t *testing.T) {
 }
 
 func TestFetchPlan(t *testing.T) {
-	wd, _ := os.Getwd()
+	wd := checkedGetwd(t)
 	path := filepath.Join(wd, "..")
 	catalog := InitCatalog(path)
 
@@ -36,7 +45,7 @@ func TestFetchPlan(t *testing.T) {
 }
 
 func TestRDSPGCheckVersion(t *testing.T) {
-	wd, _ := os.Getwd()
+	wd := checkedGetwd(t)
 	path := filepath.Join(wd, "..")
 	catalog := InitCatalog(path)
 
@@ -62,7 +71,7 @@ func TestRDSPGCheckVersion(t *testing.T) {
 }
 
 func TestRDSMySQLCheckVersion(t *testing.T) {
-	wd, _ := os.Getwd()
+	wd := checkedGetwd(t)
 	path := filepath.Join(wd, "..")
 	catalog := InitCatalog(path)
 
@@ -88,7 +97,7 @@ func TestRDSMySQLCheckVersion(t *testing.T) {
 }
 
 func TestRDSCheckVersionEmpty(t *testing.T) {
-	wd, _ := os.Getwd()
+	wd := checkedGetwd(t)
 	path := filepath.Join(wd, "..")
 	catalog := InitCatalog(path)
 

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -14,8 +14,6 @@ var rdsMySQLTestPlanID = "da91e15c-98c9-46a9-b114-02b8d28062c7"
 var rdsMySQLValidVersion = "8.0"
 var rdsMySQLInvalidVersion = "5.6"
 
-var rdsOracleTestPlanID = "332e0168-6969-4bd7-b07f-29f08c4bf78f"
-
 func TestInitCatalog(t *testing.T) {
 	wd, _ := os.Getwd()
 	path := filepath.Join(wd, "..")

--- a/db/db.go
+++ b/db/db.go
@@ -18,7 +18,7 @@ const maxDbConnections = 10
 func InternalDBInit(dbConfig *common.DBConfig) (*gorm.DB, error) {
 	db, err := common.DBInit(dbConfig)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	db.DB().SetMaxOpenConns(maxDbConnections)
 	log.Println("Migrating")

--- a/db/db.go
+++ b/db/db.go
@@ -15,13 +15,14 @@ import (
 // In addition to calling DBInit(), it also makes sure that the tables are setup for Instance and DBConfig structs.
 func InternalDBInit(dbConfig *common.DBConfig) (*gorm.DB, error) {
 	db, err := common.DBInit(dbConfig)
-	if err == nil {
-		db.DB().SetMaxOpenConns(10)
-		log.Println("Migrating")
-		// db.LogMode(true)
-		// Automigrate!
-		db.AutoMigrate(&rds.RDSInstance{}, &redis.RedisInstance{}, &elasticsearch.ElasticsearchInstance{}, &base.Instance{}) // Add all your models here to help setup the database tables
-		log.Println("Migrated")
+	if err != nil {
+		panic(err)
 	}
+	db.DB().SetMaxOpenConns(10)
+	log.Println("Migrating")
+	// db.LogMode(true)
+	// Automigrate!
+	db.AutoMigrate(&rds.RDSInstance{}, &redis.RedisInstance{}, &elasticsearch.ElasticsearchInstance{}, &base.Instance{}) // Add all your models here to help setup the database tables
+	log.Println("Migrated")
 	return db, err
 }

--- a/db/db.go
+++ b/db/db.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+const maxDbConnections = 10
+
 // InternalDBInit initializes the internal database connection that the service broker will use.
 // In addition to calling DBInit(), it also makes sure that the tables are setup for Instance and DBConfig structs.
 func InternalDBInit(dbConfig *common.DBConfig) (*gorm.DB, error) {
@@ -18,7 +20,7 @@ func InternalDBInit(dbConfig *common.DBConfig) (*gorm.DB, error) {
 	if err != nil {
 		panic(err)
 	}
-	db.DB().SetMaxOpenConns(10)
+	db.DB().SetMaxOpenConns(maxDbConnections)
 	log.Println("Migrating")
 	// db.LogMode(true)
 	// Automigrate!

--- a/helpers/crypto.go
+++ b/helpers/crypto.go
@@ -10,22 +10,17 @@ import (
 
 // RandStr will generate a random alphanumeric string of the specified length.
 func RandStr(strSize int) string {
-
-	var dictionary string
-	dictionary = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	dictionary := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	return StringWithCharset(strSize, dictionary)
 }
 
 // RandStrNoCaps will generate a random alphanumeric string of the specified length.
 func RandStrNoCaps(strSize int) string {
-
-	var dictionary string
-	dictionary = "abcdefghijklmnopqrstuvwxyz0123456789"
+	dictionary := "abcdefghijklmnopqrstuvwxyz0123456789"
 	return StringWithCharset(strSize, dictionary)
 }
 
 func StringWithCharset(length int, charset string) string {
-
 	b := make([]byte, length)
 	charsetLen := big.NewInt(int64(len(charset)))
 

--- a/helpers/crypto_test.go
+++ b/helpers/crypto_test.go
@@ -81,7 +81,7 @@ func TestRandStringDistribution(t *testing.T) {
 	dict := make(map[string]int)
 	for i := 0; i < 1000000; i++ {
 		randstring := RandStr(1)
-		dict[randstring] = dict[randstring] + 1
+		dict[randstring]++
 	}
 	fmt.Println(dict)
 	min := 1000000

--- a/main_test.go
+++ b/main_test.go
@@ -567,7 +567,7 @@ func TestRDSBindInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	type credentials struct {
-		Uri      string
+		URI      string
 		Username string
 		Password string
 		Host     string
@@ -583,7 +583,7 @@ func TestRDSBindInstance(t *testing.T) {
 	json.Unmarshal(res.Body.Bytes(), &r)
 
 	// Does it contain "uri"
-	if r.Credentials.Uri == "" {
+	if r.Credentials.URI == "" {
 		t.Error(url, "should return credentials")
 	}
 
@@ -795,7 +795,7 @@ func TestRedisBindInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	type credentials struct {
-		Uri      string
+		URI      string
 		Username string
 		Password string
 		Host     string
@@ -811,7 +811,7 @@ func TestRedisBindInstance(t *testing.T) {
 	json.Unmarshal(res.Body.Bytes(), &r)
 
 	// Does it contain "uri"
-	if r.Credentials.Uri == "" {
+	if r.Credentials.URI == "" {
 		t.Error(url, "should return credentials")
 	}
 
@@ -1126,7 +1126,7 @@ func TestElasticsearchBindInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	type credentials struct {
-		Uri      string
+		URI      string
 		Username string
 		Password string
 		Host     string
@@ -1142,7 +1142,7 @@ func TestElasticsearchBindInstance(t *testing.T) {
 	json.Unmarshal(res.Body.Bytes(), &r)
 
 	// Does it contain "uri"
-	if r.Credentials.Uri == "" {
+	if r.Credentials.URI == "" {
 		t.Error(url, "should return credentials")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -23,14 +23,10 @@ import (
 )
 
 var (
-	originalRDSPlanID                = "da91e15c-98c9-46a9-b114-02b8d28062c6"
-	originalRDSMySQLPlanID           = "da91e15c-98c9-46a9-b114-02b8d28062c7"
-	updateableRDSPlanID              = "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
-	nonUpdateableRDSPlan             = "ee75aef3-7697-4906-9330-fb1f83d719be"
-	originalRedisPlanID              = "475e36bf-387f-44c1-9b81-575fec2ee443"
-	nonUpdateableRedisPlanID         = "5nd336bf-0k7f-44c1-9b81-575fp3k764r6"
-	originalElasticsearchPlanID      = "55b529cf-639e-4673-94fd-ad0a5dafe0ad"
-	nonUpdateableElasticsearchPlanID = "162ffae8-9cf8-4806-80e5-a7f92d514198"
+	originalRDSPlanID           = "da91e15c-98c9-46a9-b114-02b8d28062c6"
+	updateableRDSPlanID         = "1070028c-b5fb-4de8-989b-4e00d07ef5e8"
+	originalRedisPlanID         = "475e36bf-387f-44c1-9b81-575fec2ee443"
+	originalElasticsearchPlanID = "55b529cf-639e-4673-94fd-ad0a5dafe0ad"
 )
 
 // micro-psql plan
@@ -38,28 +34,6 @@ var createRDSInstanceReq = []byte(
 	`{
 	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
 	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
-	"organization_guid":"an-org",
-	"space_guid":"a-space"
-}`)
-
-var createRDSMySQLInstanceReq = []byte(
-	`{
-	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
-	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c7",
-	"parameters": {
-		"version": "5.7"
-	},
-	"organization_guid":"an-org",
-	"space_guid":"a-space"
-}`)
-
-var createRDSLatestMySQLInstanceReq = []byte(
-	`{
-	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
-	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c7",
-	"parameters": {
-		"version": "8.0"
-	},
 	"organization_guid":"an-org",
 	"space_guid":"a-space"
 }`)

--- a/main_test.go
+++ b/main_test.go
@@ -257,7 +257,7 @@ func TestCreateRDSInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 	// Is it in the database and has a username and password?
@@ -297,7 +297,7 @@ func TestCreateRDSPGWithVersionInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 	// Is it in the database and has a username and password?
@@ -337,7 +337,7 @@ func TestCreateRDSPGWithInvaildVersionInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it contain "...because the service plan does not allow updates or modification."?
-	if !strings.Contains(string(res.Body.Bytes()), "is not a supported major version; major version must be one of:") {
+	if !strings.Contains(res.Body.String(), "is not a supported major version; major version must be one of:") {
 		t.Error(urlAcceptsIncomplete, "should return a message that the version is invaild")
 	}
 }
@@ -385,7 +385,7 @@ func TestModifyRDSInstance(t *testing.T) {
 	validJSON(resp.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(resp.Body.Bytes()), "accepted") {
+	if !strings.Contains(resp.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 
@@ -441,7 +441,7 @@ func TestModifyRDSInstanceNotAllowed(t *testing.T) {
 	validJSON(resp.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it contain "...because the service plan does not allow updates or modification."?
-	if !strings.Contains(string(resp.Body.Bytes()), "because the service plan does not allow updates or modification.") {
+	if !strings.Contains(resp.Body.String(), "because the service plan does not allow updates or modification.") {
 		t.Error(urlAcceptsIncomplete, "should return a message that the plan cannot be chosen")
 	}
 
@@ -501,7 +501,7 @@ func TestModifyRDSInstanceSizeIncrease(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 	// Is it in the database and does it have correct storage?
@@ -608,7 +608,7 @@ func TestRDSUnbind(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	// Is it an empty object?
-	if string(res.Body.Bytes()) != "{}" {
+	if res.Body.String() != "{}" {
 		t.Error(url, "should return an empty JSON")
 	}
 }
@@ -670,7 +670,7 @@ func TestCreateRedisInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 	// Is it in the database and has a username and password?
@@ -732,7 +732,7 @@ func TestModifyRedisInstance(t *testing.T) {
 	validJSON(resp.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it contain "Updating Redis service instances is not supported at this time"?
-	if !strings.Contains(string(resp.Body.Bytes()), "Updating Redis service instances is not supported at this time") {
+	if !strings.Contains(resp.Body.String(), "Updating Redis service instances is not supported at this time") {
 		t.Error(urlAcceptsIncomplete, "should return a message that Redis services cannot be modified at this time")
 	}
 
@@ -836,7 +836,7 @@ func TestRedisUnbind(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	// Is it an empty object?
-	if string(res.Body.Bytes()) != "{}" {
+	if res.Body.String() != "{}" {
 		t.Error(url, "should return an empty JSON")
 	}
 }
@@ -898,7 +898,7 @@ func TestCreateElasticsearchInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
 	}
 	// Is it in the database and has a username and password?
@@ -936,7 +936,7 @@ func TestCreateElasticsearchInstance(t *testing.T) {
 	validJSON(res.Body.Bytes(), urlAcceptsIncompleteAdv, t)
 
 	// Does it say "accepted"?
-	if !strings.Contains(string(res.Body.Bytes()), "accepted") {
+	if !strings.Contains(res.Body.String(), "accepted") {
 		t.Error(urlAcceptsIncompleteAdv, "should return the instance accepted message")
 	}
 	// Is it in the database and has a username and password?
@@ -1063,7 +1063,7 @@ func TestModifyElasticsearchInstancePlan(t *testing.T) {
 	validJSON(resp.Body.Bytes(), urlAcceptsIncomplete, t)
 
 	// Does it contain "Updating Redis service instances is not supported at this time"?
-	if !strings.Contains(string(resp.Body.Bytes()), "Updating Elasticsearch service instances is not supported at this time") {
+	if !strings.Contains(resp.Body.String(), "Updating Elasticsearch service instances is not supported at this time") {
 		t.Error(urlAcceptsIncomplete, "should return a message that Elasticsearch services cannot be modified at this time")
 	}
 
@@ -1167,7 +1167,7 @@ func TestElasticsearchUnbind(t *testing.T) {
 	validJSON(res.Body.Bytes(), url, t)
 
 	// Is it an empty object?
-	if string(res.Body.Bytes()) != "{}" {
+	if res.Body.String() != "{}" {
 		t.Error(url, "should return an empty JSON")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -487,7 +487,7 @@ func TestModifyRDSInstanceSizeIncrease(t *testing.T) {
 		t.Error(urlUnacceptsIncomplete, "with auth should return 422 and it returned", resp.Code)
 	}
 
-	//Pull in AllocatedStorage and increase the storage
+	// Pull in AllocatedStorage and increase the storage
 	urlAcceptsIncomplete := "/v2/service_instances/the_RDS_instance?accepts_incomplete=true"
 	resp, _ = doRequest(m, urlAcceptsIncomplete, "PATCH", true, bytes.NewBuffer(modifyRDSInstanceReqStorage))
 
@@ -496,7 +496,7 @@ func TestModifyRDSInstanceSizeIncrease(t *testing.T) {
 		t.Error(urlAcceptsIncomplete, "with auth should return 202 and it returned", resp.Code)
 	}
 
-	//Check to make sure storage size actually increased
+	// Check to make sure storage size actually increased
 	// Is it a valid JSON?
 	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -253,7 +253,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		}
 		resp1, err := svc.AddTags(paramsTags)
 		fmt.Println(awsutil.StringValue(resp1))
-		if d.didAwsCallSucceed(err) == false {
+		if !d.didAwsCallSucceed(err) {
 			return base.InstanceNotCreated, nil
 		}
 		return base.InstanceInProgress, nil
@@ -316,7 +316,7 @@ func (d *dedicatedElasticsearchAdapter) bindElasticsearchToApp(i *ElasticsearchI
 		// Pretty-print the response data.
 		fmt.Println(awsutil.StringValue(resp))
 
-		if resp.DomainStatus.Created != nil && *(resp.DomainStatus.Created) == true {
+		if resp.DomainStatus.Created != nil && *(resp.DomainStatus.Created) {
 			if resp.DomainStatus.Endpoints != nil && resp.DomainStatus.ARN != nil {
 				fmt.Printf("endpoint: %s ARN: %s \n", *(resp.DomainStatus.Endpoints["vpc"]), *(resp.DomainStatus.ARN))
 				i.Host = *(resp.DomainStatus.Endpoints["vpc"])
@@ -569,7 +569,7 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 		// Pretty-print the response data.
 		fmt.Println(awsutil.StringValue(resp))
 
-		if resp.DomainStatus.Created != nil && *(resp.DomainStatus.Created) == true {
+		if resp.DomainStatus.Created != nil && *(resp.DomainStatus.Created) {
 			switch *(resp.DomainStatus.Processing) {
 			case false:
 				return base.InstanceReady, nil

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -92,7 +92,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 	user := awsiam.NewIAMUser(iamsvc, logger)
 	stssvc := sts.New(session.New(), aws.NewConfig().WithRegion(d.settings.Region))
 
-	//IAM User and policy before domain starts creating so it can be used to create access control policy
+	// IAM User and policy before domain starts creating so it can be used to create access control policy
 	_, err := user.Create(i.Domain, "")
 	if err != nil {
 		fmt.Println(err.Error())
@@ -211,7 +211,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		})
 	}
 
-	//Standard Parameters
+	// Standard Parameters
 	params := &elasticsearchservice.CreateElasticsearchDomainInput{
 		DomainName:                  aws.String(i.Domain),
 		ElasticsearchVersion:        aws.String(i.ElasticsearchVersion),
@@ -272,7 +272,7 @@ func (d *dedicatedElasticsearchAdapter) modifyElasticsearch(i *ElasticsearchInst
 	if i.IndicesQueryBoolMaxClauseCount != "" {
 		AdvancedOptions["indices.query.bool.max_clause_count"] = &i.IndicesQueryBoolMaxClauseCount
 	}
-	//Standard Parameters
+	// Standard Parameters
 	params := &elasticsearchservice.UpdateElasticsearchDomainConfigInput{
 		DomainName:      aws.String(i.Domain),
 		AdvancedOptions: AdvancedOptions,

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -133,8 +133,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 	time.Sleep(5 * time.Second)
 
 	for k, v := range i.Tags {
-		var tag elasticsearchservice.Tag
-		tag = elasticsearchservice.Tag{
+		tag := elasticsearchservice.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -362,7 +362,7 @@ func (d *dedicatedElasticsearchAdapter) bindElasticsearchToApp(i *ElasticsearchI
 			i.SnapshotARN = *(resp.Role.Arn)
 			fmt.Println(i.getCredentials(password))
 		}
-		//Policy to for ES to passRole
+		// Policy to for ES to passRole
 		s3Policy := `{"Version": "2012-10-17","Statement": [{"Action": ["s3:ListBucket"],"Effect": "Allow","Resource": ["arn:aws-us-gov:s3:::` + i.Bucket + `"]},{"Action": ["s3:GetObject","s3:PutObject","s3:DeleteObject"],"Effect": "Allow","Resource": ["arn:aws-us-gov:s3:::` + i.Bucket + `/*"]}]}`
 		rolePolicyInput := &iam.CreatePolicyInput{
 			PolicyName:     aws.String(i.Domain + "-to-S3-RolePolicy"),

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -281,9 +281,8 @@ func (d *dedicatedElasticsearchAdapter) modifyElasticsearch(i *ElasticsearchInst
 	fmt.Println(awsutil.StringValue(resp))
 	if d.didAwsCallSucceed(err) {
 		return base.InstanceInProgress, nil
-	} else {
-		return base.InstanceNotModified, err
 	}
+	return base.InstanceNotModified, err
 }
 
 func (d *dedicatedElasticsearchAdapter) bindElasticsearchToApp(i *ElasticsearchInstance, password string) (map[string]string, error) {

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -235,7 +235,7 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 	}
 
 	// Don't allow updating to a service plan that doesn't support updates.
-	if newPlan.PlanUpdateable == false {
+	if !newPlan.PlanUpdateable {
 		return response.NewErrorResponse(
 			http.StatusBadRequest,
 			"Cannot switch to "+newPlan.Name+" because the service plan does not allow updates or modification.",

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -227,8 +227,7 @@ func (d *dedicatedDBAdapter) createDB(i *RDSInstance, password string) (base.Ins
 	var rdsTags []*rds.Tag
 
 	for k, v := range i.Tags {
-		var tag rds.Tag
-		tag = rds.Tag{
+		tag := rds.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -494,7 +493,7 @@ func (d *dedicatedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error
 		DBInstanceIdentifier: aws.String(i.Database), // Required
 		// FinalDBSnapshotIdentifier: aws.String("String"),
 		DeleteAutomatedBackups: aws.Bool(false),
-		SkipFinalSnapshot: aws.Bool(true),
+		SkipFinalSnapshot:      aws.Bool(true),
 	}
 	resp, err := svc.DeleteDBInstance(params)
 	// Pretty-print the response data.

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -468,14 +468,12 @@ func cleanupCustomParameterGroups(svc *rds.RDS) {
 					_, err := svc.DeleteDBParameterGroup(deleteinput)
 					if err == nil {
 						log.Printf("cleaned up %s parameter group", *pgroup.DBParameterGroupName)
-					} else {
+					} else if err.(awserr.Error).Code() != "InvalidDBParameterGroupState" {
 						// If you can't delete it because it's in use, that is fine.
 						// The db takes a while to delete, so we will clean it up the
 						// next time this is called.  Otherwise there is some sort of AWS error
 						// and we should log that.
-						if err.(awserr.Error).Code() != "InvalidDBParameterGroupState" {
-							log.Printf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err.Error())
-						}
+						log.Printf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err.Error())
 					}
 				}
 			}

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -93,8 +93,7 @@ func (d *dedicatedRedisAdapter) createRedis(i *RedisInstance, password string) (
 	var redisTags []*elasticache.Tag
 
 	for k, v := range i.Tags {
-		var tag elasticache.Tag
-		tag = elasticache.Tag{
+		tag := elasticache.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}


### PR DESCRIPTION
- Remove dead code in test files
- Refactor error checking logic to be idiomatic go
- Move magic number into const maxDbConnections
- Add error checking to os.Getwd calls
- Use String() method instead of string(bytes)
- Omit comparisons with boolean constants
- Merge variable declarations and assignments (S1021)
- Correct capitalization of struct field Uri to URI
- Correct comment spacing
- Simplify condition logic
- Correct comment formatting
- Remove superfluous else statement
- Simplify dict value increment operation

What I have changed here is a lot of the "low-hanging fruit" from initial linting. There are many, **many** more suggestions found including lots of unchecked errors, unused code, magic numbers, single-case switch statements, deprecated function usage, etc. I was able to find these using the golangci_lint tool within my editor, but there is a GitHub action for the linter here: https://github.com/golangci/golangci-lint-action.