### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/customer-success-squad


### PR DESCRIPTION
## Changes proposed in this pull request:

- add CODEOWNERS file which means that PRs in this repo will automatically be assigned for review to the `@cloud-gov/customer-success-squad`. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Having a CODEOWNERS file better defines ownership of code for maintenance and also ensures that the right people are automatically tagged to review any code changes, both of which are beneficial to security
