### PR TITLE
Fix error handling in RDS tag reconciliation

### DIFF
--- a/cmd/tasks/tags/tags.go
+++ b/cmd/tasks/tags/tags.go
@@ -1,7 +1,7 @@
 package tags
 
 import (
-	"log"
+	"fmt"
 
 	brokertags "github.com/cloud-gov/go-broker-tags"
 )
@@ -15,7 +15,7 @@ func GenerateTags(tagManager brokertags.TagManager, serviceOfferingName string, 
 		true,
 	)
 	if err != nil {
-		log.Fatalf("error generating new tags for database %s", err)
+		return map[string]string{}, fmt.Errorf("error generating new tags for database %s", err)
 	}
 	// We can ignore the timestamp tags, if they exist
 	delete(generatedTags, "Created at")


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove log.Fatal and return error to avoid early program termination

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just optimizing the error handling
