### PR TITLE
Support binary logging parameter

### DIFF
--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -46,7 +46,7 @@ func (o Options) Validate(settings *config.Settings) error {
 
 	switch o.BinaryLogFormat {
 	case "ROW", "STATEMENT", "MIXED":
-		// continue
+		// these are the allowed values, continue
 	default:
 		return fmt.Errorf("invalid binary log format %s", o.BinaryLogFormat)
 	}

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -15,14 +15,6 @@ import (
 	"github.com/18F/aws-broker/helpers/response"
 )
 
-type BinaryLogFormatType string
-
-const (
-	ROW       BinaryLogFormatType = "ROW"
-	STATEMENT BinaryLogFormatType = "STATEMENT"
-	MIXED     BinaryLogFormatType = "MIXED"
-)
-
 // Options is a struct containing all of the custom parameters supported by
 // the broker for the "cf create-service" and "cf update-service" commands -
 // they are passed in via the "-c <JSON string or file>" flag.

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -44,11 +44,8 @@ func (o Options) Validate(settings *config.Settings) error {
 		return fmt.Errorf("Invalid Retention Period %d; must be => %d", o.BackupRetentionPeriod, settings.MinBackupRetention)
 	}
 
-	switch o.BinaryLogFormat {
-	case "ROW", "STATEMENT", "MIXED":
-		// these are the allowed values, continue
-	default:
-		return fmt.Errorf("invalid binary log format %s", o.BinaryLogFormat)
+	if err := validateBinaryLogFormat(o.BinaryLogFormat); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -15,6 +15,14 @@ import (
 	"github.com/18F/aws-broker/helpers/response"
 )
 
+type BinaryLogFormatType string
+
+const (
+	ROW       BinaryLogFormatType = "ROW"
+	STATEMENT BinaryLogFormatType = "STATEMENT"
+	MIXED     BinaryLogFormatType = "MIXED"
+)
+
 // Options is a struct containing all of the custom parameters supported by
 // the broker for the "cf create-service" and "cf update-service" commands -
 // they are passed in via the "-c <JSON string or file>" flag.
@@ -24,6 +32,7 @@ type Options struct {
 	PubliclyAccessible    bool   `json:"publicly_accessible"`
 	Version               string `json:"version"`
 	BackupRetentionPeriod int64  `json:"backup_retention_period"`
+	BinaryLogFormat       string `json:"binary_log_format"`
 }
 
 // Validate the custom parameters passed in via the "-c <JSON string or file>"
@@ -41,6 +50,13 @@ func (o Options) Validate(settings *config.Settings) error {
 
 	if o.BackupRetentionPeriod != 0 && o.BackupRetentionPeriod < settings.MinBackupRetention {
 		return fmt.Errorf("Invalid Retention Period %d; must be => %d", o.BackupRetentionPeriod, settings.MinBackupRetention)
+	}
+
+	switch o.BinaryLogFormat {
+	case "ROW", "STATEMENT", "MIXED":
+		// continue
+	default:
+		return fmt.Errorf("invalid binary log format %s", o.BinaryLogFormat)
 	}
 
 	return nil

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -233,6 +233,11 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 		existingInstance.BackupRetentionPeriod = options.BackupRetentionPeriod
 	}
 
+	// Check if there is a binary log format change and if so, apply it
+	if options.BinaryLogFormat != "" {
+		existingInstance.BinaryLogFormat = options.BinaryLogFormat
+	}
+
 	// Fetch the new plan that has been requested.
 	newPlan, newPlanErr := c.RdsService.FetchPlan(modifyRequest.PlanID)
 	if newPlanErr != nil {

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -1,0 +1,48 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/18F/aws-broker/config"
+)
+
+func TestOptionsBinaryLogFormatValidation(t *testing.T) {
+	testCases := map[string]struct {
+		binaryLogFormat string
+		settings        *config.Settings
+		expectedErr     bool
+	}{
+		"invalid": {
+			binaryLogFormat: "foo",
+			settings:        &config.Settings{},
+			expectedErr:     true,
+		},
+		"row": {
+			binaryLogFormat: "ROW",
+			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+		"statement": {
+			binaryLogFormat: "STATEMENT",
+			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+		"mixed": {
+			binaryLogFormat: "MIXED",
+			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			opts := Options{
+				BinaryLogFormat: test.binaryLogFormat,
+			}
+			err := opts.Validate(test.settings)
+			if test.expectedErr && err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -17,8 +17,18 @@ func TestOptionsBinaryLogFormatValidation(t *testing.T) {
 			settings:        &config.Settings{},
 			expectedErr:     true,
 		},
-		"row": {
+		"ROW": {
 			binaryLogFormat: "ROW",
+			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+		"STATEMENT": {
+			binaryLogFormat: "STATEMENT",
+			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+		"MIXED": {
+			binaryLogFormat: "MIXED",
 			settings:        &config.Settings{},
 			expectedErr:     false,
 		},

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -1,0 +1,213 @@
+package rds
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/18F/aws-broker/config"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+)
+
+// PgroupPrefix is the prefix for all pgroups created by the broker.
+const PgroupPrefix = "cg-aws-broker-"
+
+var (
+	needCustomParameters               = needCustomParametersFunc
+	getCustomParameters                = getCustomParametersFunc
+	createOrModifyCustomParameterGroup = createOrModifyCustomParameterGroupFunc
+)
+
+type parameterGroupAdapterInterface interface {
+	provisionCustomParameterGroupIfNecessary(
+		i *RDSInstance,
+		d *dedicatedDBAdapter,
+		svc rdsiface.RDSAPI,
+	) (string, error)
+}
+
+type parameterGroupAdapter struct{}
+
+// This function will return the a custom parameter group with whatever custom
+// parameters have been requested.  If there is no custom parameter group, it
+// will be created.
+func createOrModifyCustomParameterGroupFunc(
+	i *RDSInstance,
+	customparams map[string]map[string]string,
+	svc rdsiface.RDSAPI,
+) (string, error) {
+	// i.FormatDBName() should always return the same value for the same database name,
+	// so the parameter group name should remain consistent
+	pgroupName := PgroupPrefix + i.FormatDBName()
+
+	dbParametersInput := &rds.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String(pgroupName),
+		MaxRecords:           aws.Int64(20),
+		Source:               aws.String("system"),
+	}
+
+	// If the db parameter group has already been created, we can return.
+	_, err := svc.DescribeDBParameters(dbParametersInput)
+	if err == nil {
+		log.Printf("%s parameter group already exists", pgroupName)
+	} else {
+		// Otherwise, create a new parameter group in the proper family.
+		pgroupFamily := ""
+
+		// If the DB version is not set (e.g., creating a new instance without
+		// providing a specific version), determine the default parameter group
+		// name from the default engine that will be chosen.
+		if i.DbVersion == "" {
+			dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{
+				DefaultOnly: aws.Bool(true),
+				Engine:      aws.String(i.DbType),
+			}
+
+			// This call requires that the broker have permissions to make it.
+			defaultEngineInfo, err := svc.DescribeDBEngineVersions(dbEngineVersionsInput)
+
+			if err != nil {
+				return "Error retrieving default parameter group name", err
+			}
+
+			// The value from the engine info is a string pointer, so we must
+			// retrieve its actual value.
+			pgroupFamily = *defaultEngineInfo.DBEngineVersions[0].DBParameterGroupFamily
+		} else {
+			// The DB instance has a version, therefore we can derive the
+			// parameter group family directly.
+			re := regexp.MustCompile(`^\d+\.*\d*`)
+			dbversion := re.Find([]byte(i.DbVersion))
+			pgroupFamily = i.DbType + string(dbversion)
+			log.Printf("creating a parameter group named %s in the family of %s", pgroupName, pgroupFamily)
+		}
+
+		createInput := &rds.CreateDBParameterGroupInput{
+			DBParameterGroupFamily: aws.String(pgroupFamily),
+			DBParameterGroupName:   aws.String(pgroupName),
+			Description:            aws.String("aws broker parameter group for " + i.FormatDBName()),
+		}
+
+		_, err = svc.CreateDBParameterGroup(createInput)
+		if err != nil {
+			return pgroupName, err
+		}
+	}
+
+	// iterate through the options and plug them into the parameter list
+	parameters := []*rds.Parameter{}
+	for k, v := range customparams[i.DbType] {
+		parameters = append(parameters, &rds.Parameter{
+			ApplyMethod:    aws.String("immediate"),
+			ParameterName:  aws.String(k),
+			ParameterValue: aws.String(v),
+		})
+	}
+
+	// modify the parameter group we just created with the parameter list
+	modifyinput := &rds.ModifyDBParameterGroupInput{
+		DBParameterGroupName: aws.String(pgroupName),
+		Parameters:           parameters,
+	}
+	_, err = svc.ModifyDBParameterGroup(modifyinput)
+	if err != nil {
+		return pgroupName, err
+	}
+
+	return pgroupName, nil
+}
+
+// This is here because the check is kinda big and ugly
+func needCustomParametersFunc(i *RDSInstance, s config.Settings) bool {
+	// Currently, we only have one custom parameter for mysql, but if
+	// we ever need to apply more, you can add them in here.
+	if i.EnableFunctions &&
+		s.EnableFunctionsFeature &&
+		(i.DbType == "mysql") {
+		return true
+	}
+	if i.BinaryLogFormat != "" &&
+		(i.DbType == "mysql") {
+		return true
+	}
+	return false
+}
+
+func getCustomParametersFunc(i *RDSInstance, s config.Settings) map[string]map[string]string {
+	customRDSParameters := make(map[string]map[string]string)
+
+	// enable functions
+	customRDSParameters["mysql"] = make(map[string]string)
+	if i.EnableFunctions && s.EnableFunctionsFeature {
+		customRDSParameters["mysql"]["log_bin_trust_function_creators"] = "1"
+	} else {
+		customRDSParameters["mysql"]["log_bin_trust_function_creators"] = "0"
+	}
+
+	// set MySQL binary log format
+	if i.BinaryLogFormat != "" {
+		customRDSParameters["mysql"]["binlog_format"] = i.BinaryLogFormat
+	}
+
+	// If you need to add more custom parameters, you can add them in here.
+
+	return customRDSParameters
+}
+
+func (p *parameterGroupAdapter) provisionCustomParameterGroupIfNecessary(
+	i *RDSInstance,
+	d *dedicatedDBAdapter,
+	svc rdsiface.RDSAPI,
+) (string, error) {
+	if !needCustomParameters(i, d.settings) {
+		return "", nil
+	}
+
+	customRDSParameters := getCustomParameters(i, d.settings)
+
+	// apply parameter group
+	pgroupName, err := createOrModifyCustomParameterGroup(i, customRDSParameters, svc)
+	if err != nil {
+		log.Println(err.Error())
+		return "", err
+	}
+	return pgroupName, nil
+}
+
+// search out all the parameter groups that we created and try to clean them up
+func cleanupCustomParameterGroups(svc rdsiface.RDSAPI) {
+	input := &rds.DescribeDBParameterGroupsInput{}
+	err := svc.DescribeDBParameterGroupsPages(input,
+		func(pgroups *rds.DescribeDBParameterGroupsOutput, lastPage bool) bool {
+			// If the pgroup matches the prefix, then try to delete it.
+			// If it's in use, it will fail, so ignore that.
+			for _, pgroup := range pgroups.DBParameterGroups {
+				matched, err := regexp.Match("^"+PgroupPrefix, []byte(*pgroup.DBParameterGroupName))
+				if err != nil {
+					log.Printf("error trying to match %s in %s: %s", PgroupPrefix, *pgroup.DBParameterGroupName, err.Error())
+				}
+				if matched {
+					deleteinput := &rds.DeleteDBParameterGroupInput{
+						DBParameterGroupName: aws.String(*pgroup.DBParameterGroupName),
+					}
+					_, err := svc.DeleteDBParameterGroup(deleteinput)
+					if err == nil {
+						log.Printf("cleaned up %s parameter group", *pgroup.DBParameterGroupName)
+					} else if err.(awserr.Error).Code() != "InvalidDBParameterGroupState" {
+						// If you can't delete it because it's in use, that is fine.
+						// The db takes a while to delete, so we will clean it up the
+						// next time this is called.  Otherwise there is some sort of AWS error
+						// and we should log that.
+						log.Printf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err.Error())
+					}
+				}
+			}
+			return true
+		})
+	if err != nil {
+		log.Printf("Could not retrieve list of parameter groups while cleaning up: %s", err.Error())
+		return
+	}
+}

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -1,0 +1,222 @@
+package rds
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/18F/aws-broker/config"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+)
+
+type mockRDSClient struct {
+	rdsiface.RDSAPI
+}
+
+func TestNeedCustomParameters(t *testing.T) {
+	testCases := map[string]struct {
+		dbInstance *RDSInstance
+		settings   config.Settings
+		expectedOk bool
+	}{
+		"default": {
+			dbInstance: &RDSInstance{},
+			settings:   config.Settings{},
+			expectedOk: false,
+		},
+		"valid binary log format": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "mysql",
+			},
+			settings:   config.Settings{},
+			expectedOk: true,
+		},
+		"valid binary log format, wrong database type": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "psql",
+			},
+			settings:   config.Settings{},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings disabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: false,
+			},
+			expectedOk: false,
+		},
+		"instance functions disabled, settings enabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: false,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings enabled, wrong db type": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "psql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings enabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: true,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if needCustomParameters(test.dbInstance, test.settings) != test.expectedOk {
+				t.Fatalf("should be %v", test.expectedOk)
+			}
+		})
+	}
+}
+
+func TestGetCustomParameters(t *testing.T) {
+	testCases := map[string]struct {
+		dbInstance     *RDSInstance
+		settings       config.Settings
+		expectedParams map[string]map[string]string
+	}{
+		"enabled functions": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedParams: map[string]map[string]string{
+				"mysql": {
+					"log_bin_trust_function_creators": "1",
+				},
+			},
+		},
+		"instance functions disabled, settings enabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: false,
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedParams: map[string]map[string]string{
+				"mysql": {
+					"log_bin_trust_function_creators": "0",
+				},
+			},
+		},
+		"instance functions enabled, settings disabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: false,
+			},
+			expectedParams: map[string]map[string]string{
+				"mysql": {
+					"log_bin_trust_function_creators": "0",
+				},
+			},
+		},
+		"binary log format": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+			},
+			settings: config.Settings{},
+			expectedParams: map[string]map[string]string{
+				"mysql": {
+					"log_bin_trust_function_creators": "0",
+					"binlog_format":                   "ROW",
+				},
+			},
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			params := getCustomParameters(test.dbInstance, test.settings)
+			if !reflect.DeepEqual(params, test.expectedParams) {
+				t.Fatalf("expected %s, got: %s", test.expectedParams, params)
+			}
+		})
+	}
+}
+
+func TestProvisionCustomParameterGroupIfNecessary(t *testing.T) {
+	p := &parameterGroupAdapter{}
+	i := &RDSInstance{}
+	d := &dedicatedDBAdapter{}
+	svc := &mockRDSClient{}
+
+	createModifyErr := errors.New("create/modify error")
+
+	testCases := map[string]struct {
+		customParams         map[string]map[string]string
+		needCustomParameters bool
+		pGroupName           string
+		createOrModifyErr    error
+		expectedPGroupName   string
+		expectedErr          error
+	}{
+		"does not need custom params": {
+			needCustomParameters: false,
+		},
+		"needs custom params, success": {
+			needCustomParameters: true,
+			pGroupName:           "group1",
+			expectedPGroupName:   "group1",
+		},
+		"needs custom params, error": {
+			needCustomParameters: true,
+			createOrModifyErr:    createModifyErr,
+			expectedErr:          createModifyErr,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			needCustomParameters = func(i *RDSInstance, s config.Settings) bool {
+				return test.needCustomParameters
+			}
+
+			createOrModifyCustomParameterGroup = func(
+				i *RDSInstance,
+				customparams map[string]map[string]string,
+				svc rdsiface.RDSAPI,
+			) (string, error) {
+				if test.createOrModifyErr != nil {
+					return "", test.createOrModifyErr
+				}
+				return test.pGroupName, nil
+			}
+
+			pGroupName, err := p.provisionCustomParameterGroupIfNecessary(i, d, svc)
+			if test.expectedErr == nil && err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if test.expectedErr != nil && err != test.expectedErr {
+				t.Errorf("expected error: %s, got: %s", test.expectedErr, err)
+			}
+			if pGroupName != test.expectedPGroupName {
+				t.Fatalf("unexpected group name: %s, expected: %s", pGroupName, test.expectedPGroupName)
+			}
+		})
+	}
+}

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -281,8 +281,11 @@ func (d *dedicatedDBAdapter) createDB(i *RDSInstance, password string) (base.Ins
 			customRDSParameters["mysql"]["log_bin_trust_function_creators"] = "0"
 		}
 
-		// Currently, we only have one custom parameter for mysql, but if
-		// we ever need to apply more, you can add them in here.
+		if i.BinaryLogFormat != "" {
+			customRDSParameters["mysql"]["binlog_format"] = i.BinaryLogFormat
+		}
+
+		// If you need to add more custom parameters for MySQL, you can add them in here.
 
 		// apply parameter group
 		pgroupName, err := getCustomParameterGroup(PgroupPrefix+i.FormatDBName(), i, customRDSParameters, svc)

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -125,7 +125,7 @@ type dedicatedDBAdapter struct {
 	settings config.Settings
 }
 
-func getModifyDbInstanceInput(
+func prepareModifyDbInstanceInput(
 	i *RDSInstance,
 	d *dedicatedDBAdapter,
 	svc rdsiface.RDSAPI,
@@ -228,7 +228,7 @@ func (d *dedicatedDBAdapter) modifyDB(i *RDSInstance, password string) (base.Ins
 	svc := rds.New(session.New(), aws.NewConfig().WithRegion(d.settings.Region))
 
 	pGroupAdapter := &parameterGroupAdapter{}
-	params, err := getModifyDbInstanceInput(i, d, svc, pGroupAdapter)
+	params, err := prepareModifyDbInstanceInput(i, d, svc, pGroupAdapter)
 	if err != nil {
 		return base.InstanceNotCreated, err
 	}

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -219,6 +219,10 @@ func needCustomParameters(i *RDSInstance, s config.Settings) bool {
 		(i.DbType == "mysql") {
 		return true
 	}
+	if i.BinaryLogFormat != "" &&
+		(i.DbType == "mysql") {
+		return true
+	}
 	return false
 }
 

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -15,8 +15,6 @@ import (
 
 	"errors"
 	"fmt"
-	"log"
-	"regexp"
 )
 
 type dbAdapter interface {
@@ -25,14 +23,6 @@ type dbAdapter interface {
 	checkDBStatus(i *RDSInstance) (base.InstanceState, error)
 	bindDBToApp(i *RDSInstance, password string) (map[string]string, error)
 	deleteDB(i *RDSInstance) (base.InstanceState, error)
-}
-
-type parameterGroupAdapterInterface interface {
-	provisionCustomParameterGroupIfNecessary(
-		i *RDSInstance,
-		d *dedicatedDBAdapter,
-		svc rdsiface.RDSAPI,
-	) (string, error)
 }
 
 // MockDBAdapter is a struct meant for testing.
@@ -133,157 +123,6 @@ func (d *sharedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error) {
 type dedicatedDBAdapter struct {
 	Plan     catalog.RDSPlan
 	settings config.Settings
-}
-
-// PgroupPrefix is the prefix for all pgroups created by the broker.
-const PgroupPrefix = "cg-aws-broker-"
-
-// This function will return the a custom parameter group with whatever custom
-// parameters have been requested.  If there is no custom parameter group, it
-// will be created.
-func createOrModifyCustomParameterGroup(
-	i *RDSInstance,
-	customparams map[string]map[string]string,
-	svc rdsiface.RDSAPI,
-) (string, error) {
-	// i.FormatDBName() should always return the same value for the same database name,
-	// so the parameter group name should remain consistent
-	pgroupName := PgroupPrefix + i.FormatDBName()
-
-	dbParametersInput := &rds.DescribeDBParametersInput{
-		DBParameterGroupName: aws.String(pgroupName),
-		MaxRecords:           aws.Int64(20),
-		Source:               aws.String("system"),
-	}
-
-	// If the db parameter group has already been created, we can return.
-	_, err := svc.DescribeDBParameters(dbParametersInput)
-	if err == nil {
-		log.Printf("%s parameter group already exists", pgroupName)
-	} else {
-		// Otherwise, create a new parameter group in the proper family.
-		pgroupFamily := ""
-
-		// If the DB version is not set (e.g., creating a new instance without
-		// providing a specific version), determine the default parameter group
-		// name from the default engine that will be chosen.
-		if i.DbVersion == "" {
-			dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{
-				DefaultOnly: aws.Bool(true),
-				Engine:      aws.String(i.DbType),
-			}
-
-			// This call requires that the broker have permissions to make it.
-			defaultEngineInfo, err := svc.DescribeDBEngineVersions(dbEngineVersionsInput)
-
-			if err != nil {
-				return "Error retrieving default parameter group name", err
-			}
-
-			// The value from the engine info is a string pointer, so we must
-			// retrieve its actual value.
-			pgroupFamily = *defaultEngineInfo.DBEngineVersions[0].DBParameterGroupFamily
-		} else {
-			// The DB instance has a version, therefore we can derive the
-			// parameter group family directly.
-			re := regexp.MustCompile(`^\d+\.*\d*`)
-			dbversion := re.Find([]byte(i.DbVersion))
-			pgroupFamily = i.DbType + string(dbversion)
-			log.Printf("creating a parameter group named %s in the family of %s", pgroupName, pgroupFamily)
-		}
-
-		createInput := &rds.CreateDBParameterGroupInput{
-			DBParameterGroupFamily: aws.String(pgroupFamily),
-			DBParameterGroupName:   aws.String(pgroupName),
-			Description:            aws.String("aws broker parameter group for " + i.FormatDBName()),
-		}
-
-		_, err = svc.CreateDBParameterGroup(createInput)
-		if err != nil {
-			return pgroupName, err
-		}
-	}
-
-	// iterate through the options and plug them into the parameter list
-	parameters := []*rds.Parameter{}
-	for k, v := range customparams[i.DbType] {
-		parameters = append(parameters, &rds.Parameter{
-			ApplyMethod:    aws.String("immediate"),
-			ParameterName:  aws.String(k),
-			ParameterValue: aws.String(v),
-		})
-	}
-
-	// modify the parameter group we just created with the parameter list
-	modifyinput := &rds.ModifyDBParameterGroupInput{
-		DBParameterGroupName: aws.String(pgroupName),
-		Parameters:           parameters,
-	}
-	_, err = svc.ModifyDBParameterGroup(modifyinput)
-	if err != nil {
-		return pgroupName, err
-	}
-
-	return pgroupName, nil
-}
-
-// This is here because the check is kinda big and ugly
-func needCustomParameters(i *RDSInstance, s config.Settings) bool {
-	// Currently, we only have one custom parameter for mysql, but if
-	// we ever need to apply more, you can add them in here.
-	if i.EnableFunctions &&
-		s.EnableFunctionsFeature &&
-		(i.DbType == "mysql") {
-		return true
-	}
-	if i.BinaryLogFormat != "" &&
-		(i.DbType == "mysql") {
-		return true
-	}
-	return false
-}
-
-func getCustomParameters(i *RDSInstance, s config.Settings) map[string]map[string]string {
-	customRDSParameters := make(map[string]map[string]string)
-
-	// enable functions
-	customRDSParameters["mysql"] = make(map[string]string)
-	if i.EnableFunctions && s.EnableFunctionsFeature {
-		customRDSParameters["mysql"]["log_bin_trust_function_creators"] = "1"
-	} else {
-		customRDSParameters["mysql"]["log_bin_trust_function_creators"] = "0"
-	}
-
-	// set MySQL binary log format
-	if i.BinaryLogFormat != "" {
-		customRDSParameters["mysql"]["binlog_format"] = i.BinaryLogFormat
-	}
-
-	// If you need to add more custom parameters, you can add them in here.
-
-	return customRDSParameters
-}
-
-type parameterGroupAdapter struct{}
-
-func (p *parameterGroupAdapter) provisionCustomParameterGroupIfNecessary(
-	i *RDSInstance,
-	d *dedicatedDBAdapter,
-	svc rdsiface.RDSAPI,
-) (string, error) {
-	if !needCustomParameters(i, d.settings) {
-		return "", nil
-	}
-
-	customRDSParameters := getCustomParameters(i, d.settings)
-
-	// apply parameter group
-	pgroupName, err := createOrModifyCustomParameterGroup(i, customRDSParameters, svc)
-	if err != nil {
-		log.Println(err.Error())
-		return "", err
-	}
-	return pgroupName, nil
 }
 
 func getModifyDbInstanceInput(
@@ -523,42 +362,6 @@ func (d *dedicatedDBAdapter) bindDBToApp(i *RDSInstance, password string) (map[s
 	}
 	// If we get here that means the instance is up and we have the information for it.
 	return i.getCredentials(password)
-}
-
-// search out all the parameter groups that we created and try to clean them up
-func cleanupCustomParameterGroups(svc rdsiface.RDSAPI) {
-	input := &rds.DescribeDBParameterGroupsInput{}
-	err := svc.DescribeDBParameterGroupsPages(input,
-		func(pgroups *rds.DescribeDBParameterGroupsOutput, lastPage bool) bool {
-			// If the pgroup matches the prefix, then try to delete it.
-			// If it's in use, it will fail, so ignore that.
-			for _, pgroup := range pgroups.DBParameterGroups {
-				matched, err := regexp.Match("^"+PgroupPrefix, []byte(*pgroup.DBParameterGroupName))
-				if err != nil {
-					log.Printf("error trying to match %s in %s: %s", PgroupPrefix, *pgroup.DBParameterGroupName, err.Error())
-				}
-				if matched {
-					deleteinput := &rds.DeleteDBParameterGroupInput{
-						DBParameterGroupName: aws.String(*pgroup.DBParameterGroupName),
-					}
-					_, err := svc.DeleteDBParameterGroup(deleteinput)
-					if err == nil {
-						log.Printf("cleaned up %s parameter group", *pgroup.DBParameterGroupName)
-					} else if err.(awserr.Error).Code() != "InvalidDBParameterGroupState" {
-						// If you can't delete it because it's in use, that is fine.
-						// The db takes a while to delete, so we will clean it up the
-						// next time this is called.  Otherwise there is some sort of AWS error
-						// and we should log that.
-						log.Printf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err.Error())
-					}
-				}
-			}
-			return true
-		})
-	if err != nil {
-		log.Printf("Could not retrieve list of parameter groups while cleaning up: %s", err.Error())
-		return
-	}
 }
 
 func (d *dedicatedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error) {

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -19,7 +19,56 @@ func (m *mockParameterGroupAdapter) provisionCustomParameterGroupIfNecessary(i *
 	return m.customPgroupName, nil
 }
 
-func TestGetModifyDbInstanceInput(t *testing.T) {
+func TestPrepareCreateDbInstanceInput(t *testing.T) {
+	testErr := errors.New("fail")
+	testCases := map[string]struct {
+		dbInstance        *RDSInstance
+		dbAdapter         *dedicatedDBAdapter
+		pGroupAdapter     *mockParameterGroupAdapter
+		svc               *mockRDSClient
+		expectedGroupName string
+		expectedErr       error
+	}{
+		"expect returned group name": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "mysql",
+			},
+			dbAdapter: &dedicatedDBAdapter{},
+			pGroupAdapter: &mockParameterGroupAdapter{
+				customPgroupName: "foobar",
+			},
+			svc:               &mockRDSClient{},
+			expectedGroupName: "foobar",
+		},
+		"expect error": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "mysql",
+			},
+			dbAdapter: &dedicatedDBAdapter{},
+			pGroupAdapter: &mockParameterGroupAdapter{
+				returnErr: testErr,
+			},
+			svc:         &mockRDSClient{},
+			expectedErr: testErr,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			params, err := prepareCreateDbInput(test.dbInstance, test.dbAdapter, test.svc, "foobar", test.pGroupAdapter)
+			if err != nil && test.expectedErr == nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if test.expectedErr == nil && *params.DBParameterGroupName != test.expectedGroupName {
+				t.Fatalf("expected group name: %s, got: %s", test.expectedGroupName, *params.DBParameterGroupName)
+			}
+		})
+	}
+}
+
+func TestPrepareModifyDbInstanceInput(t *testing.T) {
 	testErr := errors.New("fail")
 	testCases := map[string]struct {
 		dbInstance        *RDSInstance
@@ -62,7 +111,7 @@ func TestGetModifyDbInstanceInput(t *testing.T) {
 				t.Errorf("unexpected error: %s", err)
 			}
 			if test.expectedErr == nil && *params.DBParameterGroupName != test.expectedGroupName {
-				t.Fatalf("expected group name: %s", test.expectedGroupName)
+				t.Fatalf("expected group name: %s, got: %s", test.expectedGroupName, *params.DBParameterGroupName)
 			}
 		})
 	}

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -2,29 +2,10 @@ package rds
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
-	"github.com/18F/aws-broker/config"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
-
-type mockRDSClient struct {
-	rdsiface.RDSAPI
-}
-
-func (m *mockRDSClient) DescribeDBParameters(*rds.DescribeDBParametersInput) (*rds.DescribeDBParametersOutput, error) {
-	return nil, nil
-}
-
-func (m *mockRDSClient) ModifyDBInstance(*rds.ModifyDBInstanceInput) (*rds.ModifyDBInstanceOutput, error) {
-	return nil, nil
-}
-
-func (m *mockRDSClient) ModifyDBParameterGroup(*rds.ModifyDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error) {
-	return nil, nil
-}
 
 type mockParameterGroupAdapter struct {
 	customPgroupName string
@@ -36,152 +17,6 @@ func (m *mockParameterGroupAdapter) provisionCustomParameterGroupIfNecessary(i *
 		return "", m.returnErr
 	}
 	return m.customPgroupName, nil
-}
-
-func TestNeedCustomParameters(t *testing.T) {
-	testCases := map[string]struct {
-		dbInstance *RDSInstance
-		settings   config.Settings
-		expectedOk bool
-	}{
-		"default": {
-			dbInstance: &RDSInstance{},
-			settings:   config.Settings{},
-			expectedOk: false,
-		},
-		"valid binary log format": {
-			dbInstance: &RDSInstance{
-				BinaryLogFormat: "ROW",
-				DbType:          "mysql",
-			},
-			settings:   config.Settings{},
-			expectedOk: true,
-		},
-		"valid binary log format, wrong database type": {
-			dbInstance: &RDSInstance{
-				BinaryLogFormat: "ROW",
-				DbType:          "psql",
-			},
-			settings:   config.Settings{},
-			expectedOk: false,
-		},
-		"instance functions enabled, settings disabled": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: true,
-				DbType:          "mysql",
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: false,
-			},
-			expectedOk: false,
-		},
-		"instance functions disabled, settings enabled": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: false,
-				DbType:          "mysql",
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: true,
-			},
-			expectedOk: false,
-		},
-		"instance functions enabled, settings enabled, wrong db type": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: true,
-				DbType:          "psql",
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: true,
-			},
-			expectedOk: false,
-		},
-		"instance functions enabled, settings enabled": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: true,
-				DbType:          "mysql",
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: true,
-			},
-			expectedOk: true,
-		},
-	}
-
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			if needCustomParameters(test.dbInstance, test.settings) != test.expectedOk {
-				t.Fatalf("should be %v", test.expectedOk)
-			}
-		})
-	}
-}
-
-func TestGetCustomParameters(t *testing.T) {
-	testCases := map[string]struct {
-		dbInstance     *RDSInstance
-		settings       config.Settings
-		expectedParams map[string]map[string]string
-	}{
-		"enabled functions": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: true,
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: true,
-			},
-			expectedParams: map[string]map[string]string{
-				"mysql": {
-					"log_bin_trust_function_creators": "1",
-				},
-			},
-		},
-		"instance functions disabled, settings enabled": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: false,
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: true,
-			},
-			expectedParams: map[string]map[string]string{
-				"mysql": {
-					"log_bin_trust_function_creators": "0",
-				},
-			},
-		},
-		"instance functions enabled, settings disabled": {
-			dbInstance: &RDSInstance{
-				EnableFunctions: true,
-			},
-			settings: config.Settings{
-				EnableFunctionsFeature: false,
-			},
-			expectedParams: map[string]map[string]string{
-				"mysql": {
-					"log_bin_trust_function_creators": "0",
-				},
-			},
-		},
-		"binary log format": {
-			dbInstance: &RDSInstance{
-				BinaryLogFormat: "ROW",
-			},
-			settings: config.Settings{},
-			expectedParams: map[string]map[string]string{
-				"mysql": {
-					"log_bin_trust_function_creators": "0",
-					"binlog_format":                   "ROW",
-				},
-			},
-		},
-	}
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			params := getCustomParameters(test.dbInstance, test.settings)
-			if !reflect.DeepEqual(params, test.expectedParams) {
-				t.Fatalf("expected %s, got: %s", test.expectedParams, params)
-			}
-		})
-	}
 }
 
 func TestGetModifyDbInstanceInput(t *testing.T) {
@@ -232,20 +67,3 @@ func TestGetModifyDbInstanceInput(t *testing.T) {
 		})
 	}
 }
-
-// func TestProvisionCustomParameterGroupIfNecessary(t *testing.T) {
-// 	i := &RDSInstance{
-// 		BinaryLogFormat: "ROW",
-// 		DbType:          "mysql",
-// 	}
-// 	d := &dedicatedDBAdapter{}
-// 	svc := &mockRDSClient{}
-
-// 	pGroupName, err := provisionCustomParameterGroupIfNecessary(i, svc)
-// 	if err != nil {
-// 		t.Errorf("unexpected error: %s", err)
-// 	}
-// 	if pGroupName == "" {
-// 		t.Fatalf("expected group name")
-// 	}
-// }

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -5,7 +5,26 @@ import (
 	"testing"
 
 	"github.com/18F/aws-broker/config"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
+
+type mockRDSClient struct {
+	rdsiface.RDSAPI
+}
+
+func (m *mockRDSClient) DescribeDBParameters(*rds.DescribeDBParametersInput) (*rds.DescribeDBParametersOutput, error) {
+	return nil, nil
+}
+
+func (m *mockRDSClient) ModifyDBInstance(*rds.ModifyDBInstanceInput) (*rds.ModifyDBInstanceOutput, error) {
+	return nil, nil
+}
+
+func (m *mockRDSClient) ModifyDBParameterGroup(*rds.ModifyDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error) {
+	return nil, nil
+}
 
 func TestNeedCustomParameters(t *testing.T) {
 	testCases := map[string]struct {
@@ -150,5 +169,24 @@ func TestGetCustomParameters(t *testing.T) {
 				t.Fatalf("expected %s, got: %s", test.expectedParams, params)
 			}
 		})
+	}
+}
+
+func TestGetModifyDbInstanceInput(t *testing.T) {
+	i := &RDSInstance{
+		BinaryLogFormat: "ROW",
+		DbType:          "mysql",
+	}
+	d := &dedicatedDBAdapter{}
+	svc := &mockRDSClient{}
+
+	params, err := getModifyDbInstanceInput(i, d, svc)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	// log := fmt.Sprintf("params: %s", params)
+	// fmt.Println(log)
+	if params.DBParameterGroupName == aws.String("") {
+		t.Fatalf("expected group name")
 	}
 }

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -57,7 +57,7 @@ func TestGetModifyDbInstanceInput(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			params, err := getModifyDbInstanceInput(test.dbInstance, test.dbAdapter, test.svc, test.pGroupAdapter)
+			params, err := prepareModifyDbInstanceInput(test.dbInstance, test.dbAdapter, test.svc, test.pGroupAdapter)
 			if err != nil && test.expectedErr == nil {
 				t.Errorf("unexpected error: %s", err)
 			}

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -1,0 +1,85 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/18F/aws-broker/config"
+)
+
+func TestNeedCustomParameters(t *testing.T) {
+	testCases := map[string]struct {
+		dbInstance *RDSInstance
+		settings   config.Settings
+		expectedOk bool
+	}{
+		"default": {
+			dbInstance: &RDSInstance{},
+			settings:   config.Settings{},
+			expectedOk: false,
+		},
+		"valid binary log format": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "mysql",
+			},
+			settings:   config.Settings{},
+			expectedOk: true,
+		},
+		"valid binary log format, wrong database type": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat: "ROW",
+				DbType:          "psql",
+			},
+			settings:   config.Settings{},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings disabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: false,
+			},
+			expectedOk: false,
+		},
+		"instance functions disabled, settings enabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: false,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings enabled, wrong db type": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "psql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: false,
+		},
+		"instance functions enabled, settings enabled": {
+			dbInstance: &RDSInstance{
+				EnableFunctions: true,
+				DbType:          "mysql",
+			},
+			settings: config.Settings{
+				EnableFunctionsFeature: true,
+			},
+			expectedOk: true,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if needCustomParameters(test.dbInstance, test.settings) != test.expectedOk {
+				t.Fatalf("should be %v", test.expectedOk)
+			}
+		})
+	}
+}

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -39,6 +39,8 @@ type RDSInstance struct {
 	DbType       string `sql:"size(255)"`
 	DbVersion    string `sql:"size(255)"`
 	LicenseModel string `sql:"size(255)"`
+
+	BinaryLogFormat string `sql:"size(255)"`
 }
 
 func (i *RDSInstance) FormatDBName() string {
@@ -177,6 +179,7 @@ func (i *RDSInstance) init(uuid string,
 	}
 	i.EnableFunctions = options.EnableFunctions
 	i.PubliclyAccessible = options.PubliclyAccessible
+	i.BinaryLogFormat = options.BinaryLogFormat
 
 	return nil
 }

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -1,0 +1,18 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/18F/aws-broker/helpers"
+)
+
+func TestFormatDBName(t *testing.T) {
+	i := RDSInstance{
+		Database: "db" + helpers.RandStrNoCaps(15),
+	}
+	dbName1 := i.FormatDBName()
+	dbName2 := i.FormatDBName()
+	if dbName1 != dbName2 {
+		t.Fatalf("database names should be the same")
+	}
+}

--- a/services/rds/util.go
+++ b/services/rds/util.go
@@ -1,0 +1,15 @@
+package rds
+
+import "fmt"
+
+func validateBinaryLogFormat(format string) error {
+	if format == "" {
+		return nil
+	}
+	switch format {
+	case "ROW", "STATEMENT", "MIXED":
+		return nil
+	default:
+		return fmt.Errorf("invalid binary log format %s", format)
+	}
+}

--- a/services/rds/util.go
+++ b/services/rds/util.go
@@ -3,9 +3,6 @@ package rds
 import "fmt"
 
 func validateBinaryLogFormat(format string) error {
-	if format == "" {
-		return nil
-	}
 	switch format {
 	case "ROW", "STATEMENT", "MIXED":
 		return nil

--- a/services/rds/util_test.go
+++ b/services/rds/util_test.go
@@ -2,34 +2,34 @@ package rds
 
 import (
 	"testing"
-
-	"github.com/18F/aws-broker/config"
 )
 
-func TestOptionsBinaryLogFormatValidation(t *testing.T) {
+func TestBinaryLogFormatValidation(t *testing.T) {
 	testCases := map[string]struct {
 		binaryLogFormat string
-		settings        *config.Settings
 		expectedErr     bool
 	}{
 		"invalid": {
 			binaryLogFormat: "foo",
-			settings:        &config.Settings{},
 			expectedErr:     true,
 		},
-		"row": {
+		"ROW": {
 			binaryLogFormat: "ROW",
-			settings:        &config.Settings{},
+			expectedErr:     false,
+		},
+		"STATEMENT": {
+			binaryLogFormat: "STATEMENT",
+			expectedErr:     false,
+		},
+		"MIXED": {
+			binaryLogFormat: "MIXED",
 			expectedErr:     false,
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			opts := Options{
-				BinaryLogFormat: test.binaryLogFormat,
-			}
-			err := opts.Validate(test.settings)
+			err := validateBinaryLogFormat(test.binaryLogFormat)
 			if test.expectedErr && err == nil {
 				t.Fatalf("expected error")
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR add support for setting the binary logging format via a customer parameter for RDS MySQL databases as specified in AWS documentation: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html

- Add BinaryLogFormat option to command line options
- Add BinaryLogFormat property to RDS instance struct
- Add unit tests

## Security considerations

None
