### PR TITLE
change fips env vars in pipeline to strings

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -75,7 +75,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((development-rds-internal-db-name))
         ENC_KEY: ((development-enc-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
 
     on_failure:
       put: slack
@@ -525,7 +525,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((staging-rds-internal-db-name))
         ENC_KEY: ((staging-enc-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
 
     on_failure:
       put: slack
@@ -976,7 +976,7 @@ jobs:
         DB_TYPE: postgres
         DB_NAME: ((prod-rds-internal-db-name))
         ENC_KEY: ((prod-enc-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
 
     on_failure:
       put: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- change fips env vars in pipeline to strings to fix deployment errors

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just changing env variable definitions
