### PR TITLE
rename field

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -580,8 +580,8 @@ func TestCreateRDSInstanceWithEnabledLogGroups(t *testing.T) {
 		t.Error("The instance should have metadata")
 	}
 
-	if !slices.Contains(i.EnabledCloudWatchLogGroupExports, "foo") {
-		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
+	if !slices.Contains(i.EnabledCloudwatchLogGroupExports, "foo") {
+		t.Error("expected EnabledCloudwatchLogGroupExports to contain 'foo'")
 	}
 }
 
@@ -929,8 +929,8 @@ func TestModifyEnableCloudwatchLogGroups(t *testing.T) {
 		t.Error("The instance should be saved in the DB")
 	}
 
-	if !slices.Contains(i.EnabledCloudWatchLogGroupExports, "foo") {
-		t.Error("expected EnabledCloudWatchLogGroupExports to contain 'foo'")
+	if !slices.Contains(i.EnabledCloudwatchLogGroupExports, "foo") {
+		t.Error("expected EnabledCloudwatchLogGroupExports to contain 'foo'")
 	}
 }
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -61,12 +61,10 @@ type RDSInstance struct {
 	ParameterGroupFamily string `sql:"-"`
 	ParameterGroupName   string `sql:"size(255)"`
 
-	EnabledCloudWatchLogGroupExports pq.StringArray `sql:"type:text[]"`
+	EnabledCloudwatchLogGroupExports pq.StringArray `sql:"type:text[]"`
 
 	StorageType string `sql:"size(255)"`
 }
-
-type EnabledCloudwatchLogGroupExports []string
 
 func (u *RDSDatabaseUtils) FormatDBName(dbType string, database string) string {
 	switch dbType {
@@ -337,7 +335,7 @@ func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []str
 	// TODO: update this to set the enabled log groups when
 	// enabling log groups is supported by the broker
 	if len(enabledLogGroups) > 0 {
-		i.EnabledCloudWatchLogGroupExports = enabledLogGroups
+		i.EnabledCloudwatchLogGroupExports = enabledLogGroups
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- rename field so that it uses new sql type

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just renaming the field so that the column has the correct type in SQL, since GORM will not always change a field's type
