### PR TITLE
update elasticsearch service access policy creation

### DIFF
--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -114,7 +114,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		UserName: aws.String(i.Domain),
 	}
 	userResp, _ := iamsvc.GetUser(userParams)
-	uniqueUser := *(userResp.User.UserId)
+	uniqueUserArn := *(userResp.User.Arn)
 	stsInput := &sts.GetCallerIdentityInput{}
 	result, err := stssvc.GetCallerIdentity(stsInput)
 	if err != nil {
@@ -133,7 +133,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 
 	accountID := result.Account
 
-	accessControlPolicy := "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"AWS\": [\"" + uniqueUser + "\"]},\"Action\": \"es:*\",\"Resource\": \"arn:aws-us-gov:es:" + d.settings.Region + ":" + *accountID + ":domain/" + i.Domain + "/*\"}]}"
+	accessControlPolicy := "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"AWS\": [\"" + uniqueUserArn + "\"]},\"Action\": \"es:*\",\"Resource\": \"arn:aws-us-gov:es:" + d.settings.Region + ":" + *accountID + ":domain/" + i.Domain + "/*\"}]}"
 	var elasticsearchTags []*opensearchservice.Tag
 	time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update elasticsearch service creation code to use ARN instead of UserID for IAM user when creating access policy

## Security considerations

There should be no security consequence to using an ARN vs a User ID for an IAM user to specify the principal in an access policy:

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids