### PR TITLE
Nessus RDS finding: 3.1.22 Ensure 'log_error_verbosity' is set correctly

### DIFF
--- a/ci/terraform/rds_module/parameter_group.tf
+++ b/ci/terraform/rds_module/parameter_group.tf
@@ -58,6 +58,11 @@ resource "aws_db_parameter_group" "recreatable_parameter_group_postgres" {
     value = 1
   }
 
+  parameter {
+    name  = "log_error_verbosity"
+    value = "verbose"
+  }
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding parameter group option log_error_verbosity to `verbose` status per Nessus
- Part of https://github.com/cloud-gov/private/issues/2414
-

## Security considerations

Adds a parameter group option because of a Nessus finding, should make the RDS instance a touch more secure-ish
