### PR TITLE
allow setting enable_functions for mysql databases on upgrade

### DIFF
--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -153,6 +153,10 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *co
 		i.EnablePgCron = options.EnablePgCron
 	}
 
+	if options.EnableFunctions != i.EnableFunctions {
+		i.EnableFunctions = options.EnableFunctions
+	}
+
 	// Set the DB Version if it is not already set
 	// Currently only supported for MySQL and PostgreSQL instances.
 	if i.DbVersion == "" && options.Version == "" {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -145,6 +145,19 @@ func TestModifyInstance(t *testing.T) {
 			},
 			settings: &config.Settings{},
 		},
+		"enable functions": {
+			options: Options{
+				EnableFunctions: true,
+			},
+			existingInstance: &RDSInstance{
+				EnableFunctions: false,
+			},
+			expectedInstance: &RDSInstance{
+				EnableFunctions: true,
+			},
+			plan:     catalog.RDSPlan{},
+			settings: &config.Settings{},
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Changes proposed in this pull request:

Currently, we allow users to set `enable_functions` when creating new MySQL databases, but not when updating them. So users with existing MySQL databases can't enable this feature without creating a new database and importing a backup into it.

This PR enables the ability to set `enable_functions` when updating a database service, so customers with existing MySQL databases can easily enable this feature.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just exposing an option on update that is already exposed on creation
