### PR TITLE
Support enabling pg_cron extension

### DIFF
--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -25,6 +25,7 @@ type Options struct {
 	Version               string `json:"version"`
 	BackupRetentionPeriod int64  `json:"backup_retention_period"`
 	BinaryLogFormat       string `json:"binary_log_format"`
+	EnablePgCron          bool   `json:"enable_pg_cron"`
 }
 
 // Validate the custom parameters passed in via the "-c <JSON string or file>"

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -17,16 +17,6 @@ func TestOptionsBinaryLogFormatValidation(t *testing.T) {
 			settings:        &config.Settings{},
 			expectedErr:     true,
 		},
-		"ROW": {
-			binaryLogFormat: "ROW",
-			settings:        &config.Settings{},
-			expectedErr:     false,
-		},
-		"STATEMENT": {
-			binaryLogFormat: "STATEMENT",
-			settings:        &config.Settings{},
-			expectedErr:     false,
-		},
 		"MIXED": {
 			binaryLogFormat: "MIXED",
 			settings:        &config.Settings{},

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -13,10 +13,7 @@ import (
 )
 
 var (
-	needCustomParameters               = needCustomParametersFunc
-	getCustomParameters                = getCustomParametersFunc
-	createOrModifyCustomParameterGroup = createOrModifyCustomParameterGroupFunc
-	pGroupPrefix                       = pGroupPrefixReal
+	pGroupPrefix = pGroupPrefixReal
 )
 
 // PgroupPrefix is the prefix for all pgroups created by the broker.
@@ -81,7 +78,7 @@ func checkIfParameterGroupExists(pgroupName string, svc rdsiface.RDSAPI) bool {
 // This function will return the a custom parameter group with whatever custom
 // parameters have been requested.  If there is no custom parameter group, it
 // will be created.
-func createOrModifyCustomParameterGroupFunc(
+func createOrModifyCustomParameterGroup(
 	i *RDSInstance,
 	customparams map[string]map[string]string,
 	svc rdsiface.RDSAPI,
@@ -135,7 +132,7 @@ func createOrModifyCustomParameterGroupFunc(
 }
 
 // This is here because the check is kinda big and ugly
-func needCustomParametersFunc(i *RDSInstance, s config.Settings) bool {
+func needCustomParameters(i *RDSInstance, s config.Settings) bool {
 	// Currently, we only have one custom parameter for mysql, but if
 	// we ever need to apply more, you can add them in here.
 	if i.EnableFunctions &&
@@ -150,7 +147,7 @@ func needCustomParametersFunc(i *RDSInstance, s config.Settings) bool {
 	return false
 }
 
-func getCustomParametersFunc(i *RDSInstance, s config.Settings) map[string]map[string]string {
+func getCustomParameters(i *RDSInstance, s config.Settings) map[string]map[string]string {
 	customRDSParameters := make(map[string]map[string]string)
 
 	// enable functions
@@ -179,14 +176,13 @@ func (p *parameterGroupAdapter) provisionCustomParameterGroupIfNecessary(
 	if !needCustomParameters(i, d.settings) {
 		return "", nil
 	}
-
 	customRDSParameters := getCustomParameters(i, d.settings)
 
 	// apply parameter group
 	pgroupName, err := createOrModifyCustomParameterGroup(i, customRDSParameters, svc)
 	if err != nil {
 		log.Println(err.Error())
-		return "", err
+		return "", fmt.Errorf("encountered error applying parameter group: %w", err)
 	}
 	return pgroupName, nil
 }

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -162,8 +162,6 @@ func getDefaultEngineParameter(paramName string, i *RDSInstance, svc rdsiface.RD
 		MaxRecords:             aws.Int64(100),
 	}
 	for {
-		fmt.Println("here")
-		fmt.Println(describeEngDefaultParamsInput)
 		result, err := svc.DescribeEngineDefaultParameters(describeEngDefaultParamsInput)
 		if err != nil {
 			return "", err

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -63,6 +63,22 @@ func getParameterGroupFamily(
 	return pgroupFamily, nil
 }
 
+func checkIfParameterGroupExists(pgroupName string, svc rdsiface.RDSAPI) bool {
+	dbParametersInput := &rds.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String(pgroupName),
+		MaxRecords:           aws.Int64(20),
+		Source:               aws.String("system"),
+	}
+
+	// If the db parameter group has already been created, we can return.
+	_, err := svc.DescribeDBParameters(dbParametersInput)
+	parameterGroupExists := (err == nil)
+	if parameterGroupExists {
+		log.Printf("%s parameter group already exists", pgroupName)
+	}
+	return parameterGroupExists
+}
+
 // This function will return the a custom parameter group with whatever custom
 // parameters have been requested.  If there is no custom parameter group, it
 // will be created.

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -144,6 +144,10 @@ func needCustomParameters(i *RDSInstance, s config.Settings) bool {
 		(i.DbType == "mysql") {
 		return true
 	}
+	if i.EnablePgCron &&
+		(i.DbType == "postgres") {
+		return true
+	}
 	return false
 }
 

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -19,6 +19,7 @@ var (
 
 // PgroupPrefix is the prefix for all pgroups created by the broker.
 const pGroupPrefixReal = "cg-aws-broker-"
+const pgCronLibraryName = "pg_cron"
 
 type parameterGroupAdapterInterface interface {
 	provisionCustomParameterGroupIfNecessary(
@@ -226,7 +227,7 @@ func getCustomParameters(
 	if i.DbType == "postgres" {
 		customRDSParameters["postgres"] = make(map[string]string)
 		if i.EnablePgCron {
-			preloadLibrariesParam, err := buildCustomSharePreloadLibrariesParam(i, "pg-cron", svc)
+			preloadLibrariesParam, err := buildCustomSharePreloadLibrariesParam(i, pgCronLibraryName, svc)
 			if err != nil {
 				return nil, err
 			}

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -465,7 +465,7 @@ func TestGetCustomParameters(t *testing.T) {
 			settings: config.Settings{},
 			expectedParams: map[string]map[string]string{
 				"postgres": {
-					"shared_preload_libraries": "pg-cron",
+					"shared_preload_libraries": "pg_cron",
 				},
 			},
 			describeEngineDefaultParamsResults: []*rds.DescribeEngineDefaultParametersOutput{

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -406,6 +406,7 @@ func TestGetCustomParameters(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
+			describeEngineCallNum = 0
 			params, err := getCustomParameters(test.dbInstance, test.settings, &mockRDSClient{
 				describeEngineDefaultParamsResults: test.describeEngineDefaultParamsResults,
 			})

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -121,6 +121,13 @@ func TestNeedCustomParameters(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		"enable PG cron": {
+			dbInstance: &RDSInstance{
+				EnablePgCron: true,
+				DbType:       "postgres",
+			},
+			expectedOk: true,
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -41,6 +41,7 @@ type RDSInstance struct {
 	LicenseModel string `sql:"size(255)"`
 
 	BinaryLogFormat string `sql:"size(255)"`
+	EnablePgCron    bool   `sql:"-"`
 }
 
 func (i *RDSInstance) FormatDBName() string {
@@ -180,6 +181,7 @@ func (i *RDSInstance) init(uuid string,
 	i.EnableFunctions = options.EnableFunctions
 	i.PubliclyAccessible = options.PubliclyAccessible
 	i.BinaryLogFormat = options.BinaryLogFormat
+	i.EnablePgCron = options.EnablePgCron
 
 	return nil
 }

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -41,7 +41,7 @@ type RDSInstance struct {
 	LicenseModel string `sql:"size(255)"`
 
 	BinaryLogFormat      string `sql:"size(255)"`
-	EnablePgCron         bool   `sql:"-"`
+	EnablePgCron         bool   `sql:"size(255)"`
 	ParameterGroupFamily string `sql:"-"`
 }
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -40,8 +40,9 @@ type RDSInstance struct {
 	DbVersion    string `sql:"size(255)"`
 	LicenseModel string `sql:"size(255)"`
 
-	BinaryLogFormat string `sql:"size(255)"`
-	EnablePgCron    bool   `sql:"-"`
+	BinaryLogFormat      string `sql:"size(255)"`
+	EnablePgCron         bool   `sql:"-"`
+	ParameterGroupFamily string `sql:"-"`
 }
 
 func (i *RDSInstance) FormatDBName() string {


### PR DESCRIPTION
Related to #270 

## Changes proposed in this pull request:

- Add field to RDS instance model for PG cron enabled status
- Add option for enabling PG cron
- Add logic to detect default value for `shared_preload_libraries` parameter so that it is not overridden when custom `pg_cron` library is specified
- Refactor code
- Add/update unit tests

## Security considerations

None
