### PR TITLE
update size of internal db in dev to 20 GB

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       TF_VAR_aws_deploy_role_arn: ((development-aws-deploy-role-arn))
 
       TF_VAR_rds_internal_instance_type: db.t3.micro
-      TF_VAR_rds_internal_db_size: 10
+      TF_VAR_rds_internal_db_size: 20
       TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12


### PR DESCRIPTION
## Changes proposed in this pull request:

These changes to increase the storage from 10 GB to 20 GB for the internal database in dev were already applied, but never committed. We need these changes, otherwise the development deployment will fail when it tries to decrease the allocated storage from 20 GB to 10 GB.

## Security considerations

None
