### PR TITLE
use main branch

### DIFF
--- a/ci/audit-pipeline.yml
+++ b/ci/audit-pipeline.yml
@@ -79,7 +79,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/aws-broker
-    branch: audit
+    branch: main
     paths: [ci/audit-pipeline.yml]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -87,7 +87,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/aws-broker
-    branch: audit
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: cg-scripts


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switch to using main branch instead of audit branch which is really far behind

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use main branch
