### PR TITLE
Use hardened containers

### DIFF
--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -21,8 +21,10 @@ jobs:
       trigger: false
     - get: monthly
       trigger: true
+    - get: general-task
   - task: prep-email
     file: config-source/ci/audit/service-instances.yml
+    image: general-task
     params:
       CF_API_URL: ((prod-cf-api-url))
       CF_USERNAME: ((prod-cf-broker-user.username))
@@ -50,8 +52,10 @@ jobs:
       trigger: false
     - get: monthly
       trigger: true
+    - get: general-task
   - task: prep-email
     file: config-source/ci/audit/service-instances.yml
+    image: general-task
     params:
       CF_API_URL: ((prod-cf-api-url))
       CF_USERNAME: ((prod-cf-broker-user.username))
@@ -110,6 +114,15 @@ resources:
     expression: "0 6 1 * *"
     location: "America/New_York"
     fire_immediately: true
+
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 resource_types:
 - name: email-resource

--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -125,6 +125,15 @@ resources:
     tag: latest
 
 resource_types:
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
 - name: email-resource
   type: docker-image
   source:
@@ -142,14 +151,5 @@ resource_types:
     aws_access_key_id: ((aws-key))
     aws_secret_access_key: ((aws-secret))
     repository: git-resource
-    aws_region: us-gov-west-1
-    tag: latest
-
-- name: registry-image
-  type: registry-image
-  source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
-    repository: registry-image-resource
     aws_region: us-gov-west-1
     tag: latest

--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -144,3 +144,12 @@ resource_types:
     repository: git-resource
     aws_region: us-gov-west-1
     tag: latest
+
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -135,3 +135,12 @@ resource_types:
   type: docker-image
   source:
     repository: cftoolsmiths/cron-resource
+
+- name: git
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: git-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/audit/service-instances.yml
+++ b/ci/audit/service-instances.yml
@@ -1,14 +1,5 @@
 ---
 platform: linux
-
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
     
 inputs:
 - name: cg-scripts

--- a/ci/build-manifest.yml
+++ b/ci/build-manifest.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
 - name: terraform-state

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1472,6 +1472,15 @@ resources:
     tag: latest
 
 resource_types:
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
 - name: slack-notification
   type: registry-image
   source:
@@ -1496,14 +1505,5 @@ resource_types:
     aws_access_key_id: ((aws-key))
     aws_secret_access_key: ((aws-secret))
     repository: git-resource
-    aws_region: us-gov-west-1
-    tag: latest
-
-- name: registry-image
-  type: registry-image
-  source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
-    repository: registry-image-resource
     aws_region: us-gov-west-1
     tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1498,3 +1498,12 @@ resource_types:
     repository: git-resource
     aws_region: us-gov-west-1
     tag: latest
+
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,8 +11,10 @@ jobs:
     - get: db-app-development
     - get: redis-app-development
     - get: search-app-development
+    - get: general-task
   - task: run_tests
     file: aws-broker-app/ci/run_tests.yml
+    image: general-task
 
   - task: provision-rds
     tags:
@@ -51,6 +53,7 @@ jobs:
 
   - task: build-manifest
     file: aws-broker-app/ci/build-manifest.yml
+    image: general-task
     params:
       S3_TFSTATE_BUCKET: ((development-s3-tfstate-bucket))
       BASE_STACK_NAME: ((development-stack-base))
@@ -173,10 +176,12 @@ jobs:
         passed:
         - deploy-aws-broker-development
         trigger: true
+      - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-redis
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -217,10 +222,12 @@ jobs:
         passed:
         - deploy-aws-broker-development
         trigger: true
+      - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-unbound-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-unbound.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -234,6 +241,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -247,6 +255,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch-advanced-options
         file: aws-broker-app/ci/run-smoke-test-es-advanced-options.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -286,10 +295,12 @@ jobs:
       passed:
       - deploy-aws-broker-development
       trigger: true
+    - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-postgres
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -302,6 +313,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -315,6 +327,7 @@ jobs:
 
       - task: smoke-tests-postgres-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -328,6 +341,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -340,6 +354,7 @@ jobs:
 
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -352,6 +367,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -365,6 +381,7 @@ jobs:
 
       - task: smoke-tests-mysql-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -378,6 +395,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -390,6 +408,7 @@ jobs:
 
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -402,6 +421,7 @@ jobs:
 
       - task: smoke-tests-postgres-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -414,6 +434,7 @@ jobs:
 
       - task: smoke-tests-mysql-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((development-broker-name))
           CF_API_URL: ((development-cf-api-url))
@@ -461,8 +482,10 @@ jobs:
     - get: db-app-staging
     - get: redis-app-staging
     - get: search-app-staging
+    - get: general-task
   - task: run_tests
     file: aws-broker-app/ci/run_tests.yml
+    image: general-task
 
   - task: provision-rds
     tags:
@@ -501,6 +524,7 @@ jobs:
 
   - task: build-manifest
     file: aws-broker-app/ci/build-manifest.yml
+    image: general-task
     params:
       S3_TFSTATE_BUCKET: ((staging-s3-tfstate-bucket))
       BASE_STACK_NAME: ((staging-stack-base))
@@ -617,10 +641,12 @@ jobs:
         - deploy-aws-broker-staging
         trigger: true
       - get: aws-db-test
+      - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-postgres
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -633,6 +659,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -646,6 +673,7 @@ jobs:
 
       - task: smoke-tests-postgres-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -659,6 +687,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -672,6 +701,7 @@ jobs:
 
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -684,6 +714,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -696,6 +727,7 @@ jobs:
 
       - task: smoke-tests-mysql-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -709,6 +741,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -722,6 +755,7 @@ jobs:
 
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -734,6 +768,7 @@ jobs:
 
       - task: smoke-tests-postgres-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -746,6 +781,7 @@ jobs:
 
       - task: smoke-tests-mysql-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -780,10 +816,12 @@ jobs:
         - deploy-aws-broker-staging
         trigger: true
       - get: aws-db-test
+      - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-redis
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -819,10 +857,12 @@ jobs:
         - deploy-aws-broker-staging
         trigger: true
       - get: aws-db-test
+      - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-unbound-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-unbound.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -836,6 +876,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -849,6 +890,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch-advanced-options
         file: aws-broker-app/ci/run-smoke-test-es-advanced-options.yml
+        image: general-task
         params:
           BROKER_NAME: ((staging-broker-name))
           CF_API_URL: ((staging-cf-api-url))
@@ -939,6 +981,7 @@ jobs:
       - acceptance-tests-search-staging
       - terraform-plan-aws-broker-prod
     - get: pipeline-tasks
+    - get: general-task
 
   - task: provision-rds
     tags:
@@ -952,6 +995,7 @@ jobs:
 
   - task: build-manifest
     file: aws-broker-app/ci/build-manifest.yml
+    image: general-task
     params:
       S3_TFSTATE_BUCKET: ((prod-s3-tfstate-bucket))
       BASE_STACK_NAME: ((prod-stack-base))
@@ -1079,10 +1123,12 @@ jobs:
       passed: [deploy-aws-broker-prod]
       trigger: true
     - get: aws-db-test
+    - get: general-task
   - in_parallel:
       steps:
       - task: smoke-tests-postgres
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1095,6 +1141,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1107,6 +1154,7 @@ jobs:
 
       - task: smoke-tests-postgres-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1120,6 +1168,7 @@ jobs:
 
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1133,6 +1182,7 @@ jobs:
 
       - task: smoke-tests-mysql
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1145,6 +1195,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1157,6 +1208,7 @@ jobs:
 
       - task: smoke-tests-mysql-version
         file: aws-broker-app/ci/run-smoke-tests-db-version.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1170,6 +1222,7 @@ jobs:
 
       - task: smoke-tests-mysql-update-small-to-medium
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1183,6 +1236,7 @@ jobs:
 
       - task: smoke-tests-oracle
         file: aws-broker-app/ci/run-smoke-tests.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1195,6 +1249,7 @@ jobs:
 
       - task: smoke-tests-postgres-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1207,6 +1262,7 @@ jobs:
 
       - task: smoke-tests-mysql-rotate-creds
         file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1219,6 +1275,7 @@ jobs:
 
       - task: smoke-tests-redis
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1232,6 +1289,7 @@ jobs:
 
       - task: smoke-tests-unbound-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-unbound.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1245,6 +1303,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch
         file: aws-broker-app/ci/run-smoke-test-task.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1258,6 +1317,7 @@ jobs:
 
       - task: smoke-tests-elasticsearch-advanced-options
         file: aws-broker-app/ci/run-smoke-test-es-advanced-options.yml
+        image: general-task
         params:
           BROKER_NAME: ((prod-broker-name))
           CF_API_URL: ((prod-cf-api-url))
@@ -1401,6 +1461,15 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
+
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 resource_types:
 - name: slack-notification

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1489,3 +1489,12 @@ resource_types:
     repository: s3-resource
     aws_region: us-gov-west-1
     tag: latest
+
+- name: git
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: git-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1473,11 +1473,19 @@ resources:
 
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: slack-notification-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/s3-resource
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: s3-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/run-smoke-test-es-advanced-options.yml
+++ b/ci/run-smoke-test-es-advanced-options.yml
@@ -1,17 +1,8 @@
 ---
-  platform: linux
+platform: linux
 
-  image_resource:
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: harden-concourse-task
-      aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+inputs:
+- name: aws-broker-app
 
-  inputs:
-  - name: aws-broker-app
-
-  run:
-    path: aws-broker-app/ci/run-smoke-test-es-advanced-options.sh
+run:
+  path: aws-broker-app/ci/run-smoke-test-es-advanced-options.sh

--- a/ci/run-smoke-test-rotate-creds.yml
+++ b/ci/run-smoke-test-rotate-creds.yml
@@ -1,14 +1,5 @@
 ---
 platform: linux
-
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
     
 inputs:
 - name: aws-broker-app

--- a/ci/run-smoke-test-task.yml
+++ b/ci/run-smoke-test-task.yml
@@ -1,17 +1,8 @@
 ---
-  platform: linux
+platform: linux
 
-  image_resource:
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: harden-concourse-task
-      aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+inputs:
+- name: aws-broker-app
 
-  inputs:
-  - name: aws-broker-app
-
-  run:
-    path: aws-broker-app/ci/run-smoke-test-task.sh
+run:
+  path: aws-broker-app/ci/run-smoke-test-task.sh

--- a/ci/run-smoke-test-unbound.yml
+++ b/ci/run-smoke-test-unbound.yml
@@ -1,17 +1,8 @@
 ---
-  platform: linux
+platform: linux
 
-  image_resource:
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: harden-concourse-task
-      aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+inputs:
+- name: aws-broker-app
 
-  inputs:
-  - name: aws-broker-app
-
-  run:
-    path: aws-broker-app/ci/run-smoke-test-unbound.sh
+run:
+  path: aws-broker-app/ci/run-smoke-test-unbound.sh

--- a/ci/run-smoke-tests-db-updates.yml
+++ b/ci/run-smoke-tests-db-updates.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
 - name: aws-db-test

--- a/ci/run-smoke-tests-db-version.yml
+++ b/ci/run-smoke-tests-db-version.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
 - name: aws-db-test

--- a/ci/run-smoke-tests-update-storage.yml
+++ b/ci/run-smoke-tests-update-storage.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
 - name: aws-db-test

--- a/ci/run-smoke-tests.yml
+++ b/ci/run-smoke-tests.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
 - name: aws-db-test

--- a/ci/run_tests.yml
+++ b/ci/run_tests.yml
@@ -1,15 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
-
 inputs:
 - name: aws-broker-app
   path: aws-broker


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the pipeline to use currently available hardened images
- Simplifies the pipeline code by creating a resource for the general-task image and referencing that resource using the `image` key rather than needing to specify it in every yml file
- Updates yml files so they are all formatted the same

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates the pipeline to use hardened images, including updating the built-in resources with our own hardened resource images
