### PR TITLE
Add reconcile RDS parameter groups task

### DIFF
--- a/cmd/tasks/main.go
+++ b/cmd/tasks/main.go
@@ -17,7 +17,6 @@ import (
 
 	tasksElasticache "github.com/cloud-gov/aws-broker/cmd/tasks/elasticache"
 	tasksOpensearch "github.com/cloud-gov/aws-broker/cmd/tasks/opensearch"
-	"github.com/cloud-gov/aws-broker/cmd/tasks/rds"
 	tasksRds "github.com/cloud-gov/aws-broker/cmd/tasks/rds"
 
 	"github.com/cloud-gov/aws-broker/catalog"
@@ -43,7 +42,7 @@ func (s *serviceNames) Set(value string) error {
 var servicesToTag serviceNames
 
 func run() error {
-	actionPtr := flag.String("action", "", "Action to take. Accepted options: 'reconcile-tags', 'reconcile-log-groups'")
+	actionPtr := flag.String("action", "", "Action to take. Accepted options: 'reconcile-tags', 'reconcile-log-groups', 'reconcile-parameter-groups'")
 	flag.Var(&servicesToTag, "service", "Specify AWS service whose instances should have tags updated. Accepted options: 'rds', 'elasticache', 'elasticsearch', 'opensearch'")
 	flag.Parse()
 
@@ -119,7 +118,17 @@ func run() error {
 
 		if slices.Contains(servicesToTag, "rds") {
 			rdsClient := awsRds.New(sess)
-			err := rds.ReconcileRDSCloudwatchLogGroups(logsClient, rdsClient, settings.DbNamePrefix, db)
+			err := tasksRds.ReconcileRDSCloudwatchLogGroups(logsClient, rdsClient, settings.DbNamePrefix, db)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if *actionPtr == "reconcile-parameter-groups" {
+		if slices.Contains(servicesToTag, "rds") {
+			rdsClient := awsRds.New(sess)
+			err := tasksRds.ReconcileRDSParameterGroups(rdsClient, db)
 			if err != nil {
 				return err
 			}

--- a/cmd/tasks/main.go
+++ b/cmd/tasks/main.go
@@ -39,18 +39,18 @@ func (s *serviceNames) Set(value string) error {
 	return nil
 }
 
-var servicesToTag serviceNames
+var services serviceNames
 
 func run() error {
 	actionPtr := flag.String("action", "", "Action to take. Accepted options: 'reconcile-tags', 'reconcile-log-groups', 'reconcile-parameter-groups'")
-	flag.Var(&servicesToTag, "service", "Specify AWS service whose instances should have tags updated. Accepted options: 'rds', 'elasticache', 'elasticsearch', 'opensearch'")
+	flag.Var(&services, "service", "Specify AWS service whose instances should have tags updated. Accepted options: 'rds', 'elasticache', 'elasticsearch', 'opensearch'")
 	flag.Parse()
 
 	if *actionPtr == "" {
 		log.Fatal("--action flag is required")
 	}
 
-	if len(servicesToTag) == 0 {
+	if len(services) == 0 {
 		return errors.New("--service argument is required. Specify --service multiple times to update tags for multiple services")
 	}
 
@@ -90,21 +90,21 @@ func run() error {
 
 		logsClient := cloudwatchlogs.New(sess)
 
-		if slices.Contains(servicesToTag, "rds") {
+		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
 			err := tasksRds.ReconcileResourceTagsForAllRDSDatabases(c, db, rdsClient, logsClient, tagManager)
 			if err != nil {
 				return err
 			}
 		}
-		if slices.Contains(servicesToTag, "elasticache") {
+		if slices.Contains(services, "elasticache") {
 			elasticacheClient := elasticache.New(sess)
 			err := tasksElasticache.ReconcileElasticacheResourceTags(c, db, elasticacheClient, tagManager)
 			if err != nil {
 				return err
 			}
 		}
-		if slices.Contains(servicesToTag, "elasticsearch") || slices.Contains(servicesToTag, "opensearch") {
+		if slices.Contains(services, "elasticsearch") || slices.Contains(services, "opensearch") {
 			opensearchClient := opensearchservice.New(sess)
 			err := tasksOpensearch.ReconcileOpensearchResourceTags(c, db, opensearchClient, tagManager)
 			if err != nil {
@@ -116,7 +116,7 @@ func run() error {
 	if *actionPtr == "reconcile-log-groups" {
 		logsClient := cloudwatchlogs.New(sess)
 
-		if slices.Contains(servicesToTag, "rds") {
+		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
 			err := tasksRds.ReconcileRDSCloudwatchLogGroups(logsClient, rdsClient, settings.DbNamePrefix, db)
 			if err != nil {
@@ -126,7 +126,7 @@ func run() error {
 	}
 
 	if *actionPtr == "reconcile-parameter-groups" {
-		if slices.Contains(servicesToTag, "rds") {
+		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
 			err := tasksRds.ReconcileRDSParameterGroups(rdsClient, db)
 			if err != nil {

--- a/cmd/tasks/rds/parameter_groups.go
+++ b/cmd/tasks/rds/parameter_groups.go
@@ -1,0 +1,71 @@
+package rds
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awsRds "github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/cloud-gov/aws-broker/services/rds"
+	"gorm.io/gorm"
+)
+
+func reconcileDbParameterGroup(rdsClient rdsiface.RDSAPI, rdsInstance rds.RDSInstance) error {
+	resp, err := rdsClient.DescribeDBInstances(&awsRds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(rdsInstance.Database),
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == awsRds.ErrCodeDBInstanceNotFoundFault {
+				log.Printf("Could not find database %s, continuing", rdsInstance.Database)
+				return nil
+			} else {
+				return fmt.Errorf("could not describe database instance: %s", err)
+			}
+		} else {
+			return fmt.Errorf("could not describe database instance: %s", err)
+		}
+	}
+
+	if len(resp.DBInstances) == 0 {
+		return fmt.Errorf("could not find database instance info for %s", rdsInstance.Database)
+	}
+
+	instanceInfo := resp.DBInstances[0]
+
+	if rdsInstance.ParameterGroupName == "" && len(instanceInfo.DBParameterGroups) > 0 {
+		log.Printf("Database %s has parameter groups, but none are recorded in the broker database", rdsInstance.Database)
+	}
+
+	if len(instanceInfo.DBParameterGroups) == 0 && rdsInstance.ParameterGroupName != "" {
+		log.Printf("Database %s has no parameter groups, but one is recorded in the broker database", rdsInstance.Database)
+	}
+
+	return nil
+}
+
+func ReconcileRDSParameterGroups(rdsClient rdsiface.RDSAPI, dbNamePrefix string, db *gorm.DB) error {
+	rows, err := db.Model(&rds.RDSInstance{}).Rows()
+	if err != nil {
+		return err
+	}
+
+	var errs error
+
+	for rows.Next() {
+		var rdsInstance rds.RDSInstance
+		db.ScanRows(rows, &rdsInstance)
+
+		err := reconcileDbParameterGroup(rdsClient, rdsInstance)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+	}
+
+	return errs
+}

--- a/cmd/tasks/rds/parameter_groups.go
+++ b/cmd/tasks/rds/parameter_groups.go
@@ -48,7 +48,7 @@ func reconcileDbParameterGroup(rdsClient rdsiface.RDSAPI, rdsInstance rds.RDSIns
 	return nil
 }
 
-func ReconcileRDSParameterGroups(rdsClient rdsiface.RDSAPI, dbNamePrefix string, db *gorm.DB) error {
+func ReconcileRDSParameterGroups(rdsClient rdsiface.RDSAPI, db *gorm.DB) error {
 	rows, err := db.Model(&rds.RDSInstance{}).Rows()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR adds a task that can be run to reconcile the actual parameter groups attached to brokered RDS instances with what is tracked by the broker's database. Have the state reconciled allows the broker to clean up and tag resources appropriately

For now, the task is written to just log its findings, not actually update any broker database records.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. This code is not sensitive
