### PR TITLE
Fix logic error when looking up parameter group family version

### DIFF
--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -101,6 +101,27 @@ func (p *awsParameterGroupClient) CleanupCustomParameterGroups() {
 	}
 }
 
+func (p *awsParameterGroupClient) getDatabaseEngineVersion(i *RDSInstance) (string, error) {
+	if i.Database == "" {
+		return "", errors.New("database name is required to get database engine version")
+	}
+
+	dbInstanceInfo, err := p.rds.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(i.Database),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Take the engine version of the database
+	dbVersion := *dbInstanceInfo.DBInstances[0].EngineVersion
+	if dbVersion == "" {
+		return "", errors.New("could not determine DB version to set parameter group family")
+	}
+
+	return dbVersion, nil
+}
+
 func (p *awsParameterGroupClient) getParameterGroupFamily(i *RDSInstance) error {
 	if i.ParameterGroupFamily != "" {
 		return nil
@@ -108,22 +129,11 @@ func (p *awsParameterGroupClient) getParameterGroupFamily(i *RDSInstance) error 
 	parameterGroupFamily := ""
 
 	if i.DbVersion == "" {
-		if i.Database == "" {
-			return errors.New("database name is required to determine parameter group family")
-		}
-
-		dbInstanceInfo, err := p.rds.DescribeDBInstances(&rds.DescribeDBInstancesInput{
-			DBInstanceIdentifier: aws.String(i.Database),
-		})
+		dbVersion, err := p.getDatabaseEngineVersion(i)
 		if err != nil {
 			return err
 		}
-
-		// Take the engine version of the database
-		i.DbVersion = *dbInstanceInfo.DBInstances[0].EngineVersion
-		if i.DbVersion == "" {
-			return errors.New("could not determine DB version to set parameter group family")
-		}
+		i.DbVersion = dbVersion
 	}
 
 	dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -224,13 +224,6 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *co
 		i.EnableFunctions = options.EnableFunctions
 	}
 
-	// Set the DB Version if it is not already set
-	// Currently only supported for MySQL and PostgreSQL instances.
-	if i.DbVersion == "" && options.Version == "" {
-		// Default to the version provided by the plan chosen in catalog.
-		i.DbVersion = plan.DbVersion
-	}
-
 	if options.RotateCredentials != nil && *options.RotateCredentials {
 		err := i.generateCredentials(settings)
 		if err != nil {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -464,17 +464,6 @@ func TestModifyInstance(t *testing.T) {
 			plan:             catalog.RDSPlan{},
 			settings:         &config.Settings{},
 		},
-		"set DB version from plan": {
-			options:          Options{},
-			existingInstance: &RDSInstance{},
-			expectedInstance: &RDSInstance{
-				DbVersion: "12",
-			},
-			plan: catalog.RDSPlan{
-				DbVersion: "12",
-			},
-			settings: &config.Settings{},
-		},
 		"gp3 fails for allocated storage < 20": {
 			options: Options{
 				StorageType: "gp3",


### PR DESCRIPTION
## Changes proposed in this pull request:

Closes https://github.com/cloud-gov/aws-broker/issues/343

- Remove logic to set `DbVersion` on database instances from the plan if no value is found, since it was erroneously looking up the database version. The default plan `dbVersion` for PostgreSQL plans is 15, so even if they are PostgreSQL 13 or 14 and don't have a `DbVersion` on their instance from the broker database, the version for the instances was being assigned as 15, causing issues when looking up parameter group families.
- Add logic to get the database version based on the database name, which should always return the correct engine version for the database and thus parameter group family version

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No changes to broker permissions, just refactoring internal logic to fix bugs when assigning parameter groups