### PR TITLE
Add `pgaudit` to RDS, fix for ES state

### DIFF
--- a/ci/create-and-update-db.sh
+++ b/ci/create-and-update-db.sh
@@ -43,7 +43,7 @@ for db in ${DATABASES}; do
   psql_adm -d postgres -l | awk '{print $1}' | grep -q "${db}" || \
     psql_adm -d postgres -c "CREATE DATABASE ${db} OWNER ${db_user}"
   # Enable extensions
-  for ext in citext uuid-ossp pgcrypto pg_stat_statements; do
+  for ext in ${EXTENSIONS}; do
     psql_adm -d "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\""
   done
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,6 +48,11 @@ jobs:
           TF_VAR_rds_internal_apply_immediately: "true"
           TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
+          TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements"
+          #TF_VAR_rds_add_pgaudit_log_parameter: true
+          #TF_VAR_rds_pgaudit_log_values: "ddl,role"
+
           TF_VAR_snapshot_expiration: 1
           TF_VAR_platform_access_role_arn: ((development-platform-role-arn))
 
@@ -62,6 +67,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
+              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((development-rds-internal-username))
               DB_PASSWORD: ((development-rds-internal-password))
@@ -485,10 +491,10 @@ jobs:
     plan:
       - get: aws-broker-app
         trigger: true
-      - set_pipeline: deploy-aws-broker
-        file: aws-broker-app/ci/pipeline.yml
-        var_files:
-          - aws-broker-app/ci/config.yml
+#      - set_pipeline: deploy-aws-broker
+#        file: aws-broker-app/ci/pipeline.yml
+#        var_files:
+#          - aws-broker-app/ci/config.yml
 
   - name: deploy-aws-broker-staging
     plan:
@@ -1458,7 +1464,8 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: ((aws-broker-url))
-      branch: ((aws-broker-branch-development))
+      #branch: ((aws-broker-branch-development))
+      branch: pgaudit
 
   - name: db-app-development
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,7 +49,7 @@ jobs:
           TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
-          TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
           #TF_VAR_rds_add_pgaudit_log_parameter: true
           #TF_VAR_rds_pgaudit_log_values: "ddl,role"
 
@@ -67,7 +67,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
-              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
+#              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((development-rds-internal-username))
               DB_PASSWORD: ((development-rds-internal-password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -553,8 +553,8 @@ jobs:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
-              DB_USERNAME: ((development-rds-internal-username))
-              DB_PASSWORD: ((development-rds-internal-password))
+              DB_USERNAME: ((staging-rds-internal-username))
+              DB_PASSWORD: ((staging-rds-internal-password))
             run:
               path: sh
               args:
@@ -1055,8 +1055,8 @@ jobs:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
-              DB_USERNAME: ((development-rds-internal-username))
-              DB_PASSWORD: ((development-rds-internal-password))
+              DB_USERNAME: ((prod-rds-internal-username))
+              DB_PASSWORD: ((prod-rds-internal-password))
             run:
               path: sh
               args:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -491,10 +491,10 @@ jobs:
     plan:
       - get: aws-broker-app
         trigger: true
-#      - set_pipeline: deploy-aws-broker
-#        file: aws-broker-app/ci/pipeline.yml
-#        var_files:
-#          - aws-broker-app/ci/config.yml
+      - set_pipeline: deploy-aws-broker
+        file: aws-broker-app/ci/pipeline.yml
+        var_files:
+          - aws-broker-app/ci/config.yml
 
   - name: deploy-aws-broker-staging
     plan:
@@ -1022,10 +1022,10 @@ jobs:
           TF_VAR_rds_internal_apply_immediately: "true"
           TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
-          #TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
-          #TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
-          #TF_VAR_rds_add_pgaudit_log_parameter: true
-          #TF_VAR_rds_pgaudit_log_values: "ddl,role"
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
+          TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter: true
+          TF_VAR_rds_pgaudit_log_values: "ddl,role"
 
           TF_VAR_snapshot_expiration: 14
           TF_VAR_platform_access_role_arn: ((prod-platform-role-arn))
@@ -1071,7 +1071,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
-#              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
+              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((prod-rds-internal-username))
               DB_PASSWORD: ((prod-rds-internal-password))
@@ -1469,16 +1469,14 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: ((aws-broker-url))
-      #branch: ((aws-broker-branch))
-      branch: pgaudit
+      branch: ((aws-broker-branch))
 
   - name: aws-broker-app-development
     type: git
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: ((aws-broker-url))
-      #branch: ((aws-broker-branch-development))
-      branch: pgaudit
+      branch: ((aws-broker-branch-development))
 
   - name: db-app-development
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,8 +50,8 @@ jobs:
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
           TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
-          #TF_VAR_rds_add_pgaudit_log_parameter: true
-          #TF_VAR_rds_pgaudit_log_values: "ddl,role"
+          TF_VAR_rds_add_pgaudit_log_parameter: true
+          TF_VAR_rds_pgaudit_log_values: "ddl,role"
 
           TF_VAR_snapshot_expiration: 1
           TF_VAR_platform_access_role_arn: ((development-platform-role-arn))
@@ -67,7 +67,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
-#              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
+              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((development-rds-internal-username))
               DB_PASSWORD: ((development-rds-internal-password))
@@ -544,6 +544,11 @@ jobs:
           TF_VAR_rds_internal_apply_immediately: "true"
           TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
+          TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter: true
+          TF_VAR_rds_pgaudit_log_values: "ddl,role"
+
           TF_VAR_snapshot_expiration: 7
           TF_VAR_platform_access_role_arn: ((staging-platform-role-arn))
 
@@ -558,6 +563,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
+              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((staging-rds-internal-username))
               DB_PASSWORD: ((staging-rds-internal-password))
@@ -1016,6 +1022,11 @@ jobs:
           TF_VAR_rds_internal_apply_immediately: "true"
           TF_VAR_rds_internal_allow_major_version_upgrade: "true"
 
+          #TF_VAR_rds_add_pgaudit_to_shared_preload_libraries: true
+          #TF_VAR_rds_shared_preload_libraries: "pgaudit,pg_stat_statements,pg_tle"
+          #TF_VAR_rds_add_pgaudit_log_parameter: true
+          #TF_VAR_rds_pgaudit_log_values: "ddl,role"
+
           TF_VAR_snapshot_expiration: 14
           TF_VAR_platform_access_role_arn: ((prod-platform-role-arn))
 
@@ -1060,6 +1071,7 @@ jobs:
             params:
               STATE_FILE_PATH: terraform-state/terraform.tfstate
               DATABASES: aws_broker_internal
+#              CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
               TERRAFORM_DB_HOST_FIELD: rds_internal_rds_host
               DB_USERNAME: ((prod-rds-internal-username))
               DB_PASSWORD: ((prod-rds-internal-password))
@@ -1457,7 +1469,8 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: ((aws-broker-url))
-      branch: ((aws-broker-branch))
+      #branch: ((aws-broker-branch))
+      branch: pgaudit
 
   - name: aws-broker-app-development
     type: git

--- a/ci/terraform/rds-internal.tf
+++ b/ci/terraform/rds-internal.tf
@@ -19,4 +19,10 @@ module "rds_internal" {
   apply_immediately             = var.rds_internal_apply_immediately
   allow_major_version_upgrade   = var.rds_internal_allow_major_version_upgrade
   rds_force_ssl                 = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+
 }

--- a/ci/terraform/rds_module/parameter_group.tf
+++ b/ci/terraform/rds_module/parameter_group.tf
@@ -35,6 +35,24 @@ resource "aws_db_parameter_group" "recreatable_parameter_group_postgres" {
     apply_method = "pending-reboot"
   }
 
+  dynamic "parameter" {
+    for_each = var.rds_add_pgaudit_to_shared_preload_libraries ? [1] : []
+    content {
+      name         = "shared_preload_libraries"
+      value        = var.rds_shared_preload_libraries
+      apply_method = "pending-reboot"
+    }
+  }
+
+  dynamic "parameter" {
+    for_each = var.rds_add_pgaudit_log_parameter ? [1] : []
+    content {
+      name         = "pgaudit.log"
+      value        = var.rds_pgaudit_log_values
+      apply_method = "pending-reboot"
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/ci/terraform/rds_module/variables.tf
+++ b/ci/terraform/rds_module/variables.tf
@@ -83,3 +83,27 @@ variable "apply_immediately" {
 variable "allow_major_version_upgrade" {
   default = ""
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -61,3 +61,27 @@ variable "rds_force_ssl" {
   type        = number
   default     = 1
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/ci/update-db.sh
+++ b/ci/update-db.sh
@@ -4,6 +4,7 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 # Check environment variables
 export DATABASES="${DATABASES}"
+export EXTENSIONS="${CUSTOM_EXTENSIONS:-citext uuid-ossp pgcrypto pg_stat_statements}"
 export STATE_FILE_PATH="${STATE_FILE_PATH}"
 export TERRAFORM="${TERRAFORM_BIN:-terraform}"
 export TERRAFORM_DB_HOST_FIELD="${TERRAFORM_DB_HOST_FIELD}"

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -236,11 +236,12 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 	}
 
 	fmt.Println("Pickles: Attempting adapter.modifyElasticsearch(&esInstance) ... ")
-	_, err = adapter.modifyElasticsearch(&esInstance)
+	state, err := adapter.modifyElasticsearch(&esInstance)
 	if err != nil {
 		broker.logger.Error("AWS call updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error modifying Elasticsearch service instance")
 	}
+	esInstance.State = state
 
 	fmt.Println("Pickles: Attempting to broker.brokerDB.Save ... ")
 	err = broker.brokerDB.Save(&esInstance).Error

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -292,14 +292,14 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 
 	default: //all other ops use synchronous checking of aws api
 		// status, _ = adapter.checkElasticsearchStatus(&existingInstance)
-		// if err := broker.brokerDB.Save(&existingInstance).Error; err != nil {
-		// 	return response.NewErrorResponse(http.StatusInternalServerError, err.Error())
-		// }
 
 		status, statusErr = adapter.checkElasticsearchStatus(&existingInstance)
 		if statusErr != nil {
 			fmt.Printf("Error checking Elasticsearch status: %v", statusErr)
 			return response.NewErrorResponse(http.StatusInternalServerError, statusErr.Error())
+		}
+		if err := broker.brokerDB.Save(&existingInstance).Error; err != nil {
+			return response.NewErrorResponse(http.StatusInternalServerError, err.Error())
 		}
 	}
 

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -278,6 +278,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 
 	var state string
 	var status base.InstanceState
+	var statusErr error
 
 	fmt.Printf("Pickles: operation: %s ... \n", operation)
 	switch operation {

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -228,21 +228,21 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusBadRequest, "Updating Elasticsearch service instances is not supported at this time.")
 	}
 
-	fmt.Println("Pickles: Attempting esInstance.update(options) ... \n")
+	fmt.Println("Pickles: Attempting esInstance.update(options) ... ")
 	err := esInstance.update(options)
 	if err != nil {
 		broker.logger.Error("Updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error updating Elasticsearch service instance")
 	}
 
-	fmt.Println("Pickles: Attempting adapter.modifyElasticsearch(&esInstance) ... \n")
+	fmt.Println("Pickles: Attempting adapter.modifyElasticsearch(&esInstance) ... ")
 	_, err = adapter.modifyElasticsearch(&esInstance)
 	if err != nil {
 		broker.logger.Error("AWS call updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error modifying Elasticsearch service instance")
 	}
 
-	fmt.Println("Pickles: Attempting to broker.brokerDB.Save ... \n")
+	fmt.Println("Pickles: Attempting to broker.brokerDB.Save ... ")
 	err = broker.brokerDB.Save(&esInstance).Error
 	if err != nil {
 		broker.logger.Error("Saving instance failed", err)
@@ -255,7 +255,7 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, baseInstance base.Instance, operation string) response.Response {
 	existingInstance := ElasticsearchInstance{}
 
-	fmt.Println("Pickles: Running LastOperation(..) ... \n")
+	fmt.Println("Pickles: Running LastOperation(..) ... ")
 	var count int64
 	if err := broker.brokerDB.Where("uuid = ?", id).First(&existingInstance).Count(&count).Error; err != nil {
 		response.NewErrorResponse(http.StatusInternalServerError, err.Error())
@@ -264,13 +264,13 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		return response.NewErrorResponse(http.StatusNotFound, "Instance not found")
 	}
 
-	fmt.Println("Pickles: Running c.ElasticsearchService.FetchPlan(..) ... \n")
+	fmt.Println("Pickles: Running c.ElasticsearchService.FetchPlan(..) ... ")
 	plan, planErr := c.ElasticsearchService.FetchPlan(baseInstance.PlanID)
 	if planErr != nil {
 		return planErr
 	}
 
-	fmt.Println("Pickles: Running initializeAdapter(..) ... \n")
+	fmt.Println("Pickles: Running initializeAdapter(..) ... ")
 	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -290,9 +290,15 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		broker.logger.Debug(fmt.Sprintf("Deletion Job state: %s\n Message: %s\n", jobstate.State.String(), jobstate.Message))
 
 	default: //all other ops use synchronous checking of aws api
-		status, _ = adapter.checkElasticsearchStatus(&existingInstance)
-		if err := broker.brokerDB.Save(&existingInstance).Error; err != nil {
-			return response.NewErrorResponse(http.StatusInternalServerError, err.Error())
+		// status, _ = adapter.checkElasticsearchStatus(&existingInstance)
+		// if err := broker.brokerDB.Save(&existingInstance).Error; err != nil {
+		// 	return response.NewErrorResponse(http.StatusInternalServerError, err.Error())
+		// }
+
+		status, statusErr = adapter.checkElasticsearchStatus(&existingInstance)
+		if statusErr != nil {
+			fmt.Printf("Error checking Elasticsearch status: %v", statusErr)
+			return response.NewErrorResponse(http.StatusInternalServerError, statusErr.Error())
 		}
 	}
 

--- a/services/elasticsearch/broker.go
+++ b/services/elasticsearch/broker.go
@@ -228,21 +228,21 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 		return response.NewErrorResponse(http.StatusBadRequest, "Updating Elasticsearch service instances is not supported at this time.")
 	}
 
-	fmt.Printf("Pickles: Attempting esInstance.update(options) ... \n")
+	fmt.Println("Pickles: Attempting esInstance.update(options) ... \n")
 	err := esInstance.update(options)
 	if err != nil {
 		broker.logger.Error("Updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error updating Elasticsearch service instance")
 	}
 
-	fmt.Printf("Pickles: Attempting adapter.modifyElasticsearch(&esInstance) ... \n")
+	fmt.Println("Pickles: Attempting adapter.modifyElasticsearch(&esInstance) ... \n")
 	_, err = adapter.modifyElasticsearch(&esInstance)
 	if err != nil {
 		broker.logger.Error("AWS call updating instance failed", err)
 		return response.NewErrorResponse(http.StatusBadRequest, "Error modifying Elasticsearch service instance")
 	}
 
-	fmt.Printf("Pickles: Attempting to broker.brokerDB.Save ... \n")
+	fmt.Println("Pickles: Attempting to broker.brokerDB.Save ... \n")
 	err = broker.brokerDB.Save(&esInstance).Error
 	if err != nil {
 		broker.logger.Error("Saving instance failed", err)
@@ -255,7 +255,7 @@ func (broker *elasticsearchBroker) ModifyInstance(c *catalog.Catalog, id string,
 func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, baseInstance base.Instance, operation string) response.Response {
 	existingInstance := ElasticsearchInstance{}
 
-	fmt.Printf("Pickles: Running LastOperation(..) ... \n")
+	fmt.Println("Pickles: Running LastOperation(..) ... \n")
 	var count int64
 	if err := broker.brokerDB.Where("uuid = ?", id).First(&existingInstance).Count(&count).Error; err != nil {
 		response.NewErrorResponse(http.StatusInternalServerError, err.Error())
@@ -264,13 +264,13 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		return response.NewErrorResponse(http.StatusNotFound, "Instance not found")
 	}
 
-	fmt.Printf("Pickles: Running c.ElasticsearchService.FetchPlan(..) ... \n")
+	fmt.Println("Pickles: Running c.ElasticsearchService.FetchPlan(..) ... \n")
 	plan, planErr := c.ElasticsearchService.FetchPlan(baseInstance.PlanID)
 	if planErr != nil {
 		return planErr
 	}
 
-	fmt.Printf("Pickles: Running initializeAdapter(..) ... \n")
+	fmt.Println("Pickles: Running initializeAdapter(..) ... \n")
 	adapter, adapterErr := initializeAdapter(plan, broker.settings, broker.logger)
 	if adapterErr != nil {
 		return adapterErr
@@ -279,7 +279,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 	var state string
 	var status base.InstanceState
 
-	fmt.Printf("Pickles: operation", operation)
+	fmt.Printf("Pickles: operation: %s ... \n", operation)
 	switch operation {
 	case base.DeleteOp.String(): // delete is true concurrent operation
 		jobstate, err := broker.taskqueue.GetTaskState(existingInstance.ServiceID, existingInstance.Uuid, base.DeleteOp)
@@ -296,7 +296,7 @@ func (broker *elasticsearchBroker) LastOperation(c *catalog.Catalog, id string, 
 		}
 	}
 
-	fmt.Printf("Pickles: status", status)
+	fmt.Printf("Pickles: status: %s ... \n", status)
 	switch status {
 	case base.InstanceInProgress:
 		state = "in progress"

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -317,9 +317,7 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 			// Instance not up yet.
 			return base.InstanceNotCreated, errors.New("Instance not available yet. Please wait and try again..")
 		}
-	} else {
-		return base.InstanceNotCreated, nil
-	}
+	    return base.InstanceNotCreated, nil
 
 }
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -280,11 +280,7 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 	// First, we need to check if the instance state
 	// Only search for details if the instance was not indicated as ready.
 
-	fmt.Printf("Pickles: i.State: %s ... \n", i.State)
-	fmt.Printf("Pickles: base.InstanceReady: %s ... \n", base.InstanceReady)
-
 	if i.State != base.InstanceReady {
-		fmt.Println("Pickles: i.State != base.InstanceReady... ")
 		params := &opensearchservice.DescribeDomainInput{
 			DomainName: aws.String(i.Domain), // Required
 		}
@@ -322,7 +318,6 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 			return base.InstanceNotCreated, errors.New("Instance not available yet. Please wait and try again..")
 		}
 	} else {
-		fmt.Println("Pickles: i.State = base.InstanceReady... ")
 		return base.InstanceNotCreated, nil
 	}
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -279,7 +279,12 @@ func (d *dedicatedElasticsearchAdapter) deleteElasticsearch(i *ElasticsearchInst
 func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *ElasticsearchInstance) (base.InstanceState, error) {
 	// First, we need to check if the instance state
 	// Only search for details if the instance was not indicated as ready.
+
+	fmt.Printf("Pickles: i.State: %s ... \n", i.State)
+	fmt.Printf("Pickles: base.InstanceReady: %s ... \n", base.InstanceReady)
+
 	if i.State != base.InstanceReady {
+		fmt.Println("Pickles: i.State != base.InstanceReady... ")
 		params := &opensearchservice.DescribeDomainInput{
 			DomainName: aws.String(i.Domain), // Required
 		}
@@ -316,9 +321,11 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 			// Instance not up yet.
 			return base.InstanceNotCreated, errors.New("Instance not available yet. Please wait and try again..")
 		}
+	} else {
+		fmt.Println("Pickles: i.State = base.InstanceReady... ")
+		return base.InstanceNotCreated, nil
 	}
 
-	return base.InstanceNotCreated, nil
 }
 
 func (d *dedicatedElasticsearchAdapter) didAwsCallSucceed(err error) bool {

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -301,6 +301,8 @@ func (d *dedicatedElasticsearchAdapter) checkElasticsearchStatus(i *Elasticsearc
 			return base.InstanceNotCreated, err
 		}
 
+		fmt.Println(fmt.Printf("domain status: %s", resp.DomainStatus))
+
 		if resp.DomainStatus.Created != nil && *(resp.DomainStatus.Created) {
 			switch *(resp.DomainStatus.Processing) {
 			case false:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add the terraform configuration for `pgaudit`, similar to what was done for terraform-provision for all the RDS instances managed there.
- Fix for modifyElasticsearch() function to update the state properly, was causing the acceptance tests to fail on update step of `smoke-tests-elasticsearch-advanced-options`
- Part of https://github.com/cloud-gov/private/issues/2485

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No new secrets or desired behaviors
