### PR TITLE
Update Go version

### DIFF
--- a/ci/run_tests.yml
+++ b/ci/run_tests.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.18
+    tag: 1.20
 
 inputs:
 - name: aws-broker-app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/18F/aws-broker
 
-go 1.18
+go 1.20
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,5 @@ applications:
   buildpack: go_buildpack
   memory: 256M
   env:
-    GOVERSION: go1.18
+    GOVERSION: go1.20
     


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update Go version from 1.18 to 1.20 because latest buildpacks only support Go 1.19+: https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.10.8

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
