### PR TITLE
Make services shareable between spaces

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -13,6 +13,7 @@ rds:
     providerDisplayName: RDS
     documentationUrl: "https://cloud.gov/docs/services/relational-database/"
     supportUrl:
+    shareable: true
   plans:
     - id: "1bbd9c4f-adb8-43dc-bbec-ab0315bcb14e"
       name: "shared-psql"
@@ -848,6 +849,7 @@ redis:
     providerDisplayName: AWS Elasticache Redis
     documentationUrl: "https://cloud.gov/docs/services/aws-elasticache/"
     supportUrl:
+    shareable: true
   plans:
     - id: "475e36bf-387f-44c1-9b81-575fec2ee443"
       name: "redis-dev"
@@ -1015,6 +1017,7 @@ elasticsearch:
     providerDisplayName: aws-elasticsearch
     documentationUrl: "https://cloud.gov/docs/services/aws-elasticsearch/"
     supportUrl:
+    shareable: true
   plans:
   - id: "20567994-6028-4629-9761-92ebd3fc330f"
     name: "es-dev-6.8-migration"


### PR DESCRIPTION
(Similar to https://github.com/cloudfoundry-community/s3-broker/pull/41)

## Changes proposed in this pull request:

- RDS, Elasticache, and Elasticseach service instances can be shared between spaces. This enables running `cf share-service SERVICE -s OTHERSPACE` to make a service instance visible and bindable in that other space.

Here's [the spec documentation](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-service-metadata).

See [related Slack discussion](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1642687796085500?thread_ts=1642618412.072300&cid=C09CR1Q9Z).

## Security considerations

Nothing changes about the configuration and security of the provisioned service itself. Services can only be shared between spaces where the sharing user already has SpaceDeveloper privileges, and they themselves are best suited to understand the security implications of sharing, not the platform. This change only configures the CF platform to make the`share-service` command available.