### PR TITLE
Switch dev elasticsearch back to single but different az

### DIFF
--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -215,7 +215,6 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 	} else {
 		VPCOptions.SetSubnetIds([]*string{
 			&i.SubnetIDAZ3,
-			&i.SubnetIDAZ4,
 		})
 	}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switch dev elasticsearch back to single but different az
- Broker otherwise fails with multiple azs listed
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
