### PR TITLE
Fix issue with subnet & AZ compatibility

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1298,10 +1298,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 7
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1333,10 +1333,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 7
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1371,10 +1371,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1409,10 +1409,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1447,10 +1447,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1485,10 +1485,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1523,10 +1523,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1561,10 +1561,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1599,10 +1599,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1637,10 +1637,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1675,10 +1675,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"
@@ -1713,10 +1713,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: (( grab meta.elasticsearch.security_group ))
-    subnetIDaz1: (( grab meta.elasticsearch.subnet_id_az1 ))
-    subnetIDaz2: (( grab meta.elasticsearch.subnet_id_az2 ))
-    subnetIDaz3: (( grab meta.elasticsearch.subnet_id_az3 ))
-    subnetIDaz4: (( grab meta.elasticsearch.subnet_id_az4 ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
     tags:
       environment: (( grab meta.environment ))
       client: "the client"

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -38,10 +38,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 6
     securityGroup: sec-group
-    subnetIDaz1: subnet-1
-    subnetIDaz2: subnet-2
-    subnetIDaz3: subnet-3
-    subnetIDaz4: subnet-4
+    subnetID1az1: subnet-1
+    subnetID2az2: subnet-2
+    subnetID3az1: subnet-3
+    subnetID4az2: subnet-4
     tags:
       environment: "cf-env-dev"
       client: "the client"
@@ -67,10 +67,10 @@ elasticsearch:
     encryptAtRest: true
     automatedSnapshotStartHour: 7
     securityGroup: sec-group
-    subnetIDaz1: subnet-1
-    subnetIDaz2: subnet-2
-    subnetIDaz3: subnet-3
-    subnetIDaz4: subnet-4
+    subnetID1az1: subnet-1
+    subnetID2az2: subnet-2
+    subnetID3az1: subnet-3
+    subnetID4az2: subnet-4
     tags:
       environment: "cf-env-dev"
       client: "the client"

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -197,10 +197,10 @@ type ElasticsearchPlan struct {
 	NodeToNodeEncryption       bool              `yaml:"nodeToNodeEncryption" json:"-"`
 	EncryptAtRest              bool              `yaml:"encryptAtRest" json:"-"`
 	AutomatedSnapshotStartHour string            `yaml:"automatedSnapshotStartHour" json:"-"`
-	SubnetIDAZ1                string            `yaml:"subnetIDaz1" json:"-" validate:"required"`
-	SubnetIDAZ2                string            `yaml:"subnetIDaz2" json:"-" validate:"required"`
-	SubnetIDAZ3                string            `yaml:"subnetIDaz3" json:"-" validate:"required"`
-	SubnetIDAZ4                string            `yaml:"subnetIDaz4" json:"-" validate:"required"`
+	SubnetID1AZ1               string            `yaml:"subnetID1az1" json:"-" validate:"required"`
+	SubnetID2AZ2               string            `yaml:"subnetID2az2" json:"-" validate:"required"`
+	SubnetID3AZ1               string            `yaml:"subnetID3az1" json:"-" validate:"required"`
+	SubnetID4AZ2               string            `yaml:"subnetID4az2" json:"-" validate:"required"`
 	SecurityGroup              string            `yaml:"securityGroup" json:"-" validate:"required"`
 	ApprovedMajorVersions      []string          `yaml:"approvedMajorVersions" json:"-"`
 }

--- a/ci/build-manifest.sh
+++ b/ci/build-manifest.sh
@@ -33,10 +33,10 @@ meta:
     subnet_group: `${TERRAFORM} output -raw -state stack.tfstate elasticache_subnet_group`
     security_group: `${TERRAFORM} output -raw -state stack.tfstate elasticache_redis_security_group`
   elasticsearch:
-    subnet_id_az1: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az1`
-    subnet_id_az2: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az2`
-    subnet_id_az3: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az3`
-    subnet_id_az4: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet_az4`
+    subnet_id1_az1: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet1_az1`
+    subnet_id2_az2: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet2_az2`
+    subnet_id3_az1: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet3_az1`
+    subnet_id4_az2: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_subnet4_az2`
 
     security_group: `${TERRAFORM} output -raw -state stack.tfstate elasticsearch_security_group`
 EOF

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20200206145737-bbfc9a55622e // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/go-test/deep v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -780,8 +780,8 @@ func getCreateDomainInput(
 
 	if i.DataCount > 1 {
 		VPCOptions.SetSubnetIds([]*string{
-			&i.SubnetIDAZ3,
-			&i.SubnetIDAZ4,
+			&i.SubnetID3AZ1,
+			&i.SubnetID4AZ2,
 		})
 		esclusterconfig.SetZoneAwarenessEnabled(true)
 		azCount := 2 // AZ count MUST match number of subnets, max value is 3
@@ -791,7 +791,7 @@ func getCreateDomainInput(
 		esclusterconfig.SetZoneAwarenessConfig(zoneAwarenessConfig)
 	} else {
 		VPCOptions.SetSubnetIds([]*string{
-			&i.SubnetIDAZ2,
+			&i.SubnetID2AZ2,
 		})
 	}
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -117,105 +117,10 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 
 	accountID := result.Account
 
-	accessControlPolicy := "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"AWS\": \"" + uniqueUserArn + "\"},\"Action\": \"es:*\",\"Resource\": \"arn:aws-us-gov:es:" + d.settings.Region + ":" + *accountID + ":domain/" + i.Domain + "/*\"}]}"
-	var elasticsearchTags []*opensearchservice.Tag
 	time.Sleep(5 * time.Second)
 
-	for k, v := range i.Tags {
-		tag := opensearchservice.Tag{
-			Key:   aws.String(k),
-			Value: aws.String(v),
-		}
-
-		elasticsearchTags = append(elasticsearchTags, &tag)
-	}
-
-	ebsoptions := &opensearchservice.EBSOptions{
-		EBSEnabled: aws.Bool(true),
-		VolumeSize: aws.Int64(int64(i.VolumeSize)),
-		VolumeType: aws.String(i.VolumeType),
-	}
-
-	zoneAwarenessConfig := &opensearchservice.ZoneAwarenessConfig{
-		AvailabilityZoneCount: aws.Int64(2),
-	}
-
-	esclusterconfig := &opensearchservice.ClusterConfig{
-		InstanceType:  aws.String(i.InstanceType),
-		InstanceCount: aws.Int64(int64(i.DataCount)),
-	}
-	if i.MasterEnabled {
-		esclusterconfig.SetDedicatedMasterEnabled(i.MasterEnabled)
-		esclusterconfig.SetDedicatedMasterCount(int64(i.MasterCount))
-		esclusterconfig.SetDedicatedMasterType(i.MasterInstanceType)
-	}
-
-	if i.DataCount > 1 {
-		esclusterconfig.SetZoneAwarenessEnabled(true)
-		esclusterconfig.SetZoneAwarenessConfig(zoneAwarenessConfig)
-	}
-
-	snapshotOptions := &opensearchservice.SnapshotOptions{
-		AutomatedSnapshotStartHour: aws.Int64(int64(i.AutomatedSnapshotStartHour)),
-	}
-
-	nodeOptions := &opensearchservice.NodeToNodeEncryptionOptions{
-		Enabled: aws.Bool(i.NodeToNodeEncryption),
-	}
-
-	domainOptions := &opensearchservice.DomainEndpointOptions{
-		EnforceHTTPS: aws.Bool(true),
-	}
-
-	encryptionAtRestOptions := &opensearchservice.EncryptionAtRestOptions{
-		Enabled: aws.Bool(i.EncryptAtRest),
-	}
-
-	VPCOptions := &opensearchservice.VPCOptions{
-		SecurityGroupIds: []*string{
-			&i.SecGroup,
-		},
-	}
-
-	AdvancedOptions := make(map[string]*string)
-
-	if i.IndicesFieldDataCacheSize != "" {
-		AdvancedOptions["indices.fielddata.cache.size"] = &i.IndicesFieldDataCacheSize
-	}
-
-	if i.IndicesQueryBoolMaxClauseCount != "" {
-		AdvancedOptions["indices.query.bool.max_clause_count"] = &i.IndicesQueryBoolMaxClauseCount
-	}
-
-	if i.DataCount > 1 {
-		VPCOptions.SetSubnetIds([]*string{
-			&i.SubnetIDAZ1,
-			&i.SubnetIDAZ2,
-			&i.SubnetIDAZ3,
-			&i.SubnetIDAZ4,
-		})
-	} else {
-		VPCOptions.SetSubnetIds([]*string{
-			&i.SubnetIDAZ3,
-		})
-	}
-
-	// Standard Parameters
-	params := &opensearchservice.CreateDomainInput{
-		DomainName:                  aws.String(i.Domain),
-		EBSOptions:                  ebsoptions,
-		ClusterConfig:               esclusterconfig,
-		SnapshotOptions:             snapshotOptions,
-		NodeToNodeEncryptionOptions: nodeOptions,
-		DomainEndpointOptions:       domainOptions,
-		EncryptionAtRestOptions:     encryptionAtRestOptions,
-		VPCOptions:                  VPCOptions,
-		AdvancedOptions:             AdvancedOptions,
-	}
-	if i.ElasticsearchVersion != "" {
-		params.EngineVersion = aws.String(i.ElasticsearchVersion)
-	}
-	params.SetAccessPolicies(accessControlPolicy)
+	accessControlPolicy := "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"AWS\": \"" + uniqueUserArn + "\"},\"Action\": \"es:*\",\"Resource\": \"arn:aws-us-gov:es:" + d.settings.Region + ":" + *accountID + ":domain/" + i.Domain + "/*\"}]}"
+	params := getCreateDomainInput(i, accessControlPolicy)
 
 	resp, err := d.opensearch.CreateDomain(params)
 	if isInvalidTypeException(err) {
@@ -246,15 +151,7 @@ func (d *dedicatedElasticsearchAdapter) createElasticsearch(i *ElasticsearchInst
 		}
 		i.IamPolicy = policy
 		i.IamPolicyARN = policyARN
-		paramsTags := &opensearchservice.AddTagsInput{
-			TagList: elasticsearchTags,
-			ARN:     resp.DomainStatus.ARN,
-		}
-		resp1, err := d.opensearch.AddTags(paramsTags)
-		fmt.Println(awsutil.StringValue(resp1))
-		if !d.didAwsCallSucceed(err) {
-			return base.InstanceNotCreated, nil
-		}
+
 		//try setup of roles and policies on create
 		err = d.createUpdateBucketRolesAndPolicies(i, d.settings.SnapshotsBucketName, i.SnapshotPath)
 		if err != nil {
@@ -816,4 +713,109 @@ func isInvalidTypeException(createErr error) bool {
 		return aerr.Code() == "InvalidTypeException"
 	}
 	return false
+}
+
+func getCreateDomainInput(
+	i *ElasticsearchInstance,
+	accessControlPolicy string,
+) *opensearchservice.CreateDomainInput {
+	var elasticsearchTags []*opensearchservice.Tag
+
+	for k, v := range i.Tags {
+		tag := opensearchservice.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		elasticsearchTags = append(elasticsearchTags, &tag)
+	}
+
+	ebsoptions := &opensearchservice.EBSOptions{
+		EBSEnabled: aws.Bool(true),
+		VolumeSize: aws.Int64(int64(i.VolumeSize)),
+		VolumeType: aws.String(i.VolumeType),
+	}
+
+	esclusterconfig := &opensearchservice.ClusterConfig{
+		InstanceType:  aws.String(i.InstanceType),
+		InstanceCount: aws.Int64(int64(i.DataCount)),
+	}
+	if i.MasterEnabled {
+		esclusterconfig.SetDedicatedMasterEnabled(i.MasterEnabled)
+		esclusterconfig.SetDedicatedMasterCount(int64(i.MasterCount))
+		esclusterconfig.SetDedicatedMasterType(i.MasterInstanceType)
+	}
+
+	snapshotOptions := &opensearchservice.SnapshotOptions{
+		AutomatedSnapshotStartHour: aws.Int64(int64(i.AutomatedSnapshotStartHour)),
+	}
+
+	nodeOptions := &opensearchservice.NodeToNodeEncryptionOptions{
+		Enabled: aws.Bool(i.NodeToNodeEncryption),
+	}
+
+	domainOptions := &opensearchservice.DomainEndpointOptions{
+		EnforceHTTPS: aws.Bool(true),
+	}
+
+	encryptionAtRestOptions := &opensearchservice.EncryptionAtRestOptions{
+		Enabled: aws.Bool(i.EncryptAtRest),
+	}
+
+	VPCOptions := &opensearchservice.VPCOptions{
+		SecurityGroupIds: []*string{
+			&i.SecGroup,
+		},
+	}
+
+	AdvancedOptions := make(map[string]*string)
+
+	if i.IndicesFieldDataCacheSize != "" {
+		AdvancedOptions["indices.fielddata.cache.size"] = &i.IndicesFieldDataCacheSize
+	}
+
+	if i.IndicesQueryBoolMaxClauseCount != "" {
+		AdvancedOptions["indices.query.bool.max_clause_count"] = &i.IndicesQueryBoolMaxClauseCount
+	}
+
+	if i.DataCount > 1 {
+		VPCOptions.SetSubnetIds([]*string{
+			&i.SubnetIDAZ3,
+			&i.SubnetIDAZ4,
+		})
+		esclusterconfig.SetZoneAwarenessEnabled(true)
+		azCount := 2 // AZ count MUST match number of subnets, max value is 3
+		zoneAwarenessConfig := &opensearchservice.ZoneAwarenessConfig{
+			AvailabilityZoneCount: aws.Int64(int64(azCount)),
+		}
+		esclusterconfig.SetZoneAwarenessConfig(zoneAwarenessConfig)
+	} else {
+		VPCOptions.SetSubnetIds([]*string{
+			&i.SubnetIDAZ2,
+		})
+	}
+
+	// Standard Parameters
+	params := &opensearchservice.CreateDomainInput{
+		DomainName:                  aws.String(i.Domain),
+		EBSOptions:                  ebsoptions,
+		ClusterConfig:               esclusterconfig,
+		SnapshotOptions:             snapshotOptions,
+		NodeToNodeEncryptionOptions: nodeOptions,
+		DomainEndpointOptions:       domainOptions,
+		EncryptionAtRestOptions:     encryptionAtRestOptions,
+		VPCOptions:                  VPCOptions,
+		TagList:                     elasticsearchTags,
+	}
+
+	if len(AdvancedOptions) > 0 {
+		params.AdvancedOptions = AdvancedOptions
+	}
+
+	if i.ElasticsearchVersion != "" {
+		params.EngineVersion = aws.String(i.ElasticsearchVersion)
+	}
+
+	params.SetAccessPolicies(accessControlPolicy)
+	return params
 }

--- a/services/elasticsearch/elasticsearch_test.go
+++ b/services/elasticsearch/elasticsearch_test.go
@@ -3,12 +3,127 @@ package elasticsearch
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/go-test/deep"
 )
 
 func TestIsInvalidTypeException(t *testing.T) {
 	isInvalidType := isInvalidTypeException(&opensearchservice.InvalidTypeException{})
 	if !isInvalidType {
 		t.Fatal("expected isInvalidTypeException() to return true")
+	}
+}
+
+func TestGetCreateDomainInput(t *testing.T) {
+	testCases := map[string]struct {
+		esInstance     *ElasticsearchInstance
+		accessPolicy   string
+		expectedParams *opensearchservice.CreateDomainInput
+	}{
+		"data count of 1": {
+			esInstance: &ElasticsearchInstance{
+				Domain:                     "test-domain",
+				DataCount:                  1,
+				SubnetIDAZ2:                "az-2",
+				SecGroup:                   "group-1",
+				EncryptAtRest:              false,
+				VolumeSize:                 10,
+				VolumeType:                 "gp3",
+				InstanceType:               "db.m5.xlarge",
+				NodeToNodeEncryption:       true,
+				AutomatedSnapshotStartHour: 0,
+			},
+			accessPolicy: "fake-access-policy",
+			expectedParams: &opensearchservice.CreateDomainInput{
+				DomainName:     aws.String("test-domain"),
+				AccessPolicies: aws.String("fake-access-policy"),
+				VPCOptions: &opensearchservice.VPCOptions{
+					SubnetIds:        []*string{aws.String("az-2")},
+					SecurityGroupIds: []*string{aws.String("group-1")},
+				},
+				DomainEndpointOptions: &opensearchservice.DomainEndpointOptions{
+					EnforceHTTPS: aws.Bool(true),
+				},
+				EBSOptions: &opensearchservice.EBSOptions{
+					EBSEnabled: aws.Bool(true),
+					VolumeSize: aws.Int64(int64(10)),
+					VolumeType: aws.String("gp3"),
+				},
+				ClusterConfig: &opensearchservice.ClusterConfig{
+					InstanceType:  aws.String("db.m5.xlarge"),
+					InstanceCount: aws.Int64(int64(1)),
+				},
+				SnapshotOptions: &opensearchservice.SnapshotOptions{
+					AutomatedSnapshotStartHour: aws.Int64(int64(0)),
+				},
+				NodeToNodeEncryptionOptions: &opensearchservice.NodeToNodeEncryptionOptions{
+					Enabled: aws.Bool(true),
+				},
+				EncryptionAtRestOptions: &opensearchservice.EncryptionAtRestOptions{
+					Enabled: aws.Bool(false),
+				},
+			},
+		},
+		"data count is greater than 1": {
+			esInstance: &ElasticsearchInstance{
+				Domain:                     "test-domain",
+				DataCount:                  2,
+				SubnetIDAZ3:                "az-3",
+				SubnetIDAZ4:                "az-4",
+				SecGroup:                   "group-1",
+				EncryptAtRest:              false,
+				VolumeSize:                 10,
+				VolumeType:                 "gp3",
+				InstanceType:               "db.m5.xlarge",
+				NodeToNodeEncryption:       true,
+				AutomatedSnapshotStartHour: 0,
+			},
+			accessPolicy: "fake-access-policy",
+			expectedParams: &opensearchservice.CreateDomainInput{
+				DomainName:     aws.String("test-domain"),
+				AccessPolicies: aws.String("fake-access-policy"),
+				VPCOptions: &opensearchservice.VPCOptions{
+					SubnetIds:        []*string{aws.String("az-3"), aws.String("az-4")},
+					SecurityGroupIds: []*string{aws.String("group-1")},
+				},
+				DomainEndpointOptions: &opensearchservice.DomainEndpointOptions{
+					EnforceHTTPS: aws.Bool(true),
+				},
+				EBSOptions: &opensearchservice.EBSOptions{
+					EBSEnabled: aws.Bool(true),
+					VolumeSize: aws.Int64(int64(10)),
+					VolumeType: aws.String("gp3"),
+				},
+				ClusterConfig: &opensearchservice.ClusterConfig{
+					InstanceType:         aws.String("db.m5.xlarge"),
+					InstanceCount:        aws.Int64(int64(2)),
+					ZoneAwarenessEnabled: aws.Bool(true),
+					ZoneAwarenessConfig: &opensearchservice.ZoneAwarenessConfig{
+						AvailabilityZoneCount: aws.Int64(int64(2)),
+					},
+				},
+				SnapshotOptions: &opensearchservice.SnapshotOptions{
+					AutomatedSnapshotStartHour: aws.Int64(int64(0)),
+				},
+				NodeToNodeEncryptionOptions: &opensearchservice.NodeToNodeEncryptionOptions{
+					Enabled: aws.Bool(true),
+				},
+				EncryptionAtRestOptions: &opensearchservice.EncryptionAtRestOptions{
+					Enabled: aws.Bool(false),
+				},
+			},
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			params := getCreateDomainInput(
+				test.esInstance,
+				test.accessPolicy,
+			)
+			if diff := deep.Equal(params, test.expectedParams); diff != nil {
+				t.Error(diff)
+			}
+		})
 	}
 }

--- a/services/elasticsearch/elasticsearch_test.go
+++ b/services/elasticsearch/elasticsearch_test.go
@@ -25,7 +25,7 @@ func TestGetCreateDomainInput(t *testing.T) {
 			esInstance: &ElasticsearchInstance{
 				Domain:                     "test-domain",
 				DataCount:                  1,
-				SubnetIDAZ2:                "az-2",
+				SubnetID2AZ2:               "az-2",
 				SecGroup:                   "group-1",
 				EncryptAtRest:              false,
 				VolumeSize:                 10,
@@ -69,8 +69,8 @@ func TestGetCreateDomainInput(t *testing.T) {
 			esInstance: &ElasticsearchInstance{
 				Domain:                     "test-domain",
 				DataCount:                  2,
-				SubnetIDAZ3:                "az-3",
-				SubnetIDAZ4:                "az-4",
+				SubnetID3AZ1:               "az-3",
+				SubnetID4AZ2:               "az-4",
 				SecGroup:                   "group-1",
 				EncryptAtRest:              false,
 				VolumeSize:                 10,

--- a/services/elasticsearch/elasticsearchinstance.go
+++ b/services/elasticsearch/elasticsearchinstance.go
@@ -54,12 +54,12 @@ type ElasticsearchInstance struct {
 	Domain string `sql:"size(255)"`
 	ARN    string `sql:"size(255)"`
 
-	Tags        map[string]string `sql:"-"`
-	SubnetIDAZ1 string            `sql:"-"`
-	SubnetIDAZ2 string            `sql:"-"`
-	SubnetIDAZ3 string            `sql:"-"`
-	SubnetIDAZ4 string            `sql:"-"`
-	SecGroup    string            `sql:"-"`
+	Tags         map[string]string `sql:"-"`
+	SubnetID1AZ1 string            `sql:"-"`
+	SubnetID2AZ2 string            `sql:"-"`
+	SubnetID3AZ1 string            `sql:"-"`
+	SubnetID4AZ2 string            `sql:"-"`
+	SecGroup     string            `sql:"-"`
 }
 
 func (i *ElasticsearchInstance) setPassword(password, key string) error {
@@ -165,15 +165,15 @@ func (i *ElasticsearchInstance) init(uuid string,
 	i.EncryptAtRest = plan.EncryptAtRest
 	i.AutomatedSnapshotStartHour, _ = strconv.Atoi(plan.AutomatedSnapshotStartHour)
 	i.SecGroup = plan.SecurityGroup
-	i.SubnetIDAZ1 = plan.SubnetIDAZ1
-	i.SubnetIDAZ2 = plan.SubnetIDAZ2
-	i.SubnetIDAZ3 = plan.SubnetIDAZ3
-	i.SubnetIDAZ4 = plan.SubnetIDAZ4
+	i.SubnetID1AZ1 = plan.SubnetID1AZ1
+	i.SubnetID2AZ2 = plan.SubnetID2AZ2
+	i.SubnetID3AZ1 = plan.SubnetID3AZ1
+	i.SubnetID4AZ2 = plan.SubnetID4AZ2
 	i.IndicesFieldDataCacheSize = options.AdvancedOptions.IndicesFieldDataCacheSize
 	i.IndicesQueryBoolMaxClauseCount = options.AdvancedOptions.IndicesQueryBoolMaxClauseCount
 	i.SnapshotPath = "/" + i.OrganizationGUID + "/" + i.SpaceGUID + "/" + i.ServiceID + "/" + i.Uuid
 	i.BrokerSnapshotsEnabled = false
-    if options.ElasticsearchVersion != "" {
+	if options.ElasticsearchVersion != "" {
 		i.ElasticsearchVersion = options.ElasticsearchVersion
 	} else {
 		// Default to the version provided by the plan chosen in catalog.


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/cg-provision/pull/1529
Related to #306 
Related to #307 

Currently, we're having issues creating Elasticsearch/Opensearch domains with more than 1 data node. The reason why is this code:

https://github.com/cloud-gov/aws-broker/blob/42a82fe09da3a426908773b00d44bb84e997b26f/services/elasticsearch/elasticsearch.go#L190-L197

We're setting the number of subnets to 4 while we set the availability zone count to 2:

https://github.com/cloud-gov/aws-broker/blob/42a82fe09da3a426908773b00d44bb84e997b26f/services/elasticsearch/elasticsearch.go#L140

But for an availability zone count of 2, you must specify exactly 2 subnets. So this PR:

- updates to use two subnets in different AZs when the data node count is greater than 1
- adds unit tests to verify the correct subnet behavior based on the data node count
- renames variables to clarify the actual subnet/AZ behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The broker is still creating Elasticsearch/Opensearch domains using the same set of subnets, though the exact subnets used have changed to maximize IP availability. But these domains are still only accessible from within the VPC.
