### PR TITLE
Refactor RDS tagging reconciliation

### DIFF
--- a/cmd/tasks/logs/tags.go
+++ b/cmd/tasks/logs/tags.go
@@ -17,6 +17,11 @@ func TagCloudwatchLogGroup(logGroupName string, generatedTags map[string]string,
 		return err
 	}
 
+	if len(resp.LogGroups) == 0 {
+		log.Printf("could not find log group %s", logGroupName)
+		return nil
+	}
+
 	logGroupArn := *resp.LogGroups[0].Arn
 	logGroupArn, _ = strings.CutSuffix(logGroupArn, ":*")
 

--- a/cmd/tasks/logs/tags.go
+++ b/cmd/tasks/logs/tags.go
@@ -1,15 +1,38 @@
 package logs
 
 import (
+	"log"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 )
 
-func TagCloudwatchLogGroup(logsClient cloudwatchlogsiface.CloudWatchLogsAPI, logGroupArn string, tags map[string]*string) error {
-	_, err := logsClient.TagResource(&cloudwatchlogs.TagResourceInput{
+func TagCloudwatchLogGroup(logGroupName string, generatedTags map[string]string, logsClient cloudwatchlogsiface.CloudWatchLogsAPI) error {
+	log.Printf("adding tags to log group %s", logGroupName)
+
+	resp, err := DescribeLogGroups(logsClient, logGroupName)
+	if err != nil {
+		return err
+	}
+
+	logGroupArn := *resp.LogGroups[0].Arn
+	logGroupArn, _ = strings.CutSuffix(logGroupArn, ":*")
+
+	cloudwatchTags := make(map[string]*string)
+	for key, value := range generatedTags {
+		cloudwatchTags[key] = aws.String(value)
+	}
+
+	_, err = logsClient.TagResource(&cloudwatchlogs.TagResourceInput{
 		ResourceArn: aws.String(logGroupArn),
-		Tags:        tags,
+		Tags:        cloudwatchTags,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	log.Printf("finished updating tags for log group %s", logGroupName)
+	return nil
 }

--- a/cmd/tasks/logs/tags_test.go
+++ b/cmd/tasks/logs/tags_test.go
@@ -1,0 +1,89 @@
+package logs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+)
+
+type mockLogsClient struct {
+	cloudwatchlogsiface.CloudWatchLogsAPI
+
+	logGroups            []*cloudwatchlogs.LogGroup
+	describeLogGroupsErr error
+	tagResourceErr       error
+}
+
+func (m mockLogsClient) DescribeLogGroups(*cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	if m.describeLogGroupsErr != nil {
+		return nil, m.describeLogGroupsErr
+	}
+	return &cloudwatchlogs.DescribeLogGroupsOutput{
+		LogGroups: m.logGroups,
+	}, nil
+}
+
+func (m mockLogsClient) TagResource(*cloudwatchlogs.TagResourceInput) (*cloudwatchlogs.TagResourceOutput, error) {
+	return nil, m.tagResourceErr
+}
+
+func TestTagCloudwatchLogGroup(t *testing.T) {
+	testCases := map[string]struct {
+		logGroupName   string
+		generatedTags  map[string]string
+		expectErr      bool
+		mockLogsClient *mockLogsClient
+	}{
+		"success": {
+			generatedTags: map[string]string{
+				"foo": "bar",
+			},
+			mockLogsClient: &mockLogsClient{
+				logGroups: []*cloudwatchlogs.LogGroup{
+					{
+						Arn: aws.String("group1-arn"),
+					},
+				},
+			},
+		},
+		"error describing log group": {
+			mockLogsClient: &mockLogsClient{
+				describeLogGroupsErr: errors.New("error describing log group"),
+			},
+			expectErr: true,
+		},
+		"no error, but log group not found": {
+			mockLogsClient: &mockLogsClient{
+				logGroups: []*cloudwatchlogs.LogGroup{},
+			},
+		},
+		"error tagging log group": {
+			generatedTags: map[string]string{
+				"foo": "bar",
+			},
+			mockLogsClient: &mockLogsClient{
+				logGroups: []*cloudwatchlogs.LogGroup{
+					{
+						Arn: aws.String("group1-arn"),
+					},
+				},
+				tagResourceErr: errors.New("error tagging resource"),
+			},
+			expectErr: true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := TagCloudwatchLogGroup(test.logGroupName, test.generatedTags, test.mockLogsClient)
+			if err != nil && !test.expectErr {
+				t.Error(err)
+			}
+			if err == nil && test.expectErr {
+				t.Error("expected error, but received nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/144

## Changes proposed in this pull request:

- [fix code for tagging cloudwatch log groups to handle case where log group is not found](https://github.com/cloud-gov/aws-broker/commit/73e7fbd0a9b411f7e587668164ad4578b7e7ebe7) 
- [add unit tests for tagging cloudwatch log group resources](https://github.com/cloud-gov/aws-broker/commit/e13e57225d06de63e47ffac90bbf8c50fb1255de)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, the code itself is not sensitive. Just addressing a bug in the logic for tagging CloudWatch log groups.
