### PR TITLE
remove line printing options to logs

### DIFF
--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -231,7 +231,6 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 	if err != nil {
 		return response.NewErrorResponse(http.StatusBadRequest, "Invalid parameters. Error: "+err.Error())
 	}
-	fmt.Printf("options: %+v\n", options)
 
 	// Fetch the new plan that has been requested.
 	newPlan, newPlanErr := c.RdsService.FetchPlan(modifyRequest.PlanID)


### PR DESCRIPTION
## Changes proposed in this pull request:

This line is only useful for debugging and adds unnecessary noise to logs

## Security considerations

It's better not to print logs unless we truly need them to minimize the risk of accidental exposure
