### PR TITLE
Log replication commands

### DIFF
--- a/ci/terraform/rds_module/database.tf
+++ b/ci/terraform/rds_module/database.tf
@@ -17,7 +17,7 @@ resource "aws_db_instance" "rds_database" {
 
   auto_minor_version_upgrade = true
 
-  db_name              = var.rds_db_name
+  db_name           = var.rds_db_name
   allocated_storage = var.rds_db_size
   storage_type      = var.rds_db_storage_type
   iops              = var.rds_db_size < 400 && var.rds_db_engine == "postgres" ? null : var.rds_db_iops

--- a/ci/terraform/rds_module/parameter_group.tf
+++ b/ci/terraform/rds_module/parameter_group.tf
@@ -53,6 +53,11 @@ resource "aws_db_parameter_group" "recreatable_parameter_group_postgres" {
     }
   }
 
+  parameter {
+    name  = "log_replication_commands"
+    value = 1
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,5 @@ applications:
   buildpack: go_buildpack
   memory: 256M
   env:
-    GOVERSION: go1.23
+
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,5 @@ applications:
   buildpack: go_buildpack
   memory: 256M
   env:
-    GOVERSION: go1.22
+    GOVERSION: go1.23
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding parameter group option `log_replication_commands` to log if a replication status per Nessus
- Removing `GOVERSION` to no longer compete with whatever version the buildpack has by default.
- `database.tf` changed some whitespace as the result of a `terraform fmt`
- Part of https://github.com/cloud-gov/private/issues/2425

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adds a parameter group option because of a Nessus finding, should make the RDS instance a touch more secure-ish
