### PR TITLE
Fix parameter group family logic

### DIFF
--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -226,7 +226,7 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 	if count == 0 {
 		return response.NewErrorResponse(http.StatusNotFound, "The instance does not exist.")
 	}
-	fmt.Printf("modified instance: %+v\n", existingInstance)
+	fmt.Printf("existing instance: %+v\n", existingInstance)
 
 	options, err := broker.parseModifyOptionsFromRequest(modifyRequest)
 	if err != nil {
@@ -234,17 +234,17 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 	}
 	fmt.Printf("options: %+v\n", options)
 
-	err = existingInstance.modifyFromOptions(options)
-	if err != nil {
-		return response.NewErrorResponse(http.StatusBadRequest, "Invalid parameters. Error: "+err.Error())
-	}
-	fmt.Printf("modified instance: %+v\n", existingInstance)
-
 	// Fetch the new plan that has been requested.
 	newPlan, newPlanErr := c.RdsService.FetchPlan(modifyRequest.PlanID)
 	if newPlanErr != nil {
 		return newPlanErr
 	}
+
+	err = existingInstance.modify(options, newPlan)
+	if err != nil {
+		return response.NewErrorResponse(http.StatusBadRequest, "Invalid parameters. Error: "+err.Error())
+	}
+	fmt.Printf("modified instance: %+v\n", existingInstance)
 
 	// Check to make sure that we're not switching database engines; this is not
 	// allowed.

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -36,13 +36,13 @@ func (m mockRDSClient) DescribeDBParameters(*rds.DescribeDBParametersInput) (*rd
 }
 
 func (m mockRDSClient) DescribeDBEngineVersions(*rds.DescribeDBEngineVersionsInput) (*rds.DescribeDBEngineVersionsOutput, error) {
+	if m.describeEngVersionsErr != nil {
+		return nil, m.describeEngVersionsErr
+	}
 	if m.dbEngineVersions != nil {
 		return &rds.DescribeDBEngineVersionsOutput{
 			DBEngineVersions: m.dbEngineVersions,
 		}, nil
-	}
-	if m.describeEngVersionsErr != nil {
-		return nil, m.describeEngVersionsErr
 	}
 	return nil, nil
 }
@@ -296,6 +296,11 @@ func TestGetDefaultEngineParameterValue(t *testing.T) {
 							},
 						},
 					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 					describeEngineDefaultParamsNumPages: 1,
 				},
 			},
@@ -321,6 +326,11 @@ func TestGetDefaultEngineParameterValue(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
 						},
 					},
 					describeEngineDefaultParamsNumPages: 1,
@@ -360,6 +370,11 @@ func TestGetDefaultEngineParameterValue(t *testing.T) {
 							},
 						},
 					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 					describeEngineDefaultParamsNumPages: 2,
 				},
 			},
@@ -378,6 +393,11 @@ func TestGetDefaultEngineParameterValue(t *testing.T) {
 			parameterGroupAdapter: &awsParameterGroupClient{
 				rds: &mockRDSClient{
 					describeEngineDefaultParamsErr: describeEngineDefaultParamsErr,
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 				},
 			},
 		},
@@ -385,6 +405,7 @@ func TestGetDefaultEngineParameterValue(t *testing.T) {
 			dbInstance: &RDSInstance{
 				EnablePgCron: aws.Bool(true),
 				DbType:       "postgres",
+				DbVersion:    "12",
 			},
 			paramName:          "shared_preload_libraries",
 			expectedErr:        describeEngVersionsErr,
@@ -775,6 +796,11 @@ func TestGetCustomParameters(t *testing.T) {
 							},
 						},
 					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 					describeEngineDefaultParamsNumPages: 1,
 				},
 			},
@@ -845,6 +871,11 @@ func TestGetCustomParameters(t *testing.T) {
 							},
 						},
 					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 					describeEngineDefaultParamsNumPages: 2,
 				},
 			},
@@ -893,6 +924,11 @@ func TestGetCustomParameters(t *testing.T) {
 				settings: config.Settings{},
 				rds: &mockRDSClient{
 					describeEngineDefaultParamsErr: describeEngineParamsErr,
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 				},
 			},
 		},
@@ -924,6 +960,11 @@ func TestGetCustomParameters(t *testing.T) {
 				settings: config.Settings{},
 				rds: &mockRDSClient{
 					describeEngineDefaultParamsErr: describeEngineParamsErr,
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 				},
 			},
 		},
@@ -1084,6 +1125,7 @@ func TestCreateOrModifyCustomParameterGroup(t *testing.T) {
 				Database:           "foobar",
 				DbType:             "postgres",
 				ParameterGroupName: "foobar",
+				DbVersion:          "12",
 			},
 			expectedErr: describeEngVersionsErr,
 			parameterGroupAdapter: &awsParameterGroupClient{
@@ -1105,6 +1147,11 @@ func TestCreateOrModifyCustomParameterGroup(t *testing.T) {
 				rds: &mockRDSClient{
 					describeDbParamsErr:   errors.New("describe DB params err"),
 					createDbParamGroupErr: createDbParamGroupErr,
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 				},
 			},
 		},
@@ -1119,6 +1166,11 @@ func TestCreateOrModifyCustomParameterGroup(t *testing.T) {
 			parameterGroupAdapter: &awsParameterGroupClient{
 				rds: &mockRDSClient{
 					modifyDbParamGroupErr: modifyDbParamGroupErr,
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
 				},
 			},
 		},
@@ -1130,7 +1182,13 @@ func TestCreateOrModifyCustomParameterGroup(t *testing.T) {
 				ParameterGroupName: "foobar",
 			},
 			parameterGroupAdapter: &awsParameterGroupClient{
-				rds: &mockRDSClient{},
+				rds: &mockRDSClient{
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1198,6 +1256,11 @@ func TestProvisionCustomParameterGroupIfNecessary(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+					dbEngineVersions: []*rds.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("postgres12"),
 						},
 					},
 					describeEngineDefaultParamsNumPages: 1,

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -120,7 +120,7 @@ func (i *RDSInstance) getCredentials(password string) (map[string]string, error)
 	return credentials, nil
 }
 
-func (i *RDSInstance) modifyFromOptions(options Options) error {
+func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan) error {
 	// Check to see if there is a storage size change and if so, check to make sure it's a valid change.
 	if options.AllocatedStorage > 0 {
 		// Check that we are not decreasing the size of the instance.
@@ -144,6 +144,13 @@ func (i *RDSInstance) modifyFromOptions(options Options) error {
 
 	if options.EnablePgCron != i.EnablePgCron {
 		i.EnablePgCron = options.EnablePgCron
+	}
+
+	// Set the DB Version if it is not already set
+	// Currently only supported for MySQL and PostgreSQL instances.
+	if i.DbVersion == "" && options.Version != "" {
+		// Default to the version provided by the plan chosen in catalog.
+		i.DbVersion = plan.DbVersion
 	}
 
 	return nil

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -148,7 +148,7 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan) error {
 
 	// Set the DB Version if it is not already set
 	// Currently only supported for MySQL and PostgreSQL instances.
-	if i.DbVersion == "" && options.Version != "" {
+	if i.DbVersion == "" && options.Version == "" {
 		// Default to the version provided by the plan chosen in catalog.
 		i.DbVersion = plan.DbVersion
 	}

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -123,6 +123,16 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{},
 			plan:             catalog.RDSPlan{},
 		},
+		"set DB version from plan": {
+			options:          Options{},
+			existingInstance: &RDSInstance{},
+			expectedInstance: &RDSInstance{
+				DbVersion: "12",
+			},
+			plan: catalog.RDSPlan{
+				DbVersion: "12",
+			},
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/18F/aws-broker/catalog"
 	"github.com/18F/aws-broker/helpers"
 	"github.com/aws/aws-sdk-go/aws"
 )
@@ -19,12 +20,13 @@ func TestFormatDBName(t *testing.T) {
 	}
 }
 
-func TestModifyInstanceFromOptions(t *testing.T) {
+func TestModifyInstance(t *testing.T) {
 	testCases := map[string]struct {
 		options          Options
 		existingInstance *RDSInstance
 		expectedInstance *RDSInstance
 		expectErr        bool
+		plan             catalog.RDSPlan
 	}{
 		"update allocated storage": {
 			options: Options{
@@ -36,6 +38,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"allocated storage option less than existing, does not update": {
 			options: Options{
@@ -48,6 +51,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 				AllocatedStorage: 20,
 			},
 			expectErr: true,
+			plan:      catalog.RDSPlan{},
 		},
 		"allocated storage empty, does not update": {
 			options: Options{
@@ -59,6 +63,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"update backup retention period": {
 			options: Options{
@@ -70,6 +75,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"does not update backup retention period": {
 			options: Options{
@@ -81,6 +87,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"update binary log format": {
 			options: Options{
@@ -90,6 +97,7 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BinaryLogFormat: "ROW",
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"enable PG cron": {
 			options: Options{
@@ -99,11 +107,13 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				EnablePgCron: aws.Bool(true),
 			},
+			plan: catalog.RDSPlan{},
 		},
 		"enable PG cron not specified": {
 			options:          Options{},
 			existingInstance: &RDSInstance{},
 			expectedInstance: &RDSInstance{},
+			plan:             catalog.RDSPlan{},
 		},
 		"enable PG cron not specified on options, true on existing instance": {
 			options: Options{},
@@ -111,12 +121,13 @@ func TestModifyInstanceFromOptions(t *testing.T) {
 				EnablePgCron: aws.Bool(true),
 			},
 			expectedInstance: &RDSInstance{},
+			plan:             catalog.RDSPlan{},
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := test.existingInstance.modifyFromOptions(test.options)
+			err := test.existingInstance.modify(test.options, test.plan)
 			if !test.expectErr && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Ensure that a `DbVersion` is always set on the `RDSInstance` struct when updating a database service
- Update logic for determining parameter group family to always call `DescribeDBEngineVersions` with an `Engine` and `EngineVersion`, which should always produce a consistent result
- Remove logic that generates the parameter group family by concatenating the `DbType` and `DbVersion`. While this pattern works for MySQL and PostgreSQL for the available database versions, there is no guarantee it will continue to work in the future

Overall, these changes work to address a bug where the wrong parameter group family was being returned for a database that didn't have a `DbVersion` set

Closes #282 

## Security considerations

No change to the broker's boundary or permissions, just updating broker logic
