### PR TITLE
of course it runs twice...

### DIFF
--- a/ci/run-smoke-test-es-advanced-options.sh
+++ b/ci/run-smoke-test-es-advanced-options.sh
@@ -83,7 +83,7 @@ done
 cf restage $TEST_APP
 
 # Run task
-cf run-task $TEST_APP "python run.py -s $TEST_SERVICE"
+cf run-task $TEST_APP "python run.py -s $TEST_SERVICE -r $REGION"
 
 # Get finished task state with app guid
 test_app_guid=$(cf curl "/v3/apps?names=$TEST_APP" | jq -r ".resources[0].guid")


### PR DESCRIPTION
need to pass region into smoke test script

## Changes proposed in this pull request:

- pick up missed call to run-task
- 
- 

## Security considerations
None