### PR TITLE
remove minor versioning in shared and brokerdb

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 12.7
+      TF_VAR_rds_internal_db_engine_version: 12
       TF_VAR_rds_internal_db_parameter_group_family: postgres12
       TF_VAR_rds_internal_multi_az: false
       TF_VAR_rds_internal_username: ((development-rds-internal-username))
@@ -58,7 +58,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((development-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 12.7
+      TF_VAR_rds_shared_postgres_db_engine_version: 12
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
       TF_VAR_rds_shared_postgres_multi_az: false
       TF_VAR_rds_shared_postgres_username: ((development-rds-shared-postgres-username))
@@ -389,7 +389,7 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 12.7
+      TF_VAR_rds_internal_db_engine_version: 12
       TF_VAR_rds_internal_db_parameter_group_family: postgres12
       TF_VAR_rds_internal_multi_az: false
       TF_VAR_rds_internal_username: ((staging-rds-internal-username))
@@ -413,7 +413,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((staging-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 12.7
+      TF_VAR_rds_shared_postgres_db_engine_version: 12
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
       TF_VAR_rds_shared_postgres_multi_az: false
       TF_VAR_rds_shared_postgres_username: ((staging-rds-shared-postgres-username))
@@ -744,7 +744,7 @@ jobs:
       TF_VAR_rds_internal_db_size: 10
       TF_VAR_rds_internal_db_name: ((prod-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
-      TF_VAR_rds_internal_db_engine_version: 12.7 
+      TF_VAR_rds_internal_db_engine_version: 12
       TF_VAR_rds_internal_db_parameter_group_family: postgres12
       TF_VAR_rds_internal_multi_az: true
       TF_VAR_rds_internal_username: ((prod-rds-internal-username))
@@ -768,7 +768,7 @@ jobs:
       TF_VAR_rds_shared_postgres_db_size: 100
       TF_VAR_rds_shared_postgres_db_name: ((prod-rds-shared-postgres-db-name))
       TF_VAR_rds_shared_postgres_db_engine: postgres
-      TF_VAR_rds_shared_postgres_db_engine_version: 12.7
+      TF_VAR_rds_shared_postgres_db_engine_version: 12
       TF_VAR_rds_shared_postgres_db_parameter_group_family: postgres12
       TF_VAR_rds_shared_postgres_multi_az: true
       TF_VAR_rds_shared_postgres_username: ((prod-rds-shared-postgres-username))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Changing Broker internal pgsql db and shared db to major versions. 
- AWS auto upgrading minor versions is breaking TF in the pipeline. 
- 

## Security considerations
None
