### PR TITLE
fix logic for taking last snapshot when deleting elasticsearch instance

### DIFF
--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -407,7 +407,7 @@ func (d *dedicatedElasticsearchAdapter) asyncDeleteElasticSearchDomain(i *Elasti
 
 	err := d.takeLastSnapshot(i, password)
 	if err != nil {
-		desc := fmt.Sprintf("asyncDelete - \n\t takeLastSnapshot returned error: %v\n", err)
+		desc := fmt.Sprintf("asyncDeleteElasticSearchDomain - \t takeLastSnapshot returned error: %v\n", err)
 		fmt.Println(desc)
 		msg.JobState.State = base.InstanceNotGone
 		msg.JobState.Message = desc
@@ -417,7 +417,7 @@ func (d *dedicatedElasticsearchAdapter) asyncDeleteElasticSearchDomain(i *Elasti
 
 	err = d.writeManifestToS3(i, password)
 	if err != nil {
-		desc := fmt.Sprintf("asyncDelete - \n\t writeManifestToS3 returned error: %v\n", err)
+		desc := fmt.Sprintf("asyncDeleteElasticSearchDomain - \t writeManifestToS3 returned error: %v\n", err)
 		fmt.Println(desc)
 		msg.JobState.State = base.InstanceNotGone
 		msg.JobState.Message = desc
@@ -427,7 +427,7 @@ func (d *dedicatedElasticsearchAdapter) asyncDeleteElasticSearchDomain(i *Elasti
 
 	err = d.cleanupRolesAndPolicies(i)
 	if err != nil {
-		desc := fmt.Sprintf("asyncDelete - \n\t cleanupRolesAndPolicies returned error: %v\n", err)
+		desc := fmt.Sprintf("asyncDeleteElasticSearchDomain - \t cleanupRolesAndPolicies returned error: %v\n", err)
 		fmt.Println(desc)
 		msg.JobState.State = base.InstanceNotGone
 		msg.JobState.Message = desc
@@ -437,7 +437,7 @@ func (d *dedicatedElasticsearchAdapter) asyncDeleteElasticSearchDomain(i *Elasti
 
 	err = d.cleanupElasticSearchDomain(i)
 	if err != nil {
-		desc := fmt.Sprintf("asyncDelete - \n\t cleanupElasticSearchDomain returned error: %v\n", err)
+		desc := fmt.Sprintf("asyncDeleteElasticSearchDomain - \t cleanupElasticSearchDomain returned error: %v\n", err)
 		fmt.Println(desc)
 		msg.JobState.State = base.InstanceNotGone
 		msg.JobState.Message = desc
@@ -518,7 +518,7 @@ func (d *dedicatedElasticsearchAdapter) takeLastSnapshot(i *ElasticsearchInstanc
 			d.logger.Error("GetSnapShotStatus failed", err)
 			return err
 		}
-		if res != "IN_PROGRESS" {
+		if res == "SUCCESS" {
 			break
 		}
 		time.Sleep(sleep)

--- a/services/elasticsearch/elasticsearch_api.go
+++ b/services/elasticsearch/elasticsearch_api.go
@@ -163,8 +163,7 @@ func (es *EsApiHandler) GetSnapshotRepo(reponame string) (string, error) {
 }
 
 func (es *EsApiHandler) GetSnapshotStatus(reponame string, snapshotname string) (string, error) {
-
-	endpoint := "/_snapshot/" + reponame + "/" + snapshotname + "/_status"
+	endpoint := "/_snapshot/" + reponame + "/" + snapshotname
 	resp, err := es.Send(http.MethodGet, endpoint, "")
 	if err != nil {
 		fmt.Printf("es_api getsnapshot status error %v", err)


### PR DESCRIPTION
## Changes proposed in this pull request:

Elasticsearch instance deletion is sometimes failing with:

```text
 takeLastSnapshot returned error: SnapshotStatus returned empty
```

An internet search suggests that Snapshot Status returning empty is not indicative of a failure taking a snapshot. However, [the documentation on the snapshot status endpoint says that it is used to get the status of ongoing snapshots](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-status). So if a snapshot has finished, the status endpoint may not return it, but this is not really an error.

To resolve the issue, I've updated the code to use the [snapshot information API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-get) to check whether snapshot creation was successful. This API should be a reliable way to determine when a snapshot is completed.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug
