### PR TITLE
Moving small mysql plans from legacy t2 to t3

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -698,7 +698,7 @@ rds:
         displayName: *small-mysql-name
       free: true
       adapter: dedicated
-      instanceClass: db.t2.small
+      instanceClass: db.t3.small
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"
@@ -732,7 +732,7 @@ rds:
         displayName: *small-mysql-redundant-name
       free: false
       adapter: dedicated
-      instanceClass: db.t2.small
+      instanceClass: db.t3.small
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.0"

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -280,7 +280,7 @@ rds:
         displayName: "Dedicated small MySQL"
       free: true
       adapter: dedicated
-      instanceClass: db.t2.small
+      instanceClass: db.t3.small
       dbType: mysql
       allocatedStorage: 20
       approvedMajorVersions:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move MySql small plans from `db.t2.small` to `db.t3.small`

## Notes

Existing 2023 RIs for `db.t2` classes is expiring soon and new ones can't be purchased.  For 2024 `db.t3` RIs are being purchased and customers migrated over.

## Security considerations

This is just an instance change to keep current with AWS support instance types and keep RIs in place to save money

## Ticket for work

https://github.com/cloud-gov/aws-broker/issues/348
