### PR TITLE
update vars to be consistent across pipelines

### DIFF
--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -118,8 +118,8 @@ resources:
 - name: general-task
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: general-task
     aws_region: us-gov-west-1
     tag: latest
@@ -128,8 +128,8 @@ resource_types:
 - name: registry-image
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: registry-image-resource
     aws_region: us-gov-west-1
     tag: latest
@@ -148,8 +148,8 @@ resource_types:
 - name: git
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: git-resource
     aws_region: us-gov-west-1
     tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1465,8 +1465,8 @@ resources:
 - name: general-task
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: general-task
     aws_region: us-gov-west-1
     tag: latest
@@ -1475,8 +1475,8 @@ resource_types:
 - name: registry-image
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: registry-image-resource
     aws_region: us-gov-west-1
     tag: latest
@@ -1484,8 +1484,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: slack-notification-resource
     aws_region: us-gov-west-1
     tag: latest
@@ -1493,8 +1493,8 @@ resource_types:
 - name: s3-iam
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: s3-resource
     aws_region: us-gov-west-1
     tag: latest
@@ -1502,8 +1502,8 @@ resource_types:
 - name: git
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: git-resource
     aws_region: us-gov-west-1
     tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates variable names for aws keys so that they are consistent across our pipelines, and removing the need for multiple credhub variables for the same values

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adds consistency to our pipelines
