### PR TITLE
fix instance types of log group fields 

### DIFF
--- a/services/elasticsearch/elasticsearchinstance.go
+++ b/services/elasticsearch/elasticsearchinstance.go
@@ -61,10 +61,10 @@ type ElasticsearchInstance struct {
 	SubnetID4AZ2 string            `sql:"-"`
 	SecGroup     string            `sql:"-"`
 
-	SearchSlowLogsGroupARN string `sql:"size(-)"`
-	IndexSlowLogsGroupARN  string `sql:"size(-)"`
-	ErrorLogsGroupARN      string `sql:"size(-)"`
-	AuditLogsGroupARN      string `sql:"size(-)"`
+	SearchSlowLogsGroupARN string `sql:"size(2048)"`
+	IndexSlowLogsGroupARN  string `sql:"size(2048)"`
+	ErrorLogsGroupARN      string `sql:"size(2048)"`
+	AuditLogsGroupARN      string `sql:"size(2048)"`
 }
 
 func (i *ElasticsearchInstance) setPassword(password, key string) error {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -60,7 +60,7 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports []string `sql:"-"`
+	EnabledCloudWatchLogGroupExports []string `sql:"type:jsonb"`
 
 	StorageType string `sql:"size(255)"`
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix instance types of log group fields on instance structs so that they are actually saved to the database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just making sure that fields get written to the database rather than ignored
