### PR TITLE
remove MySQL 5.7 as supported version in the broker

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -613,7 +613,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -648,7 +647,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -683,7 +681,6 @@ rds:
       instanceClass: db.t2.small
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -718,7 +715,6 @@ rds:
       instanceClass: db.t2.small
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbType: mysql
       dbVersion: "8.0"
@@ -753,7 +749,6 @@ rds:
       instanceClass: db.t2.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -788,7 +783,6 @@ rds:
       instanceClass: db.t2.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -823,7 +817,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -858,7 +851,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -893,7 +885,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -928,7 +919,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -963,7 +953,6 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -998,7 +987,6 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "5.7"
         - "8.0"
       dbVersion: "8.0"
       dbType: mysql
@@ -1300,7 +1288,7 @@ elasticsearch:
     free: false
     elasticsearchVersion: Elasticsearch_6.8
     approvedMajorVersions:
-    - "Opensearch_2.3" 
+    - "Opensearch_2.3"
     - "Opensearch_1.3"
     - "Elasticsearch_7.4"
     dataCount: 1


### PR DESCRIPTION
Related to https://github.com/cloud-gov/aws-broker/issues/302

## Changes proposed in this pull request:

- remove MySQL 5.7 as supported version in the broker given impending AWS deprecation

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
