### PR TITLE
Expanding elasticsearch to use 2 new subnets

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1312,6 +1312,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1345,6 +1347,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1381,6 +1385,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1417,6 +1423,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1453,6 +1461,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1489,6 +1499,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1525,6 +1537,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1561,6 +1575,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1597,6 +1613,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1633,6 +1651,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1669,6 +1689,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1705,6 +1727,8 @@ elasticsearch:
     securityGroup: (( grab meta.elasticsearch.security_group ))
     subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
     subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
+    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
+    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -40,6 +40,8 @@ elasticsearch:
     securityGroup: sec-group
     subnetIDaz1: subnet-1
     subnetIDaz2: subnet-2
+    subnetIDaz3: subnet-3
+    subnetIDaz4: subnet-4
     tags:
       environment: "cf-env-dev"
       client: "the client"
@@ -67,6 +69,8 @@ elasticsearch:
     securityGroup: sec-group
     subnetIDaz1: subnet-1
     subnetIDaz2: subnet-2
+    subnetIDaz3: subnet-3
+    subnetIDaz4: subnet-4
     tags:
       environment: "cf-env-dev"
       client: "the client"

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -200,6 +200,8 @@ type ElasticsearchPlan struct {
 	AutomatedSnapshotStartHour string            `yaml:"automatedSnapshotStartHour" json:"-"`
 	SubnetIDAZ1                string            `yaml:"subnetIDaz1" json:"-" validate:"required"`
 	SubnetIDAZ2                string            `yaml:"subnetIDaz2" json:"-" validate:"required"`
+	SubnetIDAZ3                string            `yaml:"subnetIDaz3" json:"-" validate:"required"`
+	SubnetIDAZ4                string            `yaml:"subnetIDaz4" json:"-" validate:"required"`
 	SecurityGroup              string            `yaml:"securityGroup" json:"-" validate:"required"`
 	ApprovedMajorVersions     []string           `yaml:"approvedMajorVersions" json:"-"`
 }

--- a/ci/build-manifest.sh
+++ b/ci/build-manifest.sh
@@ -47,6 +47,9 @@ meta:
   elasticsearch:
     subnet_id_az1: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az1`
     subnet_id_az2: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az2`
+    subnet_id_az3: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az3`
+    subnet_id_az4: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az4`
+
     security_group: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_security_group`
 EOF
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -214,7 +214,8 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		})
 	} else {
 		VPCOptions.SetSubnetIds([]*string{
-			&i.SubnetIDAZ1,
+			&i.SubnetIDAZ3,
+			&i.SubnetIDAZ4,
 		})
 	}
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -209,6 +209,8 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		VPCOptions.SetSubnetIds([]*string{
 			&i.SubnetIDAZ1,
 			&i.SubnetIDAZ2,
+			&i.SubnetIDAZ3,
+			&i.SubnetIDAZ4,
 		})
 	} else {
 		VPCOptions.SetSubnetIds([]*string{

--- a/services/elasticsearch/elasticsearchinstance.go
+++ b/services/elasticsearch/elasticsearchinstance.go
@@ -57,6 +57,8 @@ type ElasticsearchInstance struct {
 	Tags        map[string]string `sql:"-"`
 	SubnetIDAZ1 string            `sql:"-"`
 	SubnetIDAZ2 string            `sql:"-"`
+	SubnetIDAZ3 string            `sql:"-"`
+	SubnetIDAZ4 string            `sql:"-"`
 	SecGroup    string            `sql:"-"`
 }
 
@@ -165,6 +167,8 @@ func (i *ElasticsearchInstance) init(uuid string,
 	i.SecGroup = plan.SecurityGroup
 	i.SubnetIDAZ1 = plan.SubnetIDAZ1
 	i.SubnetIDAZ2 = plan.SubnetIDAZ2
+	i.SubnetIDAZ3 = plan.SubnetIDAZ3
+	i.SubnetIDAZ4 = plan.SubnetIDAZ4
 	i.IndicesFieldDataCacheSize = options.AdvancedOptions.IndicesFieldDataCacheSize
 	i.IndicesQueryBoolMaxClauseCount = options.AdvancedOptions.IndicesQueryBoolMaxClauseCount
 	i.SnapshotPath = "/" + i.OrganizationGUID + "/" + i.SpaceGUID + "/" + i.ServiceID + "/" + i.Uuid


### PR DESCRIPTION
## Changes proposed in this pull request:

- Expanding elasticsearch to use 2 new (larger) subnets as the number of service instances has increased
- Moving the dev instances to use the two new AZs/subnets as a poor-mans rebalance of ips
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Just expanding to use more ips, should not be impacting the security posture
