### PR TITLE
Disable shared db

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -211,17 +211,6 @@ jobs:
           SERVICE_PLAN: micro-psql
           DB_TYPE: postgres
 
-      # - task: smoke-tests-shared-postgres
-      #   file: aws-broker-app/ci/run-smoke-tests.yml
-      #   params:
-      #     CF_API_URL: ((development-cf-api-url))
-      #     CF_USERNAME: ((development-cf-deploy-username))
-      #     CF_PASSWORD: ((development-cf-deploy-password))
-      #     CF_ORGANIZATION: ((development-cf-organization))
-      #     CF_SPACE: ((development-cf-space))
-      #     SERVICE_PLAN: shared-psql
-      #     DB_TYPE: postgres
-
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
@@ -267,17 +256,6 @@ jobs:
           CF_SPACE: ((development-cf-space))
           SERVICE_PLAN: small-mysql
           DB_TYPE: mysql
-
-      # - task: smoke-tests-shared-mysql
-      #   file: aws-broker-app/ci/run-smoke-tests.yml
-      #   params:
-      #     CF_API_URL: ((development-cf-api-url))
-      #     CF_USERNAME: ((development-cf-deploy-username))
-      #     CF_PASSWORD: ((development-cf-deploy-password))
-      #     CF_ORGANIZATION: ((development-cf-organization))
-      #     CF_SPACE: ((development-cf-space))
-      #     SERVICE_PLAN: shared-mysql
-      #     DB_TYPE: mysql
 
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
@@ -494,7 +472,7 @@ jobs:
       BROKER_NAME: ((staging-broker-name))
       AUTH_USER: ((staging-auth-user))
       AUTH_PASS: ((staging-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
+      SERVICES: aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -566,17 +544,6 @@ jobs:
           NEW_SERVICE_PLAN: small-psql
           DB_TYPE: postgres
 
-      - task: smoke-tests-shared-postgres
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((staging-cf-api-url))
-          CF_USERNAME: ((staging-cf-deploy-username))
-          CF_PASSWORD: ((staging-cf-deploy-password))
-          CF_ORGANIZATION: ((staging-cf-organization))
-          CF_SPACE: ((staging-cf-space))
-          SERVICE_PLAN: shared-psql
-          DB_TYPE: postgres
-
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
@@ -621,17 +588,6 @@ jobs:
           CF_SPACE: ((staging-cf-space))
           SERVICE_PLAN: small-mysql
           NEW_SERVICE_PLAN: medium-mysql
-          DB_TYPE: mysql
-
-      - task: smoke-tests-shared-mysql
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((staging-cf-api-url))
-          CF_USERNAME: ((staging-cf-deploy-username))
-          CF_PASSWORD: ((staging-cf-deploy-password))
-          CF_ORGANIZATION: ((staging-cf-organization))
-          CF_SPACE: ((staging-cf-space))
-          SERVICE_PLAN: shared-mysql
           DB_TYPE: mysql
 
       - task: smoke-tests-oracle
@@ -876,7 +832,7 @@ jobs:
       BROKER_NAME: ((prod-broker-name))
       AUTH_USER: ((prod-auth-user))
       AUTH_PASS: ((prod-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
+      SERVICES: aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -947,17 +903,6 @@ jobs:
           NEW_SERVICE_PLAN: small-psql
           DB_TYPE: postgres
 
-      - task: smoke-tests-shared-postgres
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((prod-cf-api-url))
-          CF_USERNAME: ((prod-cf-deploy-username))
-          CF_PASSWORD: ((prod-cf-deploy-password))
-          CF_ORGANIZATION: ((prod-cf-organization))
-          CF_SPACE: ((prod-cf-space))
-          SERVICE_PLAN: shared-psql
-          DB_TYPE: postgres
-
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
@@ -1002,17 +947,6 @@ jobs:
           CF_SPACE: ((prod-cf-space))
           SERVICE_PLAN: small-mysql
           NEW_SERVICE_PLAN: medium-mysql
-          DB_TYPE: mysql
-
-      - task: smoke-tests-shared-mysql
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((prod-cf-api-url))
-          CF_USERNAME: ((prod-cf-deploy-username))
-          CF_PASSWORD: ((prod-cf-deploy-password))
-          CF_ORGANIZATION: ((prod-cf-organization))
-          CF_SPACE: ((prod-cf-space))
-          SERVICE_PLAN: shared-mysql
           DB_TYPE: mysql
 
       - task: smoke-tests-oracle

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -139,7 +139,7 @@ jobs:
       BROKER_NAME: ((development-broker-name))
       AUTH_USER: ((development-auth-user))
       AUTH_PASS: ((development-auth-pass))
-      SERVICES: aws-rds:shared-psql aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:shared-mysql aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
+      SERVICES: aws-rds:micro-psql aws-rds:medium-psql aws-rds:medium-psql-redundant aws-rds:large-gp-psql aws-rds:large-gp-psql-redundant aws-rds:xlarge-gp-psql aws-rds:xlarge-gp-psql-redundant aws-rds:small-mysql aws-rds:medium-mysql aws-rds:medium-gp-mysql-redundant aws-rds:large-gp-mysql aws-rds:large-gp-mysql-redundant aws-rds:xlarge-gp-mysql aws-rds:xlarge-gp-mysql-redundant aws-rds:medium-mysql-redundant aws-rds:micro-psql-redundant aws-rds:small-mysql-redundant aws-rds:small-psql aws-rds:small-psql-redundant aws-rds:medium-oracle-se2 aws-elasticache-redis:redis-dev aws-elasticache-redis:redis-3node aws-elasticache-redis:redis-5node aws-elasticache-redis:redis-3node-large aws-elasticache-redis:redis-5node-large aws-elasticsearch:es-dev aws-elasticsearch:es-medium aws-elasticsearch:es-medium-ha aws-elasticsearch:es-large aws-elasticsearch:es-large-ha aws-elasticsearch:es-xlarge aws-elasticsearch:es-xlarge-ha
 
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
@@ -211,16 +211,16 @@ jobs:
           SERVICE_PLAN: micro-psql
           DB_TYPE: postgres
 
-      - task: smoke-tests-shared-postgres
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((development-cf-api-url))
-          CF_USERNAME: ((development-cf-deploy-username))
-          CF_PASSWORD: ((development-cf-deploy-password))
-          CF_ORGANIZATION: ((development-cf-organization))
-          CF_SPACE: ((development-cf-space))
-          SERVICE_PLAN: shared-psql
-          DB_TYPE: postgres
+      # - task: smoke-tests-shared-postgres
+      #   file: aws-broker-app/ci/run-smoke-tests.yml
+      #   params:
+      #     CF_API_URL: ((development-cf-api-url))
+      #     CF_USERNAME: ((development-cf-deploy-username))
+      #     CF_PASSWORD: ((development-cf-deploy-password))
+      #     CF_ORGANIZATION: ((development-cf-organization))
+      #     CF_SPACE: ((development-cf-space))
+      #     SERVICE_PLAN: shared-psql
+      #     DB_TYPE: postgres
 
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
@@ -268,16 +268,16 @@ jobs:
           SERVICE_PLAN: small-mysql
           DB_TYPE: mysql
 
-      - task: smoke-tests-shared-mysql
-        file: aws-broker-app/ci/run-smoke-tests.yml
-        params:
-          CF_API_URL: ((development-cf-api-url))
-          CF_USERNAME: ((development-cf-deploy-username))
-          CF_PASSWORD: ((development-cf-deploy-password))
-          CF_ORGANIZATION: ((development-cf-organization))
-          CF_SPACE: ((development-cf-space))
-          SERVICE_PLAN: shared-mysql
-          DB_TYPE: mysql
+      # - task: smoke-tests-shared-mysql
+      #   file: aws-broker-app/ci/run-smoke-tests.yml
+      #   params:
+      #     CF_API_URL: ((development-cf-api-url))
+      #     CF_USERNAME: ((development-cf-deploy-username))
+      #     CF_PASSWORD: ((development-cf-deploy-password))
+      #     CF_ORGANIZATION: ((development-cf-organization))
+      #     CF_SPACE: ((development-cf-space))
+      #     SERVICE_PLAN: shared-mysql
+      #     DB_TYPE: mysql
 
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- This removes the `shared-psql` and `shared-mysql` plans from the marketplaces in each env
- This does not affect existing instances on those plans, as it leaves them in the catalog and broker. 
- Once we reach full deprecation date 08-31-2022 we can remove the plans from catalog and code from broker. 

## Security considerations

None
