### PR TITLE
fix redis tags to use correct service offering name

### DIFF
--- a/services/redis/broker.go
+++ b/services/redis/broker.go
@@ -34,7 +34,7 @@ type redisBroker struct {
 	tagManager brokertags.TagManager
 }
 
-// InitRedisBroker is the constructor for the redisBroker.  
+// InitRedisBroker is the constructor for the redisBroker.
 func InitRedisBroker(
 	brokerDB *gorm.DB,
 	settings *config.Settings,
@@ -118,7 +118,7 @@ func (broker *redisBroker) CreateInstance(c *catalog.Catalog, id string, createR
 
 	tags, err := broker.tagManager.GenerateTags(
 		brokertags.Create,
-		c.ElasticsearchService.Name,
+		c.RedisService.Name,
 		plan.Name,
 		brokertags.ResourceGUIDs{
 			InstanceGUID:     id,


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix redis tags to use correct service offering name

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
