### PR TITLE
Upgrade rds to 16.8 for dev/stage, enable ssl

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,9 +39,9 @@ jobs:
           TF_VAR_rds_internal_db_size: 20
           TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
           TF_VAR_rds_internal_db_engine: postgres
-          TF_VAR_rds_internal_db_engine_version: 16.3
+          TF_VAR_rds_internal_db_engine_version: 16.8
           TF_VAR_rds_internal_db_parameter_group_family: postgres16
-          TF_VAR_rds_force_ssl: 0
+          TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_internal_multi_az: false
           TF_VAR_rds_internal_username: ((development-rds-internal-username))
           TF_VAR_rds_internal_password: ((development-rds-internal-password))
@@ -508,9 +508,9 @@ jobs:
           TF_VAR_rds_internal_db_size: 20
           TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
           TF_VAR_rds_internal_db_engine: postgres
-          TF_VAR_rds_internal_db_engine_version: 16.3
+          TF_VAR_rds_internal_db_engine_version: 16.8
           TF_VAR_rds_internal_db_parameter_group_family: postgres16
-          TF_VAR_rds_force_ssl: 0
+          TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_internal_multi_az: false
           TF_VAR_rds_internal_username: ((staging-rds-internal-username))
           TF_VAR_rds_internal_password: ((staging-rds-internal-password))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upgrade of RDS database in dev & staging to 16.8, this was already done in AWS Console, this catches the pipeline up
- Enables force_ssl on dev & staging
- Production will be a separate PR
- Part of https://github.com/cloud-gov/private/issues/2393

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This upgrades to the most recent 16.x RDS Postgres version and forces SSL connections
