### PR TITLE
Redis version upgrade

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1141,12 +1141,12 @@ redis:
   plans:
     - id: "475e36bf-387f-44c1-9b81-575fec2ee443"
       name: "redis-dev"
-      description: "AWS Elasticache Redis 5.0.6 Single node non-prod use only"
+      description: "AWS Elasticache Redis Single node non-prod use only"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis62"
           - "single node"
           - "non-prod"
         costs:
@@ -1154,14 +1154,18 @@ redis:
             amount:
               usd: 20.0
             unit: "MONTHLY"
-        displayName: "non-prod single Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "non-prod single Elasticache redis, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2
+      approvedMajorVersions:
+        - "7.0"
+        - "6.2"
+        - "6.0"
+        - "5.0.6"
       numberCluster: 1
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 1
@@ -1172,26 +1176,30 @@ redis:
         service: "aws-broker"
     - id: "3nd336bf-387f-44c1-9b81-575fel966443"
       name: "redis-3node"
-      description: "AWS Elasticache Redis 5.0.6 Three node"
+      description: "AWS Elasticache Redis Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis62"
           - "3node"
         costs:
           -
             amount:
               usd: 60.0
             unit: "MONTHLY"
-        displayName: "3 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "3 node Elasticache redis, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2
+      approvedMajorVersions:
+        - "7.0"
+        - "6.2"
+        - "6.0"
+        - "5.0.6"
       numberCluster: 3
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1202,26 +1210,31 @@ redis:
         service: "aws-broker"
     - id: "5nd336bf-0k7f-44c1-9b81-575fp3k764r6"
       name: "redis-5node"
-      description: "AWS Elasticache Redis 5.0.6 Five node"
+      description: "AWS Elasticache Redis Five node"
+      description: "AWS Elasticache Redis 6.2 Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis62"
           - "5node"
         costs:
           -
             amount:
               usd: 100.0
             unit: "MONTHLY"
-        displayName: "5 node Elasticache redis5.0.6, persistent storage, 512Mb memory limit"
+        displayName: "5 node Elasticache redis, persistent storage, 512Mb memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2
+      approvedMajorVersions:
+        - "7.0"
+        - "6.2"
+        - "6.0"
+        - "5.0.6"
       numberCluster: 5
       nodeType: cache.t3.micro
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1232,26 +1245,30 @@ redis:
         service: "aws-broker"
     - id: "3nd227bf-sm4c-44c1-0b81-575fel666443"
       name: "redis-3node-large"
-      description: "AWS Elasticache Redis 5.0.6 Three node"
+      description: "AWS Elasticache Redis Three node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis62"
           - "3node"
         costs:
           -
             amount:
               usd: 120.0
             unit: "MONTHLY"
-        displayName: "3 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
+        displayName: "3 node Elasticache redis, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2
+      approvedMajorVersions:
+        - "7.0"
+        - "6.2"
+        - "6.0"
+        - "5.0.6"
       numberCluster: 3
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3
@@ -1262,26 +1279,30 @@ redis:
         service: "aws-broker"
     - id: "5nd227bf-0k7f-44c1-90e1-575fp3k903r6"
       name: "redis-5node-large"
-      description: "AWS Elasticache Redis 5.0.6 Five node"
+      description: "AWS Elasticache Redis Five node"
       metadata:
         bullets:
           - "Elasticache"
           - "redis"
-          - "redis506"
+          - "redis62"
           - "5node"
         costs:
           -
             amount:
               usd: 200.0
             unit: "MONTHLY"
-        displayName: "5 node Elasticache redis5.0.6, persistent storage, 1.37GiB memory limit"
+        displayName: "5 node Elasticache redis, persistent storage, 1.37GiB memory limit"
       free: false
       securityGroup: (( grab meta.redis.security_group ))
-      engineVersion: 5.0.6
+      engineVersion: 6.2
+      approvedMajorVersions:
+        - "7.0"
+        - "6.2"
+        - "6.0"
+        - "5.0.6"
       numberCluster: 5
       nodeType: cache.t3.small
       subnetGroup: (( grab meta.redis.subnet_group ))
-      parameterGroup: default.redis5.0
       preferredMaintenanceWindow: mon:07:00-mon:08:00
       snapshotWindow: 06:00-07:00
       snapshotRetentionLimit: 3

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -140,11 +140,30 @@ type RedisPlan struct {
 	SecurityGroup              string            `yaml:"securityGroup" json:"-" validate:"required"`
 	CacheNodeType              string            `yaml:"nodeType" json:"-" validate:"required"`
 	NumCacheClusters           int               `yaml:"numberCluster" json:"-" validate:"required"`
-	ParameterGroup             string            `yaml:"parameterGroup" json:"-" validate:"required"`
 	PreferredMaintenanceWindow string            `yaml:"preferredMaintenanceWindow" json:"-" validate:"required"`
 	SnapshotWindow             string            `yaml:"snapshotWindow" json:"-" validate:"required"`
 	SnapshotRetentionLimit     int               `yaml:"snapshotRetentionLimit" json:"-"`
 	AutomaticFailoverEnabled   bool              `yaml:"automaticFailoverEnabled" json:"-"`
+        ApprovedMajorVersions     []string          `yaml:"approvedMajorVersions" json:"-"`
+}
+
+// CheckVersion verifies that a specific version chosen by the user for a new
+// redis instances is valid and supported in the chosen plan.
+func (p RedisPlan) CheckVersion(version string) bool {
+	// Return true if there are no valid major versions set in the plan; this
+	// lets the calls proceed and the AWS API will error out if an invalid
+	// version is provided.
+	if len(p.ApprovedMajorVersions) == 0 {
+		return true
+	}
+
+	for _, approvedVersion := range p.ApprovedMajorVersions {
+		if version == approvedVersion {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ElasticsearchService describes the Elasticsearch Service. It contains the basic Service details as well as a list of Elasticsearch Plans

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1203,7 +1203,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: ((aws-broker-url-development))
-    branch: ((aws-broker-branch-development))
+    branch: redis-version-upgrade
 
 - name: aws-db-test
   type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1203,7 +1203,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: ((aws-broker-url-development))
-    branch: redis-version-upgrade
+    branch: ((aws-broker-branch-development))
 
 - name: aws-db-test
   type: git

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -24,6 +24,7 @@ type Options struct {
 	PubliclyAccessible    bool   `json:"publicly_accessible"`
 	Version               string `json:"version"`
 	BackupRetentionPeriod int64  `json:"backup_retention_period"`
+        RedisVersion          string 'json:"redis_version"
 }
 
 // Validate the custom parameters passed in via the "-c <JSON string or file>"
@@ -131,8 +132,6 @@ func (broker *rdsBroker) CreateInstance(c *catalog.Catalog, id string, createReq
 	if planErr != nil {
 		return planErr
 	}
-
-	// Check to see if there is a major version specified and if so, check to
 	// make sure it's a valid major version.
 	if options.Version != "" {
 		// Check to make sure that the version specified is allowed by the plan.
@@ -144,6 +143,18 @@ func (broker *rdsBroker) CreateInstance(c *catalog.Catalog, id string, createReq
 		}
 	}
 
+        // Check to see if there is a major version specified for Redis and if so, check to
+        // make sure it's a valid major version.
+        if options.RedisVersion != "" {
+        // Check to make sure that the version specified is allowed by the plan.
+                 if !rplan.CheckVersion(options.RedisVersion) {
+                         return response.NewErrorResponse(
+                                 http.StatusBadRequest,
+                                 options.RedisVersion+" is not a supported major version; major version must be one of: "+strings.Join(rplan.ApprovedMajorVersions, ", ")+".",
+                         )
+                 }
+
+        }
 	err := newInstance.init(
 		id,
 		createRequest.OrganizationGUID,

--- a/services/redis/broker.go
+++ b/services/redis/broker.go
@@ -95,7 +95,15 @@ func (broker *redisBroker) CreateInstance(c *catalog.Catalog, id string, createR
 	if planErr != nil {
 		return planErr
 	}
-
+        if options.EngineVersion != "" {
+		// Check to make sure that the version specified is allowed by the plan.
+		if !plan.CheckVersion(options.EngineVersion) {
+			return response.NewErrorResponse(
+				http.StatusBadRequest,
+				options.EngineVersion +" is not a supported major version; major version must be one of: 7.0, 6.2, 6.0, 5.0.6 "+".",
+			)
+		}
+	}
 	err := newInstance.init(
 		id,
 		createRequest.OrganizationGUID,

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -123,14 +123,15 @@ func (d *dedicatedRedisAdapter) createRedis(i *RedisInstance, password string) (
 		CacheSubnetGroupName:        aws.String(i.DbSubnetGroup),
 		SecurityGroupIds:            securityGroups,
 		Engine:                      aws.String("redis"),
-		EngineVersion:               aws.String(i.EngineVersion),
 		NumCacheClusters:            aws.Int64(int64(i.NumCacheClusters)),
 		Port:                        aws.Int64(6379),
-		CacheParameterGroupName:     aws.String(i.ParameterGroup),
 		PreferredMaintenanceWindow:  aws.String(i.PreferredMaintenanceWindow),
 		SnapshotWindow:              aws.String(i.SnapshotWindow),
 		SnapshotRetentionLimit:      aws.Int64(int64(i.SnapshotRetentionLimit)),
 	}
+        if i.EngineVersion != ""{
+          params.EngineVersion = aws.String(i.EngineVersion)
+         }
 
 	resp, err := svc.CreateReplicationGroup(params)
 	// Pretty-print the response data.

--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -120,11 +120,15 @@ func (i *RedisInstance) init(uuid string,
 	if err := i.setPassword(password, s.EncryptionKey); err != nil {
 		return err
 	}
-
-	i.EngineVersion = plan.EngineVersion
-	i.NumCacheClusters = plan.NumCacheClusters
+        // Set the DB Version
+	if options.EngineVersion != "" {
+		i.EngineVersion = options.EngineVersion
+	} else {
+		// Default to the version provided by the plan chosen in catalog.
+		i.EngineVersion = plan.EngineVersion
+	}
+        i.NumCacheClusters = plan.NumCacheClusters
 	i.CacheNodeType = plan.CacheNodeType
-	i.ParameterGroup = plan.ParameterGroup
 	i.PreferredMaintenanceWindow = plan.PreferredMaintenanceWindow
 	i.SnapshotWindow = plan.SnapshotWindow
 	i.SnapshotRetentionLimit = plan.SnapshotRetentionLimit


### PR DESCRIPTION
## Changes proposed in this pull request:

- allow for version 6.x
- allow user to select versions if on majorApproved versions list
- allow for upgrades in the future to only need to be approved

## Security considerations
Able to use newer versions of redis, only consideration is that security will be as tight as the lowest redis version allowed