### PR TITLE
Update for stage/prod variable names

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -553,8 +553,8 @@ jobs:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
-              DB_USERNAME: ((development-rds-internal-username))
-              DB_PASSWORD: ((development-rds-internal-password))
+              DB_USERNAME: ((staging-rds-internal-username))
+              DB_PASSWORD: ((staging-rds-internal-password))
             run:
               path: sh
               args:
@@ -1055,8 +1055,8 @@ jobs:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
-              DB_USERNAME: ((development-rds-internal-username))
-              DB_PASSWORD: ((development-rds-internal-password))
+              DB_USERNAME: ((prod-rds-internal-username))
+              DB_PASSWORD: ((prod-rds-internal-password))
             run:
               path: sh
               args:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix for credhub variable names used for init-db in staging & prod (had dev's variables which obviously doesn't work to connect to the db)
- Part II of https://github.com/cloud-gov/aws-broker/pull/409
- Part of https://github.com/cloud-gov/private/issues/2408

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fix for variable names
