### PR TITLE
New RDS Plan: 2xlarge-gp-psql(-redundant)

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -434,6 +434,43 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
+    - id: "10d0f179-b121-4f2e-bda7-847f433ad9bd"
+      name: &2xlarge-gp-psql-name "2xlarge-gp-psql"
+      description: "Single-AZ RDS instance of PostgreSQL, minimum 4 cores, minimum 32 GiB memory"
+      metadata:
+        bullets:
+          - *single-az-rds
+          - *default-postgresql-v12
+          - &minimum-4-cores "minimum 4 cores"
+          - &minimum-32-gib-memory "minimum 32 GiB memory"
+          - *default-10-gb-storage
+        costs:
+          -
+            amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: *2xlarge-gp-psql-name
+      free: false
+      adapter: dedicated
+      instanceClass: db.m5.2xlarge
+      allocatedStorage: 10
+      approvedMajorVersions:
+        - "10"
+        - "11"
+        - "12"
+      dbVersion: "12"
+      dbType: postgres
+      plan_updateable: true
+      redundant: false
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
     - id: "3732a60e-f2a0-4112-9b64-87dd0cf10e78"
       name: &xlarge-gp-psql-redundant-name "xlarge-gp-psql-redundant"
       description: "Multi-AZ RDS instance of PostgreSQL, minimum 2 cores, minimum 16 GiB memory"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -434,6 +434,42 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
+    - id: "3732a60e-f2a0-4112-9b64-87dd0cf10e78"
+      name: &xlarge-gp-psql-redundant-name "xlarge-gp-psql-redundant"
+      description: "Multi-AZ RDS instance of PostgreSQL, minimum 2 cores, minimum 16 GiB memory"
+      metadata:
+        bullets:
+          - *multi-az-rds
+          - *default-postgresql-v12
+          - *minimum-2-cores
+          - *minimum-16-gib-memory
+          - *default-10-gb-storage
+        costs:
+          - amount:
+              usd: 0
+            unit: "HOURLY"
+        displayName: *xlarge-gp-psql-redundant-name
+      free: false
+      adapter: dedicated
+      instanceClass: db.m5.xlarge
+      allocatedStorage: 10
+      approvedMajorVersions:
+        - "10"
+        - "11"
+        - "12"
+      dbVersion: "12"
+      dbType: postgres
+      plan_updateable: true
+      redundant: true
+      encrypted: true
+      storage_type: gp2
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.postgres_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        service: "aws-broker"
     - id: "10d0f179-b121-4f2e-bda7-847f433ad9bd"
       name: &2xlarge-gp-psql-name "2xlarge-gp-psql"
       description: "Single-AZ RDS instance of PostgreSQL, minimum 4 cores, minimum 32 GiB memory"
@@ -471,24 +507,24 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         service: "aws-broker"
-    - id: "3732a60e-f2a0-4112-9b64-87dd0cf10e78"
-      name: &xlarge-gp-psql-redundant-name "xlarge-gp-psql-redundant"
-      description: "Multi-AZ RDS instance of PostgreSQL, minimum 2 cores, minimum 16 GiB memory"
+    - id: "57d75b9e-f422-4d7f-beda-7ea54cbdab0a"
+      name: &2xlarge-gp-psql-redundant-name "2xlarge-gp-psql-redundant"
+      description: "Multi-AZ RDS instance of PostgreSQL, minimum 4 cores, minimum 32 GiB memory"
       metadata:
         bullets:
           - *multi-az-rds
           - *default-postgresql-v12
-          - *minimum-2-cores
-          - *minimum-16-gib-memory
+          - *minimum-4-cores
+          - *minimum-32-gib-memory
           - *default-10-gb-storage
         costs:
           - amount:
               usd: 0
             unit: "HOURLY"
-        displayName: *xlarge-gp-psql-redundant-name
+        displayName: *2xlarge-gp-psql-redundant-name
       free: false
       adapter: dedicated
-      instanceClass: db.m5.xlarge
+      instanceClass: db.m5.2xlarge
       allocatedStorage: 10
       approvedMajorVersions:
         - "10"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -476,7 +476,7 @@ rds:
       description: "Multi-AZ RDS instance of PostgreSQL, minimum 2 cores, minimum 16 GiB memory"
       metadata:
         bullets:
-          - *single-az-rds
+          - *multi-az-rds
           - *default-postgresql-v12
           - *minimum-2-cores
           - *minimum-16-gib-memory


### PR DESCRIPTION
To support higher workload applications on cloud.gov, the Data.gov team would like to broker a 2xlarge DB instance for our postgresql service.

References: 
- [AWS DB Instance Types](https://aws.amazon.com/rds/instance-types/)
- [Preliminary slack discussion](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1657031781249599)

## Changes proposed in this pull request:

- New RDS plans: (1) `2xlarge-gp-psql`, (2) `2xlarge-gp-psql-redundant`
- Fix metadata for `xlarge-gp-psql-redundant` plan

## Security considerations
None.  The configuration changes do not affect the attack vector of the codebase.