### PR TITLE
improve logic for task to find orphaned database instances

### DIFF
--- a/cmd/tasks/main.go
+++ b/cmd/tasks/main.go
@@ -138,7 +138,7 @@ func run() error {
 	if *actionPtr == "find-orphaned-instances" {
 		if slices.Contains(services, "rds") {
 			rdsClient := awsRds.New(sess)
-			err := tasksRds.FindOrphanedInstances(rdsClient, db, settings.DbNamePrefix)
+			err := tasksRds.FindOrphanedInstances(rdsClient, db, settings.DbNamePrefix, settings.DbConfig.URL)
 			if err != nil {
 				return err
 			}

--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -11,20 +11,26 @@ import (
 	"gorm.io/gorm"
 )
 
-func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix string) error {
+func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix string, dbConfigUrl string) error {
 	err := rdsClient.DescribeDBInstancesPages(&awsRds.DescribeDBInstancesInput{}, func(page *awsRds.DescribeDBInstancesOutput, lastPage bool) bool {
 		for _, dbInstance := range page.DBInstances {
 			instanceName := *dbInstance.DBInstanceIdentifier
 			if !strings.Contains(instanceName, dbNamePrefix) {
-				log.Printf("database %s is not a brokered database, continuing", instanceName)
+				log.Printf("database %s is not a brokered database for this environment, continuing", instanceName)
+				continue
+			}
+			if strings.Contains(dbConfigUrl, instanceName) {
+				log.Printf("database %s is the database for the broker itself, continuing", instanceName)
 				continue
 			}
 			var rdsDatabase rds.RDSInstance
 			err := db.Where(&rds.RDSInstance{Database: instanceName}).First(&rdsDatabase).Error
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				log.Printf("database %s does not exist in the broker database", instanceName)
-			} else {
-				log.Printf("encountered error trying to fetch record from database: %s", err)
+			if err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					log.Printf("database %s does not exist in the broker database", instanceName)
+				} else {
+					log.Printf("encountered error trying to fetch record from database: %s", err)
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
## Changes proposed in this pull request:

- improve error handling and add condition to skip database for the broker's database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improving task logic
