### PR TITLE
add quotes to version 8.0 in pipeline YAML

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -409,7 +409,7 @@ jobs:
           CF_SPACE: ((development-cf-space))
           SERVICE_PLAN: small-mysql
           DB_TYPE: mysql
-          DB_VERSION: 8.0
+          DB_VERSION: "8.0"
 
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
@@ -575,7 +575,7 @@ jobs:
           CF_SPACE: ((staging-cf-space))
           SERVICE_PLAN: small-mysql
           DB_TYPE: mysql
-          DB_VERSION: 8.0
+          DB_VERSION: "8.0"
 
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -1284,7 +1284,7 @@ jobs:
           CF_SPACE: ((prod-cf-space))
           SERVICE_PLAN: small-mysql
           DB_TYPE: mysql
-          DB_VERSION: 8.0
+          DB_VERSION: "8.0"
 
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- add quotes to version 8.0 in pipeline YAML 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
