### PR TITLE
Update database storage sizes for gp3

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -33,7 +33,7 @@ rds:
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -70,7 +70,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.micro
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -107,7 +107,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.small
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -144,7 +144,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.small
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -181,7 +181,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -218,7 +218,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -255,7 +255,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -292,7 +292,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -329,7 +329,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -366,7 +366,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -404,7 +404,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -441,7 +441,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -480,7 +480,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.2xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -517,7 +517,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.2xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -556,7 +556,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: &m6-xlarge db.m6g.xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -593,7 +593,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: *m6-xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -631,7 +631,7 @@ rds:
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -665,7 +665,7 @@ rds:
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -699,7 +699,7 @@ rds:
       free: true
       adapter: dedicated
       instanceClass: db.t2.small
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -733,7 +733,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t2.small
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbType: mysql
@@ -767,7 +767,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t2.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -801,7 +801,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t2.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -835,7 +835,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -869,7 +869,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -903,7 +903,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -937,7 +937,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -971,7 +971,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -1005,7 +1005,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.xlarge
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       dbVersion: "8.0"
@@ -1040,7 +1040,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.t3.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       dbType: oracle-se2
       licenseModel: license-included
       redundant: false
@@ -1072,7 +1072,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m5.large
-      allocatedStorage: 10
+      allocatedStorage: 20
       dbType: sqlserver-se
       licenseModel: license-included
       redundant: false

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -183,7 +183,7 @@ rds:
       free: true
       adapter: dedicated
       instanceClass: db.t3.micro
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -216,7 +216,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -249,7 +249,7 @@ rds:
       free: false
       adapter: dedicated
       instanceClass: db.m3.medium
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "12"
         - "13"
@@ -282,7 +282,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t2.small
       dbType: mysql
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       plan_updateable: true
@@ -310,7 +310,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.medium
       dbType: mysql
-      allocatedStorage: 10
+      allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
       plan_updateable: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -508,7 +508,7 @@ jobs:
       TF_VAR_aws_deploy_role_arn: ((staging-aws-deploy-role-arn))
 
       TF_VAR_rds_internal_instance_type: ((prod-pgsql-instance-class))
-      TF_VAR_rds_internal_db_size: 10
+      TF_VAR_rds_internal_db_size: 20
       TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12
@@ -949,7 +949,7 @@ jobs:
       TF_VAR_aws_deploy_role_arn: ((prod-aws-deploy-role-arn))
 
       TF_VAR_rds_internal_instance_type: ((prod-pgsql-instance-class))
-      TF_VAR_rds_internal_db_size: 10
+      TF_VAR_rds_internal_db_size: 20
       TF_VAR_rds_internal_db_name: ((prod-rds-internal-db-name))
       TF_VAR_rds_internal_db_engine: postgres
       TF_VAR_rds_internal_db_engine_version: 12

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,7 @@ var modifyRDSInstanceReqStorage = []byte(
 	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
 	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
 	"parameters": {
-		"storage": 15
+		"storage": 25
 	  },
 	"organization_guid":"an-org",
 	"space_guid":"a-space"
@@ -281,7 +281,7 @@ func TestCatalog(t *testing.T) {
 }
 
 /*
-	Testing RDS
+Testing RDS
 */
 func TestCreateRDSInstance(t *testing.T) {
 	urlUnacceptsIncomplete := "/v2/service_instances/the_RDS_instance"
@@ -645,9 +645,9 @@ func TestModifyRDSInstanceSizeIncrease(t *testing.T) {
 		t.Error("The instance should be saved in the DB")
 	}
 
-	if i.AllocatedStorage != 15 {
+	if i.AllocatedStorage != 25 {
 		println(i.AllocatedStorage)
-		t.Error("The Allocated Storage for the instance should be 15")
+		t.Error("The Allocated Storage for the instance should be 25")
 	}
 }
 

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -35,7 +35,7 @@ func TestModifyInstance(t *testing.T) {
 				AllocatedStorage: 20,
 			},
 			existingInstance: &RDSInstance{
-				AllocatedStorage: 10,
+				AllocatedStorage: 20,
 			},
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
@@ -45,7 +45,7 @@ func TestModifyInstance(t *testing.T) {
 		},
 		"allocated storage option less than existing, does not update": {
 			options: Options{
-				AllocatedStorage: 10,
+				AllocatedStorage: 20,
 			},
 			existingInstance: &RDSInstance{
 				AllocatedStorage: 20,


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update default storage for all database plans to 20 GB to support gp3 storage volumes
- Update storage for internal databases to 20 GB to support gp3 storage volumes
- Fix unit tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating storage sizes to support gp3 storage volumes
