### PR TITLE
Fixes the provisioning of new database instances

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -52,8 +52,11 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.micro
       allocatedStorage: 10
-      minVersion: "10"
-      maxVersion: "12"
+      approvedMajorVersions:
+        - "10"
+        - "11"
+        - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -86,6 +89,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -118,6 +122,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -150,6 +155,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -182,6 +188,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -214,6 +221,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -246,6 +254,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -278,6 +287,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -310,6 +320,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -342,6 +353,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -375,6 +387,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -407,6 +420,7 @@ rds:
         - "10"
         - "11"
         - "12"
+      dbVersion: "12"
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -460,6 +474,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -522,6 +537,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -553,6 +569,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -584,6 +601,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -615,6 +633,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -646,6 +665,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -677,6 +697,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -708,6 +729,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -739,6 +761,7 @@ rds:
       approvedMajorVersions:
         - "5.7"
         - "8.0"
+      dbVersion: "8.0"
       dbType: mysql
       plan_updateable: true
       redundant: true


### PR DESCRIPTION
AWS recently changed the instance class offerings depending on the version of database you selected, and in the case of PostgreSQL the default is now version 13 as well.  Until we build in more support and update our plans, we need to make sure customers can provision the databases that we do currently support.  This changeset ensures that a default version is provided so that the instance class offerings are still valid.

Partially resolves https://github.com/cloud-gov/aws-broker/issues/197

## Changes proposed in this pull request:
- Adds the `dbVersion` parameter to our catalog and specifies default versions for all RDS plans
- Fixes the parameters for the `micro-psql` plan

## Security considerations
- None; ensures customers can still provision databases successfully without having to specify a version