### PR TITLE
Fix es deletion

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -10,15 +10,16 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
 
 type IAMUser struct {
-	iamsvc *iam.IAM
+	iamsvc iamiface.IAMAPI
 	logger lager.Logger
 }
 
 func NewIAMUser(
-	iamsvc *iam.IAM,
+	iamsvc iamiface.IAMAPI,
 	logger lager.Logger,
 ) *IAMUser {
 	return &IAMUser{

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -37,7 +37,7 @@ var _ = Describe("IAM User", func() {
 	})
 
 	JustBeforeEach(func() {
-		awsSession = session.New(nil)
+		awsSession, _ = session.NewSession()
 		iamsvc = iam.New(awsSession)
 
 		logger = lager.NewLogger("iamuser_test")
@@ -244,10 +244,10 @@ var _ = Describe("IAM User", func() {
 
 		BeforeEach(func() {
 			listAccessKeysMetadata = []*iam.AccessKeyMetadata{
-				&iam.AccessKeyMetadata{
+				{
 					AccessKeyId: aws.String("access-key-id-1"),
 				},
-				&iam.AccessKeyMetadata{
+				{
 					AccessKeyId: aws.String("access-key-id-2"),
 				},
 			}
@@ -423,100 +423,6 @@ var _ = Describe("IAM User", func() {
 
 				It("returns the proper error", func() {
 					err := user.DeleteAccessKey(userName, accessKeyID)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("code: message"))
-				})
-			})
-		})
-	})
-
-	var _ = Describe("CreatePolicy", func() {
-		var (
-			policyName string
-			template   string
-			resources  []string
-
-			createPolicy *iam.Policy
-
-			createPolicyInput *iam.CreatePolicyInput
-			createPolicyError error
-		)
-
-		BeforeEach(func() {
-			policyName = "policy-name"
-			template = `{
-	"Version": "2012-10-17",
-	"Id": "policy-name",
-	"Statement": [
-		{
-			"Effect": "effect",
-			"Action": "action",
-			"Resource": {{resources "/*"}}
-		}
-	]
-}`
-			resources = []string{"resource"}
-
-			createPolicy = &iam.Policy{
-				Arn: aws.String("policy-arn"),
-			}
-
-			createPolicyInput = &iam.CreatePolicyInput{
-				Path:       aws.String(iamPath),
-				PolicyName: aws.String(policyName),
-				PolicyDocument: aws.String(`{
-	"Version": "2012-10-17",
-	"Id": "policy-name",
-	"Statement": [
-		{
-			"Effect": "effect",
-			"Action": "action",
-			"Resource": ["resource/*"]
-		}
-	]
-}`),
-			}
-			createPolicyError = nil
-		})
-
-		JustBeforeEach(func() {
-			iamsvc.Handlers.Clear()
-
-			iamCall = func(r *request.Request) {
-				Expect(r.Operation.Name).To(Equal("CreatePolicy"))
-				Expect(r.Params).To(BeAssignableToTypeOf(&iam.CreatePolicyInput{}))
-				Expect(*r.Params.(*iam.CreatePolicyInput).PolicyDocument).To(MatchJSON(*createPolicyInput.PolicyDocument))
-				data := r.Data.(*iam.CreatePolicyOutput)
-				data.Policy = createPolicy
-				r.Error = createPolicyError
-			}
-			iamsvc.Handlers.Send.PushBack(iamCall)
-		})
-
-		It("creates the Access Key", func() {
-			policyARN, err := user.CreatePolicy(policyName, iamPath, template, resources)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(policyARN).To(Equal("policy-arn"))
-		})
-
-		Context("when creating the Policy fails", func() {
-			BeforeEach(func() {
-				createPolicyError = errors.New("operation failed")
-			})
-
-			It("returns the proper error", func() {
-				_, err := user.CreatePolicy(policyName, iamPath, template, resources)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("operation failed"))
-			})
-
-			Context("and it is an AWS error", func() {
-				BeforeEach(func() {
-					createPolicyError = awserr.New("code", "message", errors.New("operation failed"))
-				})
-
-				It("returns the proper error", func() {
-					_, err := user.CreatePolicy(policyName, iamPath, template, resources)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("code: message"))
 				})

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -6,7 +6,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cloudfoundry-community/s3-broker/awsiam"
+	// . "github.com/cloudfoundry-community/s3-broker/awsiam"
+	. "github.com/18F/aws-broker/awsiam"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
@@ -15,7 +16,41 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
+
+type mockIAMClient struct {
+	iamiface.IAMAPI
+
+	listPolicyVersionsOutput iam.ListPolicyVersionsOutput
+	listPolicyVersionsErr    error
+
+	deletePolicyOutput iam.DeletePolicyOutput
+	deletePolicyErr    error
+
+	deletePolicyVersionOutput  iam.DeletePolicyVersionOutput
+	deletePolicyVersionErr     error
+	deletedPolicyVersionInputs []*iam.DeletePolicyVersionInput
+}
+
+func (m *mockIAMClient) ListPolicyVersions(input *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error) {
+	return &m.listPolicyVersionsOutput, m.listPolicyVersionsErr
+}
+
+func (m *mockIAMClient) DeletePolicyVersion(input *iam.DeletePolicyVersionInput) (
+	*iam.DeletePolicyVersionOutput,
+	error,
+) {
+	if m.deletePolicyVersionErr != nil {
+		return nil, m.deletePolicyVersionErr
+	}
+	m.deletedPolicyVersionInputs = append(m.deletedPolicyVersionInputs, input)
+	return &m.deletePolicyVersionOutput, nil
+}
+
+func (m *mockIAMClient) DeletePolicy(input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
+	return &m.deletePolicyOutput, m.deletePolicyErr
+}
 
 var _ = Describe("IAM User", func() {
 	var (
@@ -546,10 +581,12 @@ var _ = Describe("IAM User", func() {
 			iamsvc.Handlers.Clear()
 
 			iamCall = func(r *request.Request) {
-				Expect(r.Operation.Name).To(Equal("DeletePolicy"))
-				Expect(r.Params).To(BeAssignableToTypeOf(&iam.DeletePolicyInput{}))
-				Expect(r.Params).To(Equal(deletePolicyInput))
-				r.Error = deletePolicyError
+				Expect(r.Operation.Name).To(BeElementOf([]string{"DeletePolicy", "ListPolicyVersions"}))
+				if r.Operation.Name == "DeletePolicy" {
+					Expect(r.Params).To(BeAssignableToTypeOf(&iam.DeletePolicyInput{}))
+					Expect(r.Params).To(Equal(deletePolicyInput))
+					r.Error = deletePolicyError
+				}
 			}
 			iamsvc.Handlers.Send.PushBack(iamCall)
 		})
@@ -557,6 +594,51 @@ var _ = Describe("IAM User", func() {
 		It("deletes the Policy", func() {
 			err := user.DeletePolicy(policyARN)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when there are policy versions", func() {
+			var (
+				fakeIAMClient     mockIAMClient
+				fakeIAMUserClient *IAMUser
+			)
+
+			BeforeEach(func() {
+				policyARN = "policy-arn2"
+			})
+
+			It("deletes the policy versions", func() {
+				err := fakeIAMUserClient.DeletePolicy(policyARN)
+				fakeIAMClient = mockIAMClient{
+					listPolicyVersionsOutput: iam.ListPolicyVersionsOutput{
+						Versions: []*iam.PolicyVersion{
+							{VersionId: aws.String("1"), IsDefaultVersion: aws.Bool(true)},
+							{VersionId: aws.String("2"), IsDefaultVersion: aws.Bool(false)},
+						},
+					},
+				}
+				fakeIAMUserClient = NewIAMUser(&fakeIAMClient, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeIAMClient.deletedPolicyVersionInputs).To(Equal([]*iam.DeletePolicyVersionInput{
+					{
+						VersionId: aws.String("2"),
+						PolicyArn: &policyARN,
+					},
+				}))
+			})
+
+			It("returns delete policy error", func() {
+				err := fakeIAMUserClient.DeletePolicy(policyARN)
+				fakeIAMClient = mockIAMClient{
+					listPolicyVersionsOutput: iam.ListPolicyVersionsOutput{
+						Versions: []*iam.PolicyVersion{
+							{VersionId: aws.String("1"), IsDefaultVersion: aws.Bool(true)},
+							{VersionId: aws.String("2"), IsDefaultVersion: aws.Bool(false)},
+						},
+					},
+				}
+				fakeIAMUserClient = NewIAMUser(&fakeIAMClient, logger)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 
 		Context("when deleting the Policy fails", func() {

--- a/awsiam/user.go
+++ b/awsiam/user.go
@@ -12,7 +12,6 @@ type User interface {
 	CreateAccessKey(userName string) (string, string, error)
 	DeleteAccessKey(userName, accessKeyID string) error
 	CreatePolicy(policyName, iamPath, policyTemplate string, resources []string) (string, error)
-	DeletePolicy(policyARN string) error
 	ListAttachedUserPolicies(userName, iamPath string) ([]string, error)
 	AttachUserPolicy(userName, policyARN string) error
 	DetachUserPolicy(userName, policyARN string) error

--- a/awsiam/user.go
+++ b/awsiam/user.go
@@ -11,7 +11,6 @@ type User interface {
 	ListAccessKeys(userName string) ([]string, error)
 	CreateAccessKey(userName string) (string, string, error)
 	DeleteAccessKey(userName, accessKeyID string) error
-	CreatePolicy(policyName, iamPath, policyTemplate string, resources []string) (string, error)
 	ListAttachedUserPolicies(userName, iamPath string) ([]string, error)
 	AttachUserPolicy(userName, policyARN string) error
 	DetachUserPolicy(userName, policyARN string) error

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -5,4 +5,5 @@ set -e -x
 cp secrets-test.yml secrets.yml
 cp catalog-test.yml catalog.yml
 
-go test
+# Run all _test.go files in main directory and subdirectories
+go test ./...

--- a/ci/smoke-tests/aws-elasticache-redis/manifest.yml
+++ b/ci/smoke-tests/aws-elasticache-redis/manifest.yml
@@ -2,7 +2,6 @@
 applications:
   - buildpacks:
       - python_buildpack
-    stack: cflinuxfs3
     disk_quota: 256mb
     memory: 112MB
     command: (echo SUCCESS || echo FAIL) && sleep infinity

--- a/ci/smoke-tests/aws-elasticsearch/manifest.yml
+++ b/ci/smoke-tests/aws-elasticsearch/manifest.yml
@@ -2,7 +2,6 @@
 applications:
   - buildpacks:
       - python_buildpack
-    stack: cflinuxfs3
     disk_quota: 256mb
     memory: 112MB
     command: (echo SUCCESS || echo FAIL) && sleep infinity

--- a/iampolicy/iampolicy.go
+++ b/iampolicy/iampolicy.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/url"
 	"sort"
+	"text/template"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/aws/aws-sdk-go/aws"
@@ -144,7 +144,6 @@ func (ip *IamPolicyHandler) CreatePolicyFromTemplate(
 			if err != nil {
 				panic(err)
 			}
-			fmt.Println(string(marshaled))
 			return string(marshaled)
 		},
 	}).Parse(policyTemplate)
@@ -157,7 +156,6 @@ func (ip *IamPolicyHandler) CreatePolicyFromTemplate(
 		"Resource":  resources[0],
 		"Resources": resources,
 	})
-	fmt.Println(policy.String())
 	if err != nil {
 		ip.logger.Error("aws-iam-error", err)
 		return "", err

--- a/iampolicy/iampolicy.go
+++ b/iampolicy/iampolicy.go
@@ -144,6 +144,7 @@ func (ip *IamPolicyHandler) CreatePolicyFromTemplate(
 			if err != nil {
 				panic(err)
 			}
+			fmt.Println(string(marshaled))
 			return string(marshaled)
 		},
 	}).Parse(policyTemplate)
@@ -156,6 +157,7 @@ func (ip *IamPolicyHandler) CreatePolicyFromTemplate(
 		"Resource":  resources[0],
 		"Resources": resources,
 	})
+	fmt.Println(policy.String())
 	if err != nil {
 		ip.logger.Error("aws-iam-error", err)
 		return "", err

--- a/iampolicy/iampolicy_test.go
+++ b/iampolicy/iampolicy_test.go
@@ -505,52 +505,46 @@ func TestCreatePolicyFromTemplate(t *testing.T) {
 				},
 			},
 		},
-		// "returns error": {
-		// 	policyHandler: &IamPolicyHandler{
-		// 		iamsvc: &mockIamClient{
-		// 			createPolicyErr: errors.New("create policy error"),
-		// 		},
-		// 		logger: logger,
-		// 	},
-		// 	policyName: "policy-name",
-		// 	policyTemplate: `{
-		// 		"Version": "2012-10-17",
-		// 		"Id": "policy-name",
-		// 		"Statement": [
-		// 			{
-		// 				"Effect": "effect",
-		// 				"Action": "action",
-		// 				"Resource": {{resources "/*"}}
-		// 			}
-		// 		]
-		// 	}`,
-		// 	resources:          []string{"resource"},
-		// 	iamPath:            "/path/",
-		// 	expectedErrMessage: "create policy error",
-		// },
-		// "returns AWS error": {
-		// 	policyHandler: &IamPolicyHandler{
-		// 		iamsvc: &mockIamClient{
-		// 			createPolicyErr: awserr.New("code", "message", errors.New("operation failed")),
-		// 		},
-		// 		logger: logger,
-		// 	},
-		// 	policyName: "policy-name",
-		// 	policyTemplate: `{
-		// 		"Version": "2012-10-17",
-		// 		"Id": "policy-name",
-		// 		"Statement": [
-		// 			{
-		// 				"Effect": "effect",
-		// 				"Action": "action",
-		// 				"Resource": {{resources "/*"}}
-		// 			}
-		// 		]
-		// 	}`,
-		// 	resources:          []string{"resource"},
-		// 	iamPath:            "/path/",
-		// 	expectedErrMessage: "code: message",
-		// },
+		"returns error": {
+			fakeIAMClient: &mockIamClient{
+				createPolicyErr: errors.New("create policy error"),
+			},
+			policyName: "policy-name",
+			policyTemplate: `{
+				"Version": "2012-10-17",
+				"Id": "policy-name",
+				"Statement": [
+					{
+						"Effect": "effect",
+						"Action": "action",
+						"Resource": {{resources "/*"}}
+					}
+				]
+			}`,
+			resources:          []string{"resource"},
+			iamPath:            "/path/",
+			expectedErrMessage: "create policy error",
+		},
+		"returns AWS error": {
+			fakeIAMClient: &mockIamClient{
+				createPolicyErr: awserr.New("code", "message", errors.New("operation failed")),
+			},
+			policyName: "policy-name",
+			policyTemplate: `{
+				"Version": "2012-10-17",
+				"Id": "policy-name",
+				"Statement": [
+					{
+						"Effect": "effect",
+						"Action": "action",
+						"Resource": {{resources "/*"}}
+					}
+				]
+			}`,
+			resources:          []string{"resource"},
+			iamPath:            "/path/",
+			expectedErrMessage: "code: message",
+		},
 	}
 
 	for name, test := range testCases {

--- a/iampolicy/iampolicy_test.go
+++ b/iampolicy/iampolicy_test.go
@@ -563,7 +563,7 @@ func TestCreatePolicyFromTemplate(t *testing.T) {
 				test.resources,
 			)
 			if test.expectedErrMessage != "" && err.Error() != test.expectedErrMessage {
-				t.Fatalf("expeced error message: %s, got: %s", test.expectedErrMessage, err.Error())
+				t.Fatalf("expected error message: %s, got: %s", test.expectedErrMessage, err.Error())
 			}
 			if policyARN != test.expectedPolicyArn {
 				t.Fatalf("unexpected policy ARN: %s", policyARN)

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/18F/aws-broker/awsiam"
 	"github.com/18F/aws-broker/base"
 	"github.com/18F/aws-broker/taskqueue"
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/cloudfoundry-community/s3-broker/awsiam"
 
 	"github.com/18F/aws-broker/catalog"
 	"github.com/18F/aws-broker/config"
@@ -547,8 +547,8 @@ func (d *dedicatedElasticsearchAdapter) createUpdateBucketRolesAndPolicies(i *El
 		i.SnapshotPolicyARN = policyarn
 
 	} else {
-		//snaphostpolicy has already be created so we need to add the new statements for this new bucket
-		//to the existing policy version.
+		// snaphost policy has already been created so we need to add the new statements for this new bucket
+		// to the existing policy version.
 		_, err := ip.UpdateExistingPolicy(i.SnapshotPolicyARN, []iampolicy.PolicyStatementEntry{listStatement, objectStatement})
 		if err != nil {
 			d.logger.Error("createUpdateBucketRolesAndPolcies -- UpdateExistingPolicy Error", err)
@@ -700,13 +700,11 @@ func (d *dedicatedElasticsearchAdapter) cleanupRolesAndPolicies(i *Elasticsearch
 	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.INFO))
 	user := awsiam.NewIAMUser(iamsvc, logger)
 
-	// should accept ErrCodeNoSuchEntityException ?
 	if err := user.DetachUserPolicy(i.Domain, i.IamPolicyARN); err != nil {
 		fmt.Println(err.Error())
 		return err
 	}
 
-	// should accept 404?
 	if err := user.DeleteAccessKey(i.Domain, i.AccessKey); err != nil {
 		fmt.Println(err.Error())
 		return err
@@ -727,7 +725,6 @@ func (d *dedicatedElasticsearchAdapter) cleanupRolesAndPolicies(i *Elasticsearch
 		return err
 	}
 
-	// need to handle old policy version deletion
 	if err := user.DeletePolicy(i.SnapshotPolicyARN); err != nil {
 		fmt.Println(err.Error())
 		return err

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -158,8 +158,6 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		esclusterconfig.SetZoneAwarenessConfig(zoneAwarenessConfig)
 	}
 
-	log.Println(fmt.Sprint(i.MasterCount))
-
 	snapshotOptions := &opensearchservice.SnapshotOptions{
 		AutomatedSnapshotStartHour: aws.Int64(int64(i.AutomatedSnapshotStartHour)),
 	}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update elasticsearch deletion to use helper methods from this codebase for deleting duplicate policy versions to prevent failures
- Move IAM policy related helpers to `iampolicy.go`
- Add unit tests
- Fix manifests for smoke tests to not use cflinuxfs3
- Update `ci/run_tests.sh` to run all go tests, not just the tests from `main_test.go`

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are no changes to the permissions or provisioned IAM resources of this tool, just code refactoring to avoid a bug when a policy with multiple versions needs to be deleted
