### PR TITLE
add 'shareable' to service metadata.

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -23,6 +23,7 @@ type ServiceMetadata struct {
 	ProviderDisplayName string `yaml:"providerDisplayName" json:"providerDisplayName"`
 	DocumentationURL    string `yaml:"documentationUrl" json:"documentationUrl"`
 	SupportURL          string `yaml:"supportUrl" json:"supportUrl"`
+	Shareable           bool   `yaml:"shareable" json:"shareable"`
 }
 
 // PlanCost contains an array-of-objects that describes the costs of a service,


### PR DESCRIPTION
## Changes proposed in this pull request:

- add the 'sharable' key to ServiceMetadata struct, marshalled from the catalog-template.yml
- this enables CloudController to verify if a service is shareable between spaces. 
- fixes the broker to support the change in this [commit](https://github.com/cloud-gov/aws-broker/commit/aacb74a7a0500f81753a462b6cea5b54a5389e68#diff-038351ea0dcac1fa6464b907fd0f8c005b5ba0cb6aa0ed7869e8545440a2a1f3)

## Security considerations
None
