### PR TITLE
add force_ssl configuration to pipeline

### DIFF
--- a/ci/terraform/outputs.tf
+++ b/ci/terraform/outputs.tf
@@ -6,6 +6,6 @@ output "rds_internal_rds_port" {
   value = module.rds_internal.rds_port
 }
 
-output "s3_snapshots_bucket_id"{
+output "s3_snapshots_bucket_id" {
   value = module.snapshot_bucket.s3_bucket_id
 }

--- a/ci/terraform/rds-internal.tf
+++ b/ci/terraform/rds-internal.tf
@@ -18,4 +18,5 @@ module "rds_internal" {
   rds_parameter_group_family    = var.rds_internal_db_parameter_group_family
   apply_immediately             = var.rds_internal_apply_immediately
   allow_major_version_upgrade   = var.rds_internal_allow_major_version_upgrade
+  rds_force_ssl                 = var.rds_force_ssl
 }

--- a/ci/terraform/snaps-bucket.tf
+++ b/ci/terraform/snaps-bucket.tf
@@ -1,8 +1,8 @@
-module "snapshot_bucket"{
-    source = "./s3_module"
-    stack_description = var.stack_description
-    s3_bucket_suffix = "aws-broker-snapshot-storage"
-    base_stack = var.base_stack
-    access_role_arn = var.platform_access_role_arn
-    s3_expire_after_days = var.snapshot_expiration
+module "snapshot_bucket" {
+  source               = "./s3_module"
+  stack_description    = var.stack_description
+  s3_bucket_suffix     = "aws-broker-snapshot-storage"
+  base_stack           = var.base_stack
+  access_role_arn      = var.platform_access_role_arn
+  s3_expire_after_days = var.snapshot_expiration
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -7,20 +7,20 @@ variable "stack_description" {
 variable "remote_state_bucket" {
 }
 
-variable "aws_deploy_region"{
+variable "aws_deploy_region" {
 
 }
 
-variable "aws_deploy_role_arn"{
-    
-}
-
-variable "platform_access_role_arn"{
+variable "aws_deploy_role_arn" {
 
 }
 
-variable "snapshot_expiration"{
-    default = 14
+variable "platform_access_role_arn" {
+
+}
+
+variable "snapshot_expiration" {
+  default = 14
 }
 
 variable "rds_internal_instance_type" {
@@ -54,4 +54,7 @@ variable "rds_internal_apply_immediately" {
 }
 
 variable "rds_internal_allow_major_version_upgrade" {
+}
+
+variable "rds_force_ssl" {
 }

--- a/ci/terraform/versions.tf
+++ b/ci/terraform/versions.tf
@@ -1,9 +1,9 @@
 
 terraform {
   required_version = ">= 0.15"
-    required_providers {
+  required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "< 6.0.0"
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Should expose `rds.force_ssl` to be configured for each environment from the pipeline, leaving it as the default value for now so it can be overridden as part of an upgrade.
- The rest of the whitespace changes are a result of running `terraform fmt`
- Part of Postgres upgrade 16.8 - aws_broker in development, staging and production
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This should result in a no-op deployment
