### PR TITLE
Fix ES update logic

### DIFF
--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -201,17 +201,17 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 		broker.logger.Error("Updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error updating Elasticsearch service instance")
 	}
-	err = broker.brokerDB.Save(&esInstance).Error
-	if err != nil {
-		broker.logger.Error("Saving instance failed", err)
-		return response.NewErrorResponse(http.StatusBadRequest, "Error updating Elasticsearch service instance")
-	}
-
 	_, err = adapter.modifyElasticsearch(&esInstance)
 	if err != nil {
 		broker.logger.Error("AWS call updating instance failed", err)
-		return response.NewErrorResponse(http.StatusBadRequest, "Error updating Elasticsearch service instance")
+		return response.NewErrorResponse(http.StatusBadRequest, "Error modifying Elasticsearch service instance")
 	}
+	err = broker.brokerDB.Save(&esInstance).Error
+	if err != nil {
+		broker.logger.Error("Saving instance failed", err)
+		return response.NewErrorResponse(http.StatusBadRequest, "Error saving updated Elasticsearch service instance")
+	}
+
 	return response.NewAsyncOperationResponse(base.ModifyOp.String())
 }
 


### PR DESCRIPTION


## Changes proposed in this pull request:

- As with services / rds / broker.go, lets modify the AWS instance, then update the broker database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data

No changes to logging except minor wording changes to distinguis between types of failure. 

## Security considerations

Minimal. Changed order of operations and minor wording changes. 
