### PR TITLE
Update supported ES plans

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1332,7 +1332,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "OpenSearch 2.11"
       - "single node"
       - "non-prod"
       costs:
@@ -1367,7 +1366,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
@@ -1405,7 +1403,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
@@ -1443,7 +1440,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
@@ -1481,7 +1477,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
@@ -1519,7 +1514,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
@@ -1557,7 +1551,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
@@ -1595,7 +1588,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
@@ -1633,7 +1625,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
@@ -1671,7 +1662,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
@@ -1709,7 +1699,6 @@ elasticsearch:
     metadata:
       bullets:
       - "OpenSearch"
-      - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1328,24 +1328,24 @@ elasticsearch:
       broker: "AWS broker"
   - id: "162ffae8-9cf8-4806-80e5-a7f92d514198"
     name: "es-dev"
-    description: "AWS Elasticsearch 7.4 - Single node non-prod use only"
+    description: "Single small Elasticsearch/OpenSearch node, non-prod use only"
     metadata:
       bullets:
-      - "elasticsearch"
-      - "es 7.4"
+      - "OpenSearch"
+      - "OpenSearch 2.11"
       - "single node"
       - "non-prod"
       costs:
       - amount:
           usd: 200.0
         unit: "MONTHLY"
-      displayName: "non-prod single node elasticsearch 7.4"
+      displayName: "Small, single node, non-prod"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     dataCount: 1
     instanceType: t3.small.search
     volumeSize: 15
@@ -1363,23 +1363,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "55b529cf-639e-4673-94fd-ad0a5dafe0ad"
     name: "es-medium"
-    description: "AWS Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    description: "Elasticsearch/OpenSearch medium - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
           usd: 1000.0
         unit: "MONTHLY"
-      displayName: "es cluster 3 master 2 data based on elasticsearch 7.4"
+      displayName: "Medium, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
     instanceType: c5.large.search
@@ -1401,23 +1401,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "95b528cf-743e-2996-32yt-mc0a5vnf87cg"
     name: "es-medium-ha"
-    description: "AWS Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    description: "Elasticsearch/OpenSearch medium - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
           usd: 1400.0
         unit: "MONTHLY"
-      displayName: "es cluster 3 master 4 data based on elasticsearch 7.4"
+      displayName: "Medium, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 4
     instanceType: c5.large.search
@@ -1439,23 +1439,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "4c9529cf-93be-4873-94fd-ad0a5daf9ty1"
     name: "es-large"
-    description: "AWS Large Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    description: "Elasticsearch/OpenSearch large - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
           usd: 2000.0
         unit: "MONTHLY"
-      displayName: "es large cluster 3 master 2 data based on elasticsearch 7.4"
+      displayName: "Large, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "Opensearch_2.3"
-    - "Opensearch_1.3"
-    - "Elasticsearch_7.4"
+    - "OpenSearch_2.11"
+    - "OpenSearch_1.3"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
     instanceType: c5.xlarge.search
@@ -1477,23 +1477,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "2dd3528cf-9gc2-2996-32yt-mc0a5vnfee56"
     name: "es-large-ha"
-    description: "AWS Large Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    description: "Elasticsearch/OpenSearch large - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
           usd: 2800.0
         unit: "MONTHLY"
-      displayName: "es large cluster 3 master 4 data based on elasticsearch 7.4"
+      displayName: "Large, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 4
     instanceType: c5.xlarge.search
@@ -1515,23 +1515,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "31d9abdc-424b-4e75-a43f-a09cd64216e9"
     name: "es-xlarge"
-    description: "AWS X-Large Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    description: "Elasticsearch/OpenSearch large - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
           usd: 3000.0
         unit: "MONTHLY"
-      displayName: "es xlarge cluster 3 master 2 data based on elasticsearch 7.4"
+      displayName: "X-Large, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
     instanceType: c5.2xlarge.search
@@ -1553,23 +1553,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "a40344fc-73ec-461d-952e-5601fec173b1"
     name: "es-xlarge-ha"
-    description: "AWS X-Large Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    description: "AWS X-Large OpenSearch 2.11 - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
           usd: 4200.0
         unit: "MONTHLY"
-      displayName: "es xlarge cluster 3 master 4 data based on elasticsearch 7.4"
+      displayName: "X-Large, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 4
     instanceType: c5.2xlarge.search
@@ -1591,23 +1591,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "4a286fc7-e6f5-4c73-9d4f-65d899354abd"
     name: "es-2xlarge-gp"
-    description: "AWS 2X-Large General-Purpose Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    description: "AWS 2X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
           usd: 4000.00
         unit: "MONTHLY"
-      displayName: "es 2xlarge general-purpose cluster 3 master 2 data based on elasticsearch 7.4"
+      displayName: "2X-Large, General-Purpose, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
     instanceType: m5.2xlarge.search
@@ -1629,23 +1629,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "e7d1f1b3-f539-4573-a4f9-ff3db9de1550"
     name: "es-2xlarge-gp-ha"
-    description: "AWS 2X-Large General-Purpose Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    description: "AWS 2X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
           usd: 5600.00
         unit: "MONTHLY"
-      displayName: "es 2xlarge general-purpose cluster 3 master 4 data based on elasticsearch 7.4"
+      displayName: "2X-Large, General-Purpose, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 4
     instanceType: m5.2xlarge.search
@@ -1667,23 +1667,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "7e005210-a5f5-41bf-9ada-d0fce8c49f00"
     name: "es-4xlarge-gp"
-    description: "AWS 4X-Large General-Purpose Elasticsearch 7.4 - 3 node master with 2 data nodes"
+    description: "AWS 4X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "2 data nodes"
       costs:
       - amount:
           usd: 8000.00
         unit: "MONTHLY"
-      displayName: "es 4xlarge general-purpose cluster 3 master 2 data based on elasticsearch 7.4"
+      displayName: "4X-Large, General-Purpose, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
     instanceType: m5.4xlarge.search
@@ -1705,23 +1705,23 @@ elasticsearch:
       broker: "AWS broker"
   - id: "20209473-6fab-44ed-93f2-46cc29c1ca00"
     name: "es-4xlarge-gp-ha"
-    description: "AWS 4X-Large General-Purpose Elasticsearch 7.4 - 3 node master with 4 data nodes"
+    description: "AWS 4X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "elasticsearch"
+      - "OpenSearch"
       - "es 7.4"
       - "4 data nodes"
       costs:
       - amount:
           usd: 11200.00
         unit: "MONTHLY"
-      displayName: "es 4xlarge general-purpose cluster 3 master 4 data based on elasticsearch 7.4"
+      displayName: "4X-Large, General-Purpose, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: Elasticsearch_7.4
+    elasticsearchVersion: OpenSearch_2.11
     approvedMajorVersions:
-    - "OpenSearch_2.3"
+    - "OpenSearch_2.11"
     - "OpenSearch_1.3"
-    - "Elasticsearch_7.4"
+    - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 4
     instanceType: m5.4xlarge.search

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1547,7 +1547,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "a40344fc-73ec-461d-952e-5601fec173b1"
     name: "es-xlarge-ha"
-    description: "AWS X-Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
+    description: "X-Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1362,7 +1362,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "55b529cf-639e-4673-94fd-ad0a5dafe0ad"
     name: "es-medium"
-    description: "Elasticsearch/OpenSearch medium - 3 master nodes with 2 data nodes"
+    description: "Medium Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1399,7 +1399,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "95b528cf-743e-2996-32yt-mc0a5vnf87cg"
     name: "es-medium-ha"
-    description: "Elasticsearch/OpenSearch medium - 3 master nodes with 4 data nodes"
+    description: "Medium Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1436,7 +1436,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "4c9529cf-93be-4873-94fd-ad0a5daf9ty1"
     name: "es-large"
-    description: "Elasticsearch/OpenSearch large - 3 master nodes with 2 data nodes"
+    description: "Large Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1473,7 +1473,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "2dd3528cf-9gc2-2996-32yt-mc0a5vnfee56"
     name: "es-large-ha"
-    description: "Elasticsearch/OpenSearch large - 3 master nodes with 4 data nodes"
+    description: "Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1510,7 +1510,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "31d9abdc-424b-4e75-a43f-a09cd64216e9"
     name: "es-xlarge"
-    description: "Elasticsearch/OpenSearch large - 3 master nodes with 2 data nodes"
+    description: "Large Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1547,7 +1547,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "a40344fc-73ec-461d-952e-5601fec173b1"
     name: "es-xlarge-ha"
-    description: "AWS X-Large OpenSearch 2.11 - 3 master nodes with 4 data nodes"
+    description: "AWS X-Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1584,7 +1584,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "4a286fc7-e6f5-4c73-9d4f-65d899354abd"
     name: "es-2xlarge-gp"
-    description: "AWS 2X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 2 data nodes"
+    description: "2X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1621,7 +1621,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "e7d1f1b3-f539-4573-a4f9-ff3db9de1550"
     name: "es-2xlarge-gp-ha"
-    description: "AWS 2X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 4 data nodes"
+    description: "2X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1658,7 +1658,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "7e005210-a5f5-41bf-9ada-d0fce8c49f00"
     name: "es-4xlarge-gp"
-    description: "AWS 4X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 2 data nodes"
+    description: "4X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "OpenSearch"
@@ -1695,7 +1695,7 @@ elasticsearch:
       broker: "AWS broker"
   - id: "20209473-6fab-44ed-93f2-46cc29c1ca00"
     name: "es-4xlarge-gp-ha"
-    description: "AWS 4X-Large General-Purpose OpenSearch 2.11 - 3 master nodes with 4 data nodes"
+    description: "4X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
       - "OpenSearch"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1331,9 +1331,9 @@ elasticsearch:
     description: "Single small Elasticsearch/OpenSearch node, non-prod use only"
     metadata:
       bullets:
-      - "OpenSearch"
-      - "single node"
-      - "non-prod"
+      - "Small"
+      - "Single node"
+      - "Non-prod"
       costs:
       - amount:
           usd: 200.0
@@ -1365,7 +1365,7 @@ elasticsearch:
     description: "Medium Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "Medium"
       - "2 data nodes"
       costs:
       - amount:
@@ -1402,7 +1402,7 @@ elasticsearch:
     description: "Medium Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "Medium"
       - "4 data nodes"
       costs:
       - amount:
@@ -1439,7 +1439,7 @@ elasticsearch:
     description: "Large Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "Large"
       - "2 data nodes"
       costs:
       - amount:
@@ -1476,7 +1476,7 @@ elasticsearch:
     description: "Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "Large"
       - "4 data nodes"
       costs:
       - amount:
@@ -1513,7 +1513,7 @@ elasticsearch:
     description: "Large Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "X-Large"
       - "2 data nodes"
       costs:
       - amount:
@@ -1550,7 +1550,7 @@ elasticsearch:
     description: "X-Large Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "X-Large"
       - "4 data nodes"
       costs:
       - amount:
@@ -1587,7 +1587,7 @@ elasticsearch:
     description: "2X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "2X-Large"
       - "2 data nodes"
       costs:
       - amount:
@@ -1624,7 +1624,7 @@ elasticsearch:
     description: "2X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "2X-Large"
       - "4 data nodes"
       costs:
       - amount:
@@ -1661,7 +1661,7 @@ elasticsearch:
     description: "4X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "4X-Large"
       - "2 data nodes"
       costs:
       - amount:
@@ -1698,7 +1698,7 @@ elasticsearch:
     description: "4X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
     metadata:
       bullets:
-      - "OpenSearch"
+      - "4X-Large"
       - "4 data nodes"
       costs:
       - amount:

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1340,7 +1340,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "Small, single node, non-prod"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1373,7 +1373,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "Medium, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1410,7 +1410,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "Medium, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1447,7 +1447,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "Large, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1484,7 +1484,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "Large, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1521,7 +1521,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "X-Large, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1558,7 +1558,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "X-Large, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1595,7 +1595,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "2X-Large, General-Purpose, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1632,7 +1632,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "2X-Large, General-Purpose, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1669,7 +1669,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "4X-Large, General-Purpose, 3 master nodes, 2 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"
@@ -1706,7 +1706,7 @@ elasticsearch:
         unit: "MONTHLY"
       displayName: "4X-Large, General-Purpose, 3 master nodes, 4 data nodes"
     free: false
-    elasticsearchVersion: OpenSearch_2.11
+    elasticsearchVersion: Elasticsearch_7.10
     approvedMajorVersions:
     - "OpenSearch_2.11"
     - "OpenSearch_1.3"


### PR DESCRIPTION
## Changes proposed in this pull request:

- [Update supported Elasticsearch/OpenSearch plans the highest minor version for each major version](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version), for anything above Elasticsearch 7:
    - "OpenSearch_2.11"
    - "OpenSearch_1.3"
    - "Elasticsearch_7.10"
- Refactor plan descriptions and metadata for more consistently and to remove the default engine version. Since the default engine version can and will change frequently, this makes plan metadata much more maintainable

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating supported versions for the broker
