### PR TITLE
update postgresql db v11

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -324,7 +324,7 @@ jobs:
           CF_SPACE: ((development-cf-space))
           SERVICE_PLAN: micro-psql
           DB_TYPE: postgres
-          DB_VERSION: 11
+          DB_VERSION: 14
 
       - task: smoke-tests-postgres-update-storage
         file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
@@ -655,7 +655,7 @@ jobs:
           CF_SPACE: ((staging-cf-space))
           SERVICE_PLAN: micro-psql
           DB_TYPE: postgres
-          DB_VERSION: 11
+          DB_VERSION: 14
 
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -1116,7 +1116,7 @@ jobs:
           CF_SPACE: ((prod-cf-space))
           SERVICE_PLAN: micro-psql
           DB_TYPE: postgres
-          DB_VERSION: 11
+          DB_VERSION: 14
 
       - task: smoke-tests-postgres-update-micro-to-small
         file: aws-broker-app/ci/run-smoke-tests-db-updates.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- upgrade the db version for postgresql from 11 -> 14 
- v11 is no longer supported and needs to updated to reflect support db on the platform to pass smoke tests

## Things to check

integrated tests/smoke test on service broker

## Security considerations

N/A
