### PR TITLE
add quotes around docker image version

### DIFF
--- a/ci/run_tests.yml
+++ b/ci/run_tests.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20
+    tag: "1.20"
 
 inputs:
 - name: aws-broker-app


### PR DESCRIPTION
## Changes proposed in this pull request:

- add quotes around docker image version so that Concourse recognizes the correct version

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
