### PR TITLE
Add task to find orphaned instances

### DIFF
--- a/cmd/tasks/main.go
+++ b/cmd/tasks/main.go
@@ -42,7 +42,7 @@ func (s *serviceNames) Set(value string) error {
 var services serviceNames
 
 func run() error {
-	actionPtr := flag.String("action", "", "Action to take. Accepted options: 'reconcile-tags', 'reconcile-log-groups', 'reconcile-parameter-groups'")
+	actionPtr := flag.String("action", "", "Action to take. Accepted options: 'reconcile-tags', 'reconcile-log-groups', 'reconcile-parameter-groups', 'find-orphaned-instances'")
 	flag.Var(&services, "service", "Specify AWS service whose instances should have tags updated. Accepted options: 'rds', 'elasticache', 'elasticsearch', 'opensearch'")
 	flag.Parse()
 
@@ -129,6 +129,16 @@ func run() error {
 		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
 			err := tasksRds.ReconcileRDSParameterGroups(rdsClient, db)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if *actionPtr == "find-orphaned-instances" {
+		if slices.Contains(services, "rds") {
+			rdsClient := awsRds.New(sess)
+			err := tasksRds.FindOrphanedInstances(rdsClient, db)
 			if err != nil {
 				return err
 			}

--- a/cmd/tasks/main.go
+++ b/cmd/tasks/main.go
@@ -138,7 +138,7 @@ func run() error {
 	if *actionPtr == "find-orphaned-instances" {
 		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
-			err := tasksRds.FindOrphanedInstances(rdsClient, db)
+			err := tasksRds.FindOrphanedInstances(rdsClient, db, settings.DbNamePrefix)
 			if err != nil {
 				return err
 			}

--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -3,6 +3,7 @@ package rds
 import (
 	"errors"
 	"log"
+	"strings"
 
 	awsRds "github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -10,13 +11,18 @@ import (
 	"gorm.io/gorm"
 )
 
-func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB) error {
+func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix string) error {
 	err := rdsClient.DescribeDBInstancesPages(&awsRds.DescribeDBInstancesInput{}, func(page *awsRds.DescribeDBInstancesOutput, lastPage bool) bool {
 		for _, dbInstance := range page.DBInstances {
+			dbName := *dbInstance.DBName
+			if !strings.Contains(dbName, dbNamePrefix) {
+				log.Printf("database %s is not a brokered database, continuing", dbName)
+				continue
+			}
 			var rdsDatabase rds.RDSInstance
-			err := db.Where(&rds.RDSInstance{Database: *dbInstance.DBName}).First(&rdsDatabase).Error
+			err := db.Where(&rds.RDSInstance{Database: dbName}).First(&rdsDatabase).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				log.Printf("database %s does not exist in the broker database", *dbInstance.DBName)
+				log.Printf("database %s does not exist in the broker database", dbName)
 			} else {
 				log.Printf("encountered error trying to fetch record from database: %s", err)
 			}

--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -1,0 +1,34 @@
+package rds
+
+import (
+	"errors"
+	"log"
+
+	awsRds "github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/cloud-gov/aws-broker/services/rds"
+	"gorm.io/gorm"
+)
+
+func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB) error {
+	err := rdsClient.DescribeDBInstancesPages(&awsRds.DescribeDBInstancesInput{}, func(page *awsRds.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbInstance := range page.DBInstances {
+			var rdsDatabase rds.RDSInstance
+			err := db.Where(&rds.RDSInstance{Database: *dbInstance.DBName}).First(&rdsDatabase).Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Printf("database %s does not exist in the broker database", *dbInstance.DBName)
+
+			} else {
+				log.Printf("encountered error trying to fetch record from database: %s", err)
+			}
+			continue
+		}
+		return !lastPage // Continue iterating until the last page is reached.
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -17,7 +17,6 @@ func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB) error {
 			err := db.Where(&rds.RDSInstance{Database: *dbInstance.DBName}).First(&rdsDatabase).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				log.Printf("database %s does not exist in the broker database", *dbInstance.DBName)
-
 			} else {
 				log.Printf("encountered error trying to fetch record from database: %s", err)
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add task to find RDS instances that have no corresponding record in the broker

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. This code is not sensitive
