### PR TITLE
fix acceptance tests by adding missing var in parameter

### DIFF
--- a/ci/run-smoke-test-rotate-creds.sh
+++ b/ci/run-smoke-test-rotate-creds.sh
@@ -23,7 +23,7 @@ cf delete-service -f "rds-smoke-tests-db-rotate-creds-$SERVICE_PLAN"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds
-cf push "smoke-tests-db-rotate-creds-${SERVICE_PLAN}" -f manifest.yml --no-start
+cf push "smoke-tests-db-rotate-creds-${SERVICE_PLAN}" -f manifest.yml --var rds-service="rds-smoke-tests-db-rotate-creds-$SERVICE_PLAN" --no-start
 
 # set some variables that it needs
 cf set-env "smoke-tests-db-rotate-creds-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
@@ -43,7 +43,7 @@ while true; do
 done
 
 # wait for the app to start. if the app starts, it's passed the smoke test.
-cf push "smoke-tests-db-rotate-creds-${SERVICE_PLAN}"
+cf push "smoke-tests-db-rotate-creds-${SERVICE_PLAN}" --var rds-service="rds-smoke-tests-db-rotate-creds-$SERVICE_PLAN"
 
 # Rotate creds
 cf update-service "rds-smoke-tests-db-rotate-creds-$SERVICE_PLAN" -c '{"rotate_credentials": true}'
@@ -68,6 +68,7 @@ cf restage "smoke-tests-db-rotate-creds-${SERVICE_PLAN}"
 
 # Restart app - if it succeeds, then smoke tests have passed with new credentials
 cf restart "smoke-tests-db-rotate-creds-${SERVICE_PLAN}"
+
 
 # Clean up app and service
 cf delete -f "smoke-tests-db-rotate-creds-$SERVICE_PLAN"

--- a/ci/run-smoke-tests-db-updates.sh
+++ b/ci/run-smoke-tests-db-updates.sh
@@ -24,7 +24,7 @@ cf delete-service -f "rds-smoke-tests-db-update-$SERVICE_PLAN"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds
-cf push "smoke-tests-db-update-${SERVICE_PLAN}" -f manifest.yml --no-start
+cf push "smoke-tests-db-update-${SERVICE_PLAN}" -f manifest.yml --var rds-service="rds-smoke-tests-update-$SERVICE_PLAN" --no-start
 
 # set some variables that it needs
 cf set-env "smoke-tests-db-update-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
@@ -50,7 +50,7 @@ while true; do
 done
 
 # wait for the app to start. if the app starts, it's passed the smoke test.
-cf push "smoke-tests-db-update-${SERVICE_PLAN}"
+cf push "smoke-tests-db-update-${SERVICE_PLAN}" --var rds-service="rds-smoke-tests-db-update-$SERVICE_PLAN"
 
 # Update service
 cf update-service "rds-smoke-tests-db-update-$SERVICE_PLAN" -p "$NEW_SERVICE_PLAN"

--- a/ci/run-smoke-tests-db-version.sh
+++ b/ci/run-smoke-tests-db-version.sh
@@ -23,7 +23,7 @@ cf delete-service -f "rds-smoke-tests-db-version-$SERVICE_PLAN"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds
-cf push "smoke-tests-db-version-${SERVICE_PLAN}" -f manifest.yml --no-start
+cf push "smoke-tests-db-version-${SERVICE_PLAN}" -f manifest.yml --var rds-service="rds-smoke-tests-db-version-$SERVICE_PLAN" --no-start
 
 # set some variables that it needs
 cf set-env "smoke-tests-db-version-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
@@ -49,7 +49,7 @@ while true; do
 done
 
 # wait for the app to start. if the app starts, it's passed the smoke test.
-cf push "smoke-tests-db-version-${SERVICE_PLAN}"
+cf push "smoke-tests-db-version-${SERVICE_PLAN}" --var rds-service="rds-smoke-tests-db-version-$SERVICE_PLAN"
 
 # Clean up app and service
 cf delete -f "smoke-tests-db-version-$SERVICE_PLAN"

--- a/ci/run-smoke-tests-update-storage.sh
+++ b/ci/run-smoke-tests-update-storage.sh
@@ -24,7 +24,7 @@ cf delete-service -f "rds-smoke-tests-db-update-storage-$SERVICE_PLAN"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds
-cf push "smoke-tests-db-update-storage-${SERVICE_PLAN}" -f manifest.yml --no-start
+cf push "smoke-tests-db-update-storage-${SERVICE_PLAN}" -f manifest.yml --var rds-service="rds-smoke-tests-db-update-storage-$SERVICE_PLAN" --no-start
 
 # set some variables that it needs
 cf set-env "smoke-tests-db-update-storage-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
@@ -50,7 +50,7 @@ while true; do
 done
 
 # wait for the app to start. if the app starts, it's passed the smoke test.
-cf push "smoke-tests-db-update-storage-${SERVICE_PLAN}"
+cf push "smoke-tests-db-update-storage-${SERVICE_PLAN}" --var rds-service="rds-smoke-tests-db-update-storage-$SERVICE_PLAN"
 
 # Update storage size
 cf update-service "rds-smoke-tests-db-update-storage-$SERVICE_PLAN" -c '{"storage": 25}'

--- a/ci/run-smoke-tests.sh
+++ b/ci/run-smoke-tests.sh
@@ -11,7 +11,7 @@ cf delete-service -f "rds-smoke-tests-$SERVICE_PLAN"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds
-cf push "smoke-tests-${SERVICE_PLAN}" -f manifest.yml --no-start
+cf push "smoke-tests-${SERVICE_PLAN}" -f manifest.yml --var rds-service="rds-smoke-tests-$SERVICE_PLAN" --no-start
 
 # set some variables that it needs
 cf set-env "smoke-tests-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
@@ -37,7 +37,7 @@ while true; do
 done
 
 # wait for the app to start. if the app starts, it's passed the smoke test.
-cf push "smoke-tests-${SERVICE_PLAN}"
+cf push "smoke-tests-${SERVICE_PLAN}" --var rds-service="rds-smoke-tests-$SERVICE_PLAN"
 
 # Clean up app and service
 cf delete -f "smoke-tests-$SERVICE_PLAN"


### PR DESCRIPTION
## Changes proposed in this pull request:

- This fixes the acceptance tests by adding the rds-service var with the appropriate value for the given test
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
