### PR TITLE
Redis version upgrade

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1161,7 +1161,7 @@ redis:
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
+      parameterGroup: default.redis6.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1191,7 +1191,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
+      parameterGroup: default.redis6.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1221,7 +1221,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
+      parameterGroup: default.redis6.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1244,14 +1244,14 @@ redis:
             amount:
               usd: 120.0
             unit: "MONTHLY"
-        displayName: "3 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
+        displayName: "3 node Elasticache redis6.2, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
+      parameterGroup: default.redis6.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1281,7 +1281,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
+      parameterGroup: default.redis6.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1164,7 +1164,7 @@ redis:
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      #parameterGroup: default.redis6.x
+      parameterGroup: default
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1197,7 +1197,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      #parameterGroup: default.redis6.x
+      parameterGroup: default
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1230,7 +1230,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      #parameterGroup: default.redis6.x
+      parameterGroup: default
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1263,7 +1263,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      #parameterGroup: default.redis6.x
+      parameterGroup: default
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1296,7 +1296,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      #parameterGroup: default.redis6.x
+      parameterGroup: default
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1164,7 +1164,7 @@ redis:
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default
+      parameterGroup: ""
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1197,7 +1197,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default
+      parameterGroup: ""
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1230,7 +1230,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default
+      parameterGroup: ""
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1263,7 +1263,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default
+      parameterGroup: ""
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1296,7 +1296,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default
+      parameterGroup: ""
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1161,7 +1161,7 @@ redis:
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.0
+      parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1191,7 +1191,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.0
+      parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1221,7 +1221,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.0
+      parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1251,7 +1251,7 @@ redis:
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.0
+      parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1281,7 +1281,7 @@ redis:
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.0
+      parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1158,10 +1158,13 @@ redis:
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
+      approvedMajorVersions:
+        - "6.2"
+        - "5.0.6"
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.x
+      #parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1188,10 +1191,13 @@ redis:
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
+      approvedMajorVersions:
+        - "6.2"
+        - "5.0.6"
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.x
+      #parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1218,10 +1224,13 @@ redis:
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
+      approvedMajorVersions:
+        - "6.2"
+        - "5.0.6"
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.x
+      #parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1248,10 +1257,13 @@ redis:
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
+      approvedMajorVersions:
+        - "6.2"
+        - "5.0.6"
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.x
+      #parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1278,10 +1290,13 @@ redis:
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2
+      approvedMajorVersions:
+        - "6.2"
+        - "5.0.6"
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis6.x
+      #parameterGroup: default.redis6.x
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1154,7 +1154,7 @@ redis:
             amount:
               usd: 20.0
             unit: "MONTHLY"
-        displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "non-prod single Elasticache redis 6.2.0, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2.0

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1157,7 +1157,7 @@ redis:
         displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2.0
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1187,7 +1187,7 @@ redis:
         displayName: "3 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2.0
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1217,7 +1217,7 @@ redis:
         displayName: "5 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2.0
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1247,7 +1247,7 @@ redis:
         displayName: "3 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2.0
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1277,7 +1277,7 @@ redis:
         displayName: "5 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2.0
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1141,12 +1141,12 @@ redis:
   plans:
     - id: "475e36bf-387f-44c1-9b81-575fec2ee443"
       name: "redis-dev"
-      description: "AWS Elasticache Redis 5.0.6 Single node non-prod use only"
+      description: "AWS Elasticache Redis 6.2.0 Single node non-prod use only"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis620"
           - "single node"
           - "non-prod"
         costs:
@@ -1154,7 +1154,7 @@ redis:
             amount:
               usd: 20.0
             unit: "MONTHLY"
-        displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "non-prod single Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2.0
@@ -1172,19 +1172,19 @@ redis:
         service: "aws-broker"
     - id: "3nd336bf-387f-44c1-9b81-575fel966443"
       name: "redis-3node"
-      description: "AWS Elasticache Redis 5.0.6 Three node"
+      description: "AWS Elasticache Redis 6.2.0 Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis620"
           - "3node"
         costs:
           -
             amount:
               usd: 60.0
             unit: "MONTHLY"
-        displayName: "3 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "3 node Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2.0
@@ -1202,19 +1202,19 @@ redis:
         service: "aws-broker"
     - id: "5nd336bf-0k7f-44c1-9b81-575fp3k764r6"
       name: "redis-5node"
-      description: "AWS Elasticache Redis 5.0.6 Five node"
+      description: "AWS Elasticache Redis 6.2.0 Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis620"
           - "5node"
         costs:
           -
             amount:
               usd: 100.0
             unit: "MONTHLY"
-        displayName: "5 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "5 node Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2.0
@@ -1232,12 +1232,12 @@ redis:
         service: "aws-broker"
     - id: "3nd227bf-sm4c-44c1-0b81-575fel666443"
       name: "redis-3node-large"
-      description: "AWS Elasticache Redis 5.0.6 Three node"
+      description: "AWS Elasticache Redis 6.2.0 Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis620"
           - "3node"
         costs:
           -
@@ -1262,12 +1262,12 @@ redis:
         service: "aws-broker"
     - id: "5nd227bf-0k7f-44c1-90e1-575fp3k903r6"
       name: "redis-5node-large"
-      description: "AWS Elasticache Redis 5.0.6 Five node"
+      description: "AWS Elasticache Redis 6.2.0 Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis620"
           - "5node"
         costs:
           -

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1141,12 +1141,12 @@ redis:
   plans:
     - id: "475e36bf-387f-44c1-9b81-575fec2ee443"
       name: "redis-dev"
-      description: "AWS Elasticache Redis 6.2.0 Single node non-prod use only"
+      description: "AWS Elasticache Redis 6.2 Single node non-prod use only"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis620"
+          - "redis62"
           - "single node"
           - "non-prod"
         costs:
@@ -1154,10 +1154,10 @@ redis:
             amount:
               usd: 20.0
             unit: "MONTHLY"
-        displayName: "non-prod single Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
+        displayName: "non-prod single Elasticache redis6.2, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 6.2.0
+      engineVersion: 6.2
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1172,22 +1172,22 @@ redis:
         service: "aws-broker"
     - id: "3nd336bf-387f-44c1-9b81-575fel966443"
       name: "redis-3node"
-      description: "AWS Elasticache Redis 6.2.0 Three node"
+      description: "AWS Elasticache Redis 6.2 Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis620"
+          - "redis62"
           - "3node"
         costs:
           -
             amount:
               usd: 60.0
             unit: "MONTHLY"
-        displayName: "3 node Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
+        displayName: "3 node Elasticache redis6.2, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 6.2.0
+      engineVersion: 6.2
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1202,22 +1202,22 @@ redis:
         service: "aws-broker"
     - id: "5nd336bf-0k7f-44c1-9b81-575fp3k764r6"
       name: "redis-5node"
-      description: "AWS Elasticache Redis 6.2.0 Five node"
+      description: "AWS Elasticache Redis 6.2 Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis620"
+          - "redis62"
           - "5node"
         costs:
           -
             amount:
               usd: 100.0
             unit: "MONTHLY"
-        displayName: "5 node Elasticache redis6.2.0, persistent storage, 512Mb memory limit"
+        displayName: "5 node Elasticache redis6.2, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 6.2.0
+      engineVersion: 6.2
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1232,12 +1232,12 @@ redis:
         service: "aws-broker"
     - id: "3nd227bf-sm4c-44c1-0b81-575fel666443"
       name: "redis-3node-large"
-      description: "AWS Elasticache Redis 6.2.0 Three node"
+      description: "AWS Elasticache Redis 6.2 Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis620"
+          - "redis62"
           - "3node"
         costs:
           -
@@ -1247,7 +1247,7 @@ redis:
         displayName: "3 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 6.2.0
+      engineVersion: 6.2
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
@@ -1262,22 +1262,22 @@ redis:
         service: "aws-broker"
     - id: "5nd227bf-0k7f-44c1-90e1-575fp3k903r6"
       name: "redis-5node-large"
-      description: "AWS Elasticache Redis 6.2.0 Five node"
+      description: "AWS Elasticache Redis 6.2 Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis620"
+          - "redis62"
           - "5node"
         costs:
           -
             amount:
               usd: 200.0
             unit: "MONTHLY"
-        displayName: "5 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
+        displayName: "5 node Elasticache redis6.2, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 6.2.0
+      engineVersion: 6.2
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1154,7 +1154,7 @@ redis:
             amount:
               usd: 20.0
             unit: "MONTHLY"
-        displayName: "non-prod single Elasticache redis 6.2.0, persistent storage, 512Mb memory limit"
+        displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
       engineVersion: 6.2.0

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -140,7 +140,7 @@ type RedisPlan struct {
 	SecurityGroup              string            `yaml:"securityGroup" json:"-" validate:"required"`
 	CacheNodeType              string            `yaml:"nodeType" json:"-" validate:"required"`
 	NumCacheClusters           int               `yaml:"numberCluster" json:"-" validate:"required"`
-	ParameterGroup             string            `yaml:"parameterGroup" json:"-" validate:"required"`
+	//ParameterGroup             string            `yaml:"parameterGroup" json:"-" validate:"required"`
 	PreferredMaintenanceWindow string            `yaml:"preferredMaintenanceWindow" json:"-" validate:"required"`
 	SnapshotWindow             string            `yaml:"snapshotWindow" json:"-" validate:"required"`
 	SnapshotRetentionLimit     int               `yaml:"snapshotRetentionLimit" json:"-"`

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1203,7 +1203,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: ((aws-broker-url-development))
-    branch: ((aws-broker-branch-development))
+    branch: redis-version-upgrade
 
 - name: aws-db-test
   type: git

--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -124,7 +124,7 @@ func (i *RedisInstance) init(uuid string,
 	i.EngineVersion = plan.EngineVersion
 	i.NumCacheClusters = plan.NumCacheClusters
 	i.CacheNodeType = plan.CacheNodeType
-	i.ParameterGroup = plan.ParameterGroup
+	// i.ParameterGroup = plan.ParameterGroup
 	i.PreferredMaintenanceWindow = plan.PreferredMaintenanceWindow
 	i.SnapshotWindow = plan.SnapshotWindow
 	i.SnapshotRetentionLimit = plan.SnapshotRetentionLimit


### PR DESCRIPTION
## Changes proposed in this pull request:

- default to engine version 6.2
- allow support for none default Redis versions
- 

## Security considerations
 Users will be able to run earlier versions of Redis than the latest and 5.x 
[Note the any security considerations here, or make note of why there are none]
