### PR TITLE
fix logic for finding orphaned RDS instances

### DIFF
--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -14,15 +14,15 @@ import (
 func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix string) error {
 	err := rdsClient.DescribeDBInstancesPages(&awsRds.DescribeDBInstancesInput{}, func(page *awsRds.DescribeDBInstancesOutput, lastPage bool) bool {
 		for _, dbInstance := range page.DBInstances {
-			dbName := *dbInstance.DBName
-			if !strings.Contains(dbName, dbNamePrefix) {
-				log.Printf("database %s is not a brokered database, continuing", dbName)
+			instanceName := *dbInstance.DBInstanceIdentifier
+			if !strings.Contains(instanceName, dbNamePrefix) {
+				log.Printf("database %s is not a brokered database, continuing", instanceName)
 				continue
 			}
 			var rdsDatabase rds.RDSInstance
-			err := db.Where(&rds.RDSInstance{Database: dbName}).First(&rdsDatabase).Error
+			err := db.Where(&rds.RDSInstance{Database: instanceName}).First(&rdsDatabase).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				log.Printf("database %s does not exist in the broker database", dbName)
+				log.Printf("database %s does not exist in the broker database", instanceName)
 			} else {
 				log.Printf("encountered error trying to fetch record from database: %s", err)
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix logic for finding orphaned RDS instances

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing logic in a reconciliation task for finding RDS databases that are no longer tracked by the broker
