### PR TITLE
Fix RDS instance JSON handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ secrets.yml contains the all of the secrets for the different resources.
 
 ## Testing and development
 
-Make sure you have a valid secrets.yml and catalog.yml. The easiest way is to copy catalog-test.yml and secrets-test.yml to catalog.yml and secrets.yml. Once you have these in place
-run `go test` to run the tests
+Make sure you have a valid `secrets.yml` and `catalog.yml`:
+
+```shell
+cp catalog-test.yml catalog.yml
+cp secrets-test.yml secrets.yml
+```
+
+Once you have these in place, run `go test ./...` to run the tests.
 
 ### How to deploy it
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"slices"
 	"strings"
 
 	"github.com/go-martini/martini"
@@ -37,6 +38,17 @@ var createRDSInstanceReq = []byte(
 	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
 	"organization_guid":"an-org",
 	"space_guid":"a-space"
+}`)
+
+var createRDSInstanceWithEnabledLogGroupsReq = []byte(
+	`{
+	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
+	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
+	"organization_guid":"an-org",
+	"space_guid":"a-space",
+	"parameters": {
+	  "enable_cloudwatch_log_groups_exports": ["foo"]
+	}
 }`)
 
 var createRDSPGWithVersionInstanceReq = []byte(
@@ -478,6 +490,47 @@ func TestCreateRDSPGWithInvaildVersionInstance(t *testing.T) {
 	// Does it contain "...because the service plan does not allow updates or modification."?
 	if !strings.Contains(res.Body.String(), "is not a supported major version; major version must be one of:") {
 		t.Error(urlAcceptsIncomplete, "should return a message that the version is invaild")
+	}
+}
+
+func TestCreateRDSInstanceWithEnabledLogGroups(t *testing.T) {
+	urlAcceptsIncomplete := "/v2/service_instances/the_RDS_instance?accepts_incomplete=true"
+	res, _ := doRequest(nil, urlAcceptsIncomplete, "PUT", true, bytes.NewBuffer(createRDSInstanceWithEnabledLogGroupsReq))
+
+	if res.Code != http.StatusAccepted {
+		t.Logf("Unable to create instance. Body is: " + res.Body.String())
+		t.Error(urlAcceptsIncomplete, "with auth should return 202 and it returned", res.Code)
+	}
+
+	// Is it a valid JSON?
+	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
+
+	// Does it say "accepted"?
+	if !strings.Contains(res.Body.String(), "accepted") {
+		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
+	}
+	// Is it in the database and has a username and password?
+	i := rds.RDSInstance{}
+	brokerDB.Where("uuid = ?", "the_RDS_instance").First(&i)
+	if i.Uuid == "0" {
+		t.Error("The instance should be saved in the DB")
+	}
+
+	if i.Username == "" || i.Password == "" {
+		t.Error("The instance should have a username and password")
+	}
+
+	if i.PlanID == "" || i.OrganizationGUID == "" || i.SpaceGUID == "" {
+		t.Error("The instance should have metadata")
+	}
+
+	var enabledGroups []string
+	err := i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledGroups)
+	if err != nil {
+		t.Error(err)
+	}
+	if !slices.Contains(enabledGroups, "foo") {
+		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }
 

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -23,15 +23,16 @@ import (
 // the broker for the "cf create-service" and "cf update-service" commands -
 // they are passed in via the "-c <JSON string or file>" flag.
 type Options struct {
-	AllocatedStorage      int64  `json:"storage"`
-	EnableFunctions       bool   `json:"enable_functions"`
-	PubliclyAccessible    bool   `json:"publicly_accessible"`
-	Version               string `json:"version"`
-	BackupRetentionPeriod *int64 `json:"backup_retention_period"`
-	BinaryLogFormat       string `json:"binary_log_format"`
-	EnablePgCron          *bool  `json:"enable_pg_cron"`
-	RotateCredentials     *bool  `json:"rotate_credentials"`
-	StorageType           string `json:"storage_type"`
+	AllocatedStorage                int64    `json:"storage"`
+	EnableFunctions                 bool     `json:"enable_functions"`
+	PubliclyAccessible              bool     `json:"publicly_accessible"`
+	Version                         string   `json:"version"`
+	BackupRetentionPeriod           *int64   `json:"backup_retention_period"`
+	BinaryLogFormat                 string   `json:"binary_log_format"`
+	EnablePgCron                    *bool    `json:"enable_pg_cron"`
+	RotateCredentials               *bool    `json:"rotate_credentials"`
+	StorageType                     string   `json:"storage_type"`
+	EnableCloudWatchLogGroupExports []string `json:"enable_cloudwatch_log_groups_exports"`
 }
 
 // Validate the custom parameters passed in via the "-c <JSON string or file>"

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -61,7 +61,7 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports pgtype.JSONB `sql:"type:jsonb"`
+	EnabledCloudWatchLogGroupExports pgtype.JSONB `sql:"type:jsonb;default:'[]';not null"`
 
 	StorageType string `sql:"size(255)"`
 }
@@ -242,6 +242,8 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *co
 		}
 	}
 
+	i.setEnabledCloudwatchLogGroupExports(options.EnableCloudWatchLogGroupExports)
+
 	return nil
 }
 
@@ -309,6 +311,8 @@ func (i *RDSInstance) init(
 	i.BinaryLogFormat = options.BinaryLogFormat
 	i.EnablePgCron = options.EnablePgCron
 
+	i.setEnabledCloudwatchLogGroupExports(options.EnableCloudWatchLogGroupExports)
+
 	return nil
 }
 
@@ -323,6 +327,16 @@ func (i *RDSInstance) setTags(
 	}
 	for k, v := range tags {
 		i.Tags[k] = v
+	}
+	return nil
+}
+
+func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []string) error {
+	// TODO: update this to set the enabled log groups when
+	// enabling log groups is supported by the broker
+	if enabledLogGroups != nil {
+		err := i.EnabledCloudWatchLogGroupExports.Set(enabledLogGroups)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix handling of EnabledCloudWatchLogGroupExports JSONB field to fix test errors

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing test errors
