### PR TITLE
Fix RDS enabled groups property

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,2 @@
+DB_TYPE="postgres"
+DB_SSLMODE="disable"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 gin-bin
 aws-broker
 secrets.yml
+secrets*.yml
 catalog.yml
+catalog*.yml
 ci/credentials.yml
 .DS_Store
 *.swp

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Once you have these in place, run `go test ./...` to run the tests.
 1. Start the PostgreSQL docker container:
 
       ```shell
-      cd docker && docker compose up -d 
+      cd docker && docker compose up -d  && cd -
       ```
 
 1. **OPTIONAL**: For `.env` file integration with the VSCode Go test runner, create `.vscode/settings.json` with:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ cp secrets-test.yml secrets.yml
 
 Once you have these in place, run `go test ./...` to run the tests.
 
+### Testing with PostgreSQL database
+
+1. Copy `.env-sample` to `.env`
+1. Add a value for `POSTGRES_USER` to the `.env` file
+1. Add a value for `POSTGRES_PASSWORD` to the `.env` file
+1. Start the PostgreSQL docker container:
+
+      ```shell
+      cd docker && docker compose up -d 
+      ```
+
+1. **OPTIONAL**: For `.env` file integration with the VSCode Go test runner, create `.vscode/settings.json` with:
+
+   ```json
+   {
+      "go.testEnvFile": "/path/to/aws-broker/.env"
+   }
+   ```
+
+1. Run the tests using `godotenv`:
+
+   ```shell
+   go install github.com/joho/godotenv/cmd/godotenv@latest
+   godotenv -f ./.env go test ./...
+   ```
+
 ### How to deploy it
 
 1. `cf push`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: postgres
     ports:
       - 5432:5432
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    env_file: ../.env
+    command: ["postgres", "-c", "log_statement=all"]
     expose:
       - "5432"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    expose:
+      - "5432"
+

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/cloud-gov/go-broker-tags v0.0.0-20241218215556-c78c3f147c5a
 	github.com/go-co-op/gocron v1.13.0
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-test/deep v1.1.0
 	github.com/jinzhu/gorm v1.9.16
 	github.com/lib/pq v1.10.5
 	github.com/martini-contrib/auth v0.0.0-20150219114609-fa62c19b7ae8
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11
-	github.com/mattn/go-sqlite3 v1.14.12
+	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	gopkg.in/go-playground/validator.v8 v8.18.2
@@ -24,16 +24,18 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.9 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20200206145737-bbfc9a55622e // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgtype v1.14.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/jinzhu/now v1.1.1 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
@@ -51,4 +53,7 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
+	gorm.io/driver/mysql v1.5.6 // indirect
+	gorm.io/gorm v1.25.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 code.cloudfoundry.org/lager v2.0.0+incompatible h1:WZwDKDB2PLd/oL+USK4b4aEjUymIej9My2nUQ9oWEwQ=
 code.cloudfoundry.org/lager v2.0.0+incompatible/go.mod h1:O2sS7gKP3HM2iemG+EnwvyNQK7pTSC6Foi4QiMp9sSk=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
@@ -37,6 +39,9 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AE
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
@@ -44,6 +49,7 @@ github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -59,6 +65,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -109,6 +117,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -142,6 +152,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
+github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -344,4 +356,11 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/datatypes v1.2.5 h1:9UogU3jkydFVW1bIVVeoYsTpLRgwDVW3rHfJG6/Ek9I=
+gorm.io/datatypes v1.2.5/go.mod h1:I5FUdlKpLb5PMqeMQhm30CQ6jXP8Rj89xkTeCSAaAD4=
+gorm.io/driver/mysql v1.5.6 h1:Ld4mkIickM+EliaQZQx3uOJDJHtrd70MxAUqWqlx3Y8=
+gorm.io/driver/mysql v1.5.6/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkDM=
+gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
+gorm.io/gorm v1.25.11 h1:/Wfyg1B/je1hnDx3sMkX+gAlxrlZpn6X0BXRlwXlvHg=
+gorm.io/gorm v1.25.11/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/main_test.go
+++ b/main_test.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/go-martini/martini"
 	"github.com/jinzhu/gorm"
-	"github.com/lib/pq"
 
 	"encoding/json"
 	"io"
@@ -602,7 +601,9 @@ func TestCreateRDSInstanceWithEnabledLogGroups(t *testing.T) {
 		t.Error("The instance should have metadata")
 	}
 
-	if !reflect.DeepEqual(i.EnabledCloudWatchLogGroupExports, pq.Array([]string{"foo"})) {
+	var enabledLogGroups []string
+	i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledLogGroups)
+	if !slices.Contains(enabledLogGroups, "foo") {
 		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }
@@ -945,7 +946,9 @@ func TestModifyEnableCloudwatchLogGroups(t *testing.T) {
 		t.Error("The instance should be saved in the DB")
 	}
 
-	if !reflect.DeepEqual(i.EnabledCloudWatchLogGroupExports, []string{"foo"}) {
+	var enabledLogGroups []string
+	i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledLogGroups)
+	if !slices.Contains(enabledLogGroups, "foo") {
 		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -266,7 +266,7 @@ func recreateTestDbTables(brokerDB *gorm.DB) error {
 		"elasticsearch": elasticsearch.ElasticsearchInstance{},
 	}
 	for _, model := range models {
-		err := brokerDB.DropTable(model).Error
+		err := brokerDB.DropTableIfExists(model).Error
 		if err != nil {
 			return err
 		}
@@ -601,9 +601,7 @@ func TestCreateRDSInstanceWithEnabledLogGroups(t *testing.T) {
 		t.Error("The instance should have metadata")
 	}
 
-	var enabledLogGroups []string
-	i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledLogGroups)
-	if !slices.Contains(enabledLogGroups, "foo") {
+	if !slices.Contains(i.EnabledCloudWatchLogGroupExports, "foo") {
 		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }
@@ -946,9 +944,7 @@ func TestModifyEnableCloudwatchLogGroups(t *testing.T) {
 		t.Error("The instance should be saved in the DB")
 	}
 
-	var enabledLogGroups []string
-	i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledLogGroups)
-	if !slices.Contains(enabledLogGroups, "foo") {
+	if !slices.Contains(i.EnabledCloudWatchLogGroupExports, "foo") {
 		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"slices"
+	"reflect"
 	"strings"
 
 	"github.com/go-martini/martini"
 	"github.com/jinzhu/gorm"
+	"github.com/lib/pq"
 
 	"encoding/json"
 	"io"
@@ -124,6 +125,17 @@ var modifyRDSInstanceEnablePgCron = []byte(
 	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
 	"parameters": {
 		"enable_pg_cron": true
+	},
+	"organization_guid":"an-org",
+	"space_guid":"a-space"
+}`)
+
+var modifyRDSInstanceEnableCloudwatchLogGroups = []byte(
+	`{
+	"service_id":"db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
+	"plan_id":"da91e15c-98c9-46a9-b114-02b8d28062c6",
+	"parameters": {
+		"enable_cloudwatch_log_groups_exports": ["foo"]
 	},
 	"organization_guid":"an-org",
 	"space_guid":"a-space"
@@ -524,12 +536,7 @@ func TestCreateRDSInstanceWithEnabledLogGroups(t *testing.T) {
 		t.Error("The instance should have metadata")
 	}
 
-	var enabledGroups []string
-	err := i.EnabledCloudWatchLogGroupExports.AssignTo(&enabledGroups)
-	if err != nil {
-		t.Error(err)
-	}
-	if !slices.Contains(enabledGroups, "foo") {
+	if !reflect.DeepEqual(i.EnabledCloudWatchLogGroupExports, pq.Array([]string{"foo"})) {
 		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }
@@ -823,6 +830,57 @@ func TestModifyEnablePgCron(t *testing.T) {
 
 	if i.EnablePgCron != nil && !*i.EnablePgCron {
 		t.Error("EnablePgCron should be true")
+	}
+}
+
+func TestModifyEnableCloudwatchLogGroups(t *testing.T) {
+	// We need to create an instance first before we can try to modify it.
+	createURL := "/v2/service_instances/the_RDS_instance?accepts_incomplete=true"
+	res, m := doRequest(nil, createURL, "PUT", true, bytes.NewBuffer(createRDSInstanceReq))
+
+	// Check to make sure the request was successful.
+	if res.Code != http.StatusAccepted {
+		t.Logf("Unable to create instance. Body is: " + res.Body.String())
+		t.Error(createURL, "with auth should return 202 and it returned", res.Code)
+	}
+
+	// Check to make sure the instance was saved.
+	i := rds.RDSInstance{}
+	brokerDB.Where("uuid = ?", "the_RDS_instance").First(&i)
+	if i.Uuid == "0" {
+		t.Error("The instance was not saved to the DB.")
+	}
+
+	// Check to make sure the instance has the original plan set on it.
+	if i.PlanID != originalRDSPlanID {
+		t.Error("The instance should have the plan provided with the create request.")
+	}
+
+	// Pull in AllocatedStorage and increase the storage
+	urlAcceptsIncomplete := "/v2/service_instances/the_RDS_instance?accepts_incomplete=true"
+	resp, _ := doRequest(m, urlAcceptsIncomplete, "PATCH", true, bytes.NewBuffer(modifyRDSInstanceEnableCloudwatchLogGroups))
+
+	if resp.Code != http.StatusAccepted {
+		t.Logf("Unable to modify instance. Body is: " + resp.Body.String())
+		t.Error(urlAcceptsIncomplete, "with auth should return 202 and it returned", resp.Code)
+	}
+
+	// Check to make sure storage size actually increased
+	// Is it a valid JSON?
+	validJSON(res.Body.Bytes(), urlAcceptsIncomplete, t)
+
+	// Does it say "accepted"?
+	if !strings.Contains(res.Body.String(), "accepted") {
+		t.Error(urlAcceptsIncomplete, "should return the instance accepted message")
+	}
+	// Is it in the database and does it have correct storage?
+	brokerDB.Where("uuid = ?", "the_RDS_instance").First(&i)
+	if i.Uuid == "0" {
+		t.Error("The instance should be saved in the DB")
+	}
+
+	if !reflect.DeepEqual(i.EnabledCloudWatchLogGroupExports, []string{"foo"}) {
+		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
 	}
 }
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -2,7 +2,7 @@ package rds
 
 import (
 	"github.com/18F/aws-broker/base"
-	"github.com/jackc/pgtype"
+	"github.com/lib/pq"
 
 	"crypto/aes"
 	"encoding/base64"
@@ -61,7 +61,7 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports pgtype.JSONB `sql:"type:jsonb;default:'[]';not null"`
+	EnabledCloudWatchLogGroupExports pq.StringArray `sql:"type:text[]"`
 
 	StorageType string `sql:"size(255)"`
 }
@@ -336,10 +336,8 @@ func (i *RDSInstance) setTags(
 func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []string) error {
 	// TODO: update this to set the enabled log groups when
 	// enabling log groups is supported by the broker
-	// i.EnabledCloudWatchLogGroupExports = enabledLogGroups
-	if enabledLogGroups != nil {
-		err := i.EnabledCloudWatchLogGroupExports.Set(enabledLogGroups)
-		return err
+	if len(enabledLogGroups) > 0 {
+		i.EnabledCloudWatchLogGroupExports = enabledLogGroups
 	}
 	return nil
 }

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -2,7 +2,7 @@ package rds
 
 import (
 	"github.com/18F/aws-broker/base"
-	"github.com/jackc/pgtype"
+	"github.com/lib/pq"
 
 	"crypto/aes"
 	"encoding/base64"
@@ -61,10 +61,12 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports pgtype.JSONB `sql:"type:jsonb;default:'[]';not null"`
+	EnabledCloudWatchLogGroupExports pq.StringArray `sql:"type:text[]"`
 
 	StorageType string `sql:"size(255)"`
 }
+
+type EnabledCloudwatchLogGroupExports []string
 
 func (u *RDSDatabaseUtils) FormatDBName(dbType string, database string) string {
 	switch dbType {
@@ -334,9 +336,6 @@ func (i *RDSInstance) setTags(
 func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []string) error {
 	// TODO: update this to set the enabled log groups when
 	// enabling log groups is supported by the broker
-	if enabledLogGroups != nil {
-		err := i.EnabledCloudWatchLogGroupExports.Set(enabledLogGroups)
-		return err
-	}
+	i.EnabledCloudWatchLogGroupExports = enabledLogGroups
 	return nil
 }

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -2,7 +2,7 @@ package rds
 
 import (
 	"github.com/18F/aws-broker/base"
-	"github.com/lib/pq"
+	"github.com/jackc/pgtype"
 
 	"crypto/aes"
 	"encoding/base64"
@@ -61,7 +61,7 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports pq.StringArray `sql:"type:text[]"`
+	EnabledCloudWatchLogGroupExports pgtype.JSONB `sql:"type:jsonb;default:'[]';not null"`
 
 	StorageType string `sql:"size(255)"`
 }
@@ -336,6 +336,10 @@ func (i *RDSInstance) setTags(
 func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []string) error {
 	// TODO: update this to set the enabled log groups when
 	// enabling log groups is supported by the broker
-	i.EnabledCloudWatchLogGroupExports = enabledLogGroups
+	// i.EnabledCloudWatchLogGroupExports = enabledLogGroups
+	if enabledLogGroups != nil {
+		err := i.EnabledCloudWatchLogGroupExports.Set(enabledLogGroups)
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/144

- Add docker-compose setup for running tests locally with PostgreSQL
- Add README docs on testing with PostgreSQL container
- Change type of `EnabledCloudWatchLogGroupExports` to `pq.StringArray` to allow saving strings to the database. **This change does require that the broker's internal database use PostgreSQL**, but every other type that I tried for this field had issues saving to the database. See https://github.com/go-gorm/gorm/issues/4498
- Update test bootstrapping to allow using configured local PostgreSQL database
- Add test for setting `EnabledCloudWatchLogGroupExports` when modifying an RDS database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing issues with persisting `EnabledCloudWatchLogGroupExports` to the database and adding necessary test setup to catch this issue locally 
