### PR TITLE
Update CI pipeline + scripts to specify broker name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -168,6 +168,7 @@ jobs:
       - task: smoke-tests-postgres
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -179,6 +180,7 @@ jobs:
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -191,6 +193,7 @@ jobs:
       - task: smoke-tests-postgres-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -203,6 +206,7 @@ jobs:
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -214,6 +218,7 @@ jobs:
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -225,6 +230,7 @@ jobs:
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -237,6 +243,7 @@ jobs:
       - task: smoke-tests-mysql-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -249,6 +256,7 @@ jobs:
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -260,6 +268,7 @@ jobs:
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -271,6 +280,7 @@ jobs:
       - task: smoke-tests-redis
         file: aws-broker-app/ci/run-smoke-test-task.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -283,6 +293,7 @@ jobs:
       - task: smoke-tests-unbound-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-unbound.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -295,6 +306,7 @@ jobs:
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))
@@ -307,6 +319,7 @@ jobs:
       - task: smoke-tests-elasticsearch-advanced-options
         file: aws-broker-app/ci/run-smoke-test-es-advanced-options.yml
         params:
+          BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
           CF_USERNAME: ((development-cf-deploy-username))
           CF_PASSWORD: ((development-cf-deploy-password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -545,6 +545,7 @@ jobs:
       - task: smoke-tests-postgres
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -556,6 +557,7 @@ jobs:
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -568,6 +570,7 @@ jobs:
       - task: smoke-tests-postgres-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -580,6 +583,7 @@ jobs:
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -592,6 +596,7 @@ jobs:
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -603,6 +608,7 @@ jobs:
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -614,6 +620,7 @@ jobs:
       - task: smoke-tests-mysql-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -626,6 +633,7 @@ jobs:
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -638,6 +646,7 @@ jobs:
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -649,6 +658,7 @@ jobs:
       - task: smoke-tests-redis
         file: aws-broker-app/ci/run-smoke-test-task.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -661,6 +671,7 @@ jobs:
       - task: smoke-tests-unbound-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-unbound.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -673,6 +684,7 @@ jobs:
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))
@@ -685,6 +697,7 @@ jobs:
       - task: smoke-tests-elasticsearch-advanced-options
         file: aws-broker-app/ci/run-smoke-test-es-advanced-options.yml
         params:
+          BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
           CF_USERNAME: ((staging-cf-deploy-username))
           CF_PASSWORD: ((staging-cf-deploy-password))

--- a/ci/run-smoke-test-es-advanced-options.sh
+++ b/ci/run-smoke-test-es-advanced-options.sh
@@ -66,7 +66,7 @@ pushd $TASK_DIRECTORY
 cf push $TEST_APP -f manifest.yml
 
 # Create service
-cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE -c '{"advanced_options": {"indices.fielddata.cache.size": "21", "indices.query.bool.max_clause_count": "1025"}}'
+cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE -b "$BROKER_NAME" -c '{"advanced_options": {"indices.fielddata.cache.size": "21", "indices.query.bool.max_clause_count": "1025"}}'
 
 # Wait for service to be created
 wait_for_service_instance $TEST_SERVICE

--- a/ci/run-smoke-test-task.sh
+++ b/ci/run-smoke-test-task.sh
@@ -66,7 +66,7 @@ pushd $TASK_DIRECTORY
 cf push $TEST_APP -f manifest.yml
 
 # Create service
-cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE
+cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE -b "$BROKER_NAME"
 
 # Wait for service to be created
 wait_for_service_instance $TEST_SERVICE

--- a/ci/run-smoke-test-unbound.sh
+++ b/ci/run-smoke-test-unbound.sh
@@ -40,7 +40,7 @@ cf delete-service -f $TEST_SERVICE
 wait_for_service_instance $TEST_SERVICE
 
 # Create service
-cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE
+cf create-service $SERVICE_NAME $SERVICE_PLAN $TEST_SERVICE -b "$BROKER_NAME"
 
 # Wait for service to be created
 wait_for_service_instance $TEST_SERVICE

--- a/ci/run-smoke-tests-db-updates.sh
+++ b/ci/run-smoke-tests-db-updates.sh
@@ -33,10 +33,10 @@ cf set-env "smoke-tests-db-update-${SERVICE_PLAN}" SERVICE_NAME "rds-smoke-tests
 # Create service
 if echo "$SERVICE_PLAN" | grep -v shared | grep mysql >/dev/null ; then
   # test out the enable_functions stuff, which only works on non-shared mysql databases
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-$SERVICE_PLAN" -c '{"enable_functions": true}'
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-$SERVICE_PLAN" -b "$BROKER_NAME" -c '{"enable_functions": true}'
 else
   # create a regular instance
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-$SERVICE_PLAN"
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-$SERVICE_PLAN" -b "$BROKER_NAME"
 fi
 
 while true; do

--- a/ci/run-smoke-tests-db-version.sh
+++ b/ci/run-smoke-tests-db-version.sh
@@ -32,10 +32,10 @@ cf set-env "smoke-tests-db-version-${SERVICE_PLAN}" SERVICE_NAME "rds-smoke-test
 # Create service
 if echo "$SERVICE_PLAN" | grep -v shared | grep mysql >/dev/null ; then
   # test out the enable_functions stuff, which only works on non-shared mysql databases
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-version-$SERVICE_PLAN" -c '{"enable_functions": true, "version": "'"$DB_VERSION"'"}'
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-version-$SERVICE_PLAN" -b "$BROKER_NAME" -c '{"enable_functions": true, "version": "'"$DB_VERSION"'"}'
 else
   # create a regular instance
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-version-$SERVICE_PLAN" -c '{"version": "'"$DB_VERSION"'"}'
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-version-$SERVICE_PLAN" -b "$BROKER_NAME" -c '{"version": "'"$DB_VERSION"'"}'
 fi
 
 while true; do

--- a/ci/run-smoke-tests-update-storage.sh
+++ b/ci/run-smoke-tests-update-storage.sh
@@ -33,10 +33,10 @@ cf set-env "smoke-tests-db-update-storage-${SERVICE_PLAN}" SERVICE_NAME "rds-smo
 # Create service
 if echo "$SERVICE_PLAN" | grep -v shared | grep mysql >/dev/null ; then
   # test out the enable_functions stuff, which only works on non-shared mysql databases
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-storage-$SERVICE_PLAN" -c '{"enable_functions": true}'
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-storage-$SERVICE_PLAN" -b "$BROKER_NAME" -c '{"enable_functions": true}'
 else
   # create a regular instance
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-storage-$SERVICE_PLAN"
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-db-update-storage-$SERVICE_PLAN" -b "$BROKER_NAME"
 fi
 
 while true; do

--- a/ci/run-smoke-tests.sh
+++ b/ci/run-smoke-tests.sh
@@ -20,10 +20,10 @@ cf set-env "smoke-tests-${SERVICE_PLAN}" SERVICE_NAME "rds-smoke-tests-$SERVICE_
 # Create service
 if echo "$SERVICE_PLAN" | grep -v shared | grep mysql >/dev/null ; then
   # test out the enable_functions stuff, which only works on non-shared mysql databases
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN" -c '{"enable_functions": true}'
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN" -b "$BROKER_NAME" -c '{"enable_functions": true}'
 else
   # create a regular instance
-  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN"
+  cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN" -b "$BROKER_NAME"
 fi
 
 while true; do


### PR DESCRIPTION
## Background

Occasionally we may have the same service provided by multiple brokers, especially in our development environment. We currently have this situation, which was causing our CI scripts to fail since they try to enable the `aws-rds` service without specifying which broker to use.

## Changes proposed in this pull request:

- Update CI pipeline.yml to specify broker for acceptance tests
- Update scripts for acceptance tests to use environment variable to specify broker name

## Security considerations

None
