### PR TITLE
Add/Update resource types to use hardened images

### DIFF
--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -135,15 +135,22 @@ resource_types:
     tag: latest
 
 - name: email-resource
-  type: docker-image
+  type: registry-image
   source:
-    repository: pcfseceng/email-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: email-resource
+    aws_region: us-gov-west-1
     tag: latest
 
 - name: cron-resource
-  type: docker-image
+  type: registry-image
   source:
-    repository: cftoolsmiths/cron-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: cron-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: git
   type: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1507,3 +1507,12 @@ resource_types:
     repository: git-resource
     aws_region: us-gov-west-1
     tag: latest
+
+- name: cf
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: cf-resource
+    aws_region: us-gov-west-1
+    tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add/Update resource types in pipeline files to use hardened images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

With this update the pipeline should now only be using hardened images
