### PR TITLE
deprecate postgresql v10/11

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -35,8 +35,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -74,8 +72,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -113,8 +109,6 @@ rds:
       instanceClass: db.t3.small
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -152,8 +146,6 @@ rds:
       instanceClass: db.t3.small
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -191,8 +183,6 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -230,8 +220,6 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -269,8 +257,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -308,8 +294,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -347,8 +331,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -386,8 +368,6 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -426,8 +406,6 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -465,8 +443,6 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -506,8 +482,6 @@ rds:
       instanceClass: db.m5.2xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -545,8 +519,6 @@ rds:
       instanceClass: db.m5.2xlarge
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -185,8 +185,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -220,8 +218,6 @@ rds:
       instanceClass: db.m3.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"
@@ -255,8 +251,6 @@ rds:
       instanceClass: db.m3.medium
       allocatedStorage: 10
       approvedMajorVersions:
-        - "10"
-        - "11"
         - "12"
         - "13"
         - "14"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove all plans of PostgresQL version 10/11 in catalog-template.yml and catalog-test.yml



## Security considerations

N/A
