### PR TITLE
Enable FIPS endpoints across broker

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -75,6 +75,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((development-rds-internal-db-name))
         ENC_KEY: ((development-enc-key))
+        AWS_USE_FIPS_ENDPOINT: true
 
     on_failure:
       put: slack
@@ -524,6 +525,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((staging-rds-internal-db-name))
         ENC_KEY: ((staging-enc-key))
+        AWS_USE_FIPS_ENDPOINT: true
 
     on_failure:
       put: slack
@@ -974,6 +976,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((prod-rds-internal-db-name))
         ENC_KEY: ((prod-enc-key))
+        AWS_USE_FIPS_ENDPOINT: true
 
     on_failure:
       put: slack

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -52,8 +52,15 @@ func InitElasticsearchBroker(brokerDB *gorm.DB, settings *config.Settings, taskq
 }
 
 // initializeAdapter is the main function to create database instances
-func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
-	elasticsearchAdapter := &dedicatedElasticsearchAdapter{
+func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, c *catalog.Catalog, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
+	var elasticsearchAdapter ElasticsearchAdapter
+
+	if s.Environment == "test" {
+		elasticsearchAdapter = &mockElasticsearchAdapter{}
+		return elasticsearchAdapter, nil
+	}
+
+	elasticsearchAdapter = &dedicatedElasticsearchAdapter{
 		Plan:       plan,
 		settings:   *s,
 		logger:     logger,
@@ -129,7 +136,7 @@ func (broker *elasticsearchBroker) CreateInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusBadRequest, "There was an error initializing the instance. Error: "+err.Error())
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -172,7 +179,7 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 	if planErr != nil {
 		return planErr
 	}
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -218,7 +225,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		return planErr
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -294,7 +301,7 @@ func (broker *elasticsearchBroker) BindInstance(c *catalog.Catalog, id string, b
 	}
 
 	// Get the correct database logic depending on the type of plan
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -331,7 +338,7 @@ func (broker *elasticsearchBroker) DeleteInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusInternalServerError, "Unable to get instance password.")
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -52,15 +52,8 @@ func InitElasticsearchBroker(brokerDB *gorm.DB, settings *config.Settings, taskq
 }
 
 // initializeAdapter is the main function to create database instances
-func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, c *catalog.Catalog, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
-	var elasticsearchAdapter ElasticsearchAdapter
-
-	if s.Environment == "test" {
-		elasticsearchAdapter = &mockElasticsearchAdapter{}
-		return elasticsearchAdapter, nil
-	}
-
-	elasticsearchAdapter = &dedicatedElasticsearchAdapter{
+func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
+	elasticsearchAdapter := &dedicatedElasticsearchAdapter{
 		Plan:       plan,
 		settings:   *s,
 		logger:     logger,
@@ -136,7 +129,7 @@ func (broker *elasticsearchBroker) CreateInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusBadRequest, "There was an error initializing the instance. Error: "+err.Error())
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -179,7 +172,7 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 	if planErr != nil {
 		return planErr
 	}
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -225,7 +218,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		return planErr
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -301,7 +294,7 @@ func (broker *elasticsearchBroker) BindInstance(c *catalog.Catalog, id string, b
 	}
 
 	// Get the correct database logic depending on the type of plan
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -338,7 +331,7 @@ func (broker *elasticsearchBroker) DeleteInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusInternalServerError, "Unable to get instance password.")
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -52,7 +52,7 @@ func InitElasticsearchBroker(brokerDB *gorm.DB, settings *config.Settings, taskq
 }
 
 // initializeAdapter is the main function to create database instances
-func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, c *catalog.Catalog, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
+func initializeAdapter(plan catalog.ElasticsearchPlan, s *config.Settings, logger lager.Logger) (ElasticsearchAdapter, response.Response) {
 	var elasticsearchAdapter ElasticsearchAdapter
 
 	if s.Environment == "test" {
@@ -136,7 +136,7 @@ func (broker *elasticsearchBroker) CreateInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusBadRequest, "There was an error initializing the instance. Error: "+err.Error())
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -179,7 +179,7 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 	if planErr != nil {
 		return planErr
 	}
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -225,7 +225,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		return planErr
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -301,7 +301,7 @@ func (broker *elasticsearchBroker) BindInstance(c *catalog.Catalog, id string, b
 	}
 
 	// Get the correct database logic depending on the type of plan
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}
@@ -338,7 +338,7 @@ func (broker *elasticsearchBroker) DeleteInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusInternalServerError, "Unable to get instance password.")
 	}
 
-	adapter, adapterErr := initializeAdapter(plan, broker.settings, c, broker.logger)
+	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
 	}

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -37,34 +37,6 @@ type ElasticsearchAdapter interface {
 	deleteElasticsearch(i *ElasticsearchInstance, passoword string, queue *taskqueue.QueueManager) (base.InstanceState, error)
 }
 
-type mockElasticsearchAdapter struct {
-}
-
-func (d *mockElasticsearchAdapter) createElasticsearch(i *ElasticsearchInstance, password string) (base.InstanceState, error) {
-	// TODO
-	return base.InstanceReady, nil
-}
-
-func (d *mockElasticsearchAdapter) modifyElasticsearch(i *ElasticsearchInstance, password string) (base.InstanceState, error) {
-	// TODO
-	return base.InstanceReady, nil
-}
-
-func (d *mockElasticsearchAdapter) checkElasticsearchStatus(i *ElasticsearchInstance) (base.InstanceState, error) {
-	// TODO
-	return base.InstanceReady, nil
-}
-
-func (d *mockElasticsearchAdapter) bindElasticsearchToApp(i *ElasticsearchInstance, password string) (map[string]string, error) {
-	// TODO
-	return i.getCredentials(password)
-}
-
-func (d *mockElasticsearchAdapter) deleteElasticsearch(i *ElasticsearchInstance, password string, queue *taskqueue.QueueManager) (base.InstanceState, error) {
-	// TODO
-	return base.InstanceGone, nil
-}
-
 type dedicatedElasticsearchAdapter struct {
 	Plan       catalog.ElasticsearchPlan
 	settings   config.Settings

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -37,6 +37,34 @@ type ElasticsearchAdapter interface {
 	deleteElasticsearch(i *ElasticsearchInstance, passoword string, queue *taskqueue.QueueManager) (base.InstanceState, error)
 }
 
+type mockElasticsearchAdapter struct {
+}
+
+func (d *mockElasticsearchAdapter) createElasticsearch(i *ElasticsearchInstance, password string) (base.InstanceState, error) {
+	// TODO
+	return base.InstanceReady, nil
+}
+
+func (d *mockElasticsearchAdapter) modifyElasticsearch(i *ElasticsearchInstance, password string) (base.InstanceState, error) {
+	// TODO
+	return base.InstanceReady, nil
+}
+
+func (d *mockElasticsearchAdapter) checkElasticsearchStatus(i *ElasticsearchInstance) (base.InstanceState, error) {
+	// TODO
+	return base.InstanceReady, nil
+}
+
+func (d *mockElasticsearchAdapter) bindElasticsearchToApp(i *ElasticsearchInstance, password string) (map[string]string, error) {
+	// TODO
+	return i.getCredentials(password)
+}
+
+func (d *mockElasticsearchAdapter) deleteElasticsearch(i *ElasticsearchInstance, password string, queue *taskqueue.QueueManager) (base.InstanceState, error) {
+	// TODO
+	return base.InstanceGone, nil
+}
+
 type dedicatedElasticsearchAdapter struct {
 	Plan       catalog.ElasticsearchPlan
 	settings   config.Settings

--- a/services/elasticsearch/elasticsearch_api_test.go
+++ b/services/elasticsearch/elasticsearch_api_test.go
@@ -53,7 +53,7 @@ func TestNewSnapShotRepo(t *testing.T) {
 		}
 		fmt.Printf("%+v", snaprepo)
 	} else {
-		t.Error("Snapreop is nil")
+		t.Error("Snaprepo is nil")
 	}
 }
 


### PR DESCRIPTION
Related to #322 

## Changes proposed in this pull request:

- Update pipeline to set `AWS_USE_FIPS_ENDPOINT=true` environment variable when deploying AWS broker so that FIPS endpoints will be used. See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-FIPS_and_DualStack_Endpoints
- Remove unused argument from `services/elasticsearch/broker.initializeAdapter`

I performed manual testing to ensure that `AWS_USE_FIPS_ENDPOINT=true` actually enforces the use of FIPS endpoints:

```shell
$ AWS_USE_FIPS_ENDPOINT=true aws-vault exec <profile-name> -- go run main.go                                                                                                     

2023/08/22 11:49:39 DEBUG: Request OpenSearch/ListDomainNames Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /2021-01-01/domain HTTP/1.1
Host: es-fips.us-gov-west-1.amazonaws.com
```

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes ensure that FIPS endpoints are always used when communicating with AWS 
