### PR TITLE
fix logic for reconcile parameter groups task 

### DIFF
--- a/cmd/tasks/rds/parameter_groups.go
+++ b/cmd/tasks/rds/parameter_groups.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -38,7 +39,11 @@ func reconcileDbParameterGroup(rdsClient rdsiface.RDSAPI, rdsInstance rds.RDSIns
 	instanceInfo := resp.DBInstances[0]
 
 	if rdsInstance.ParameterGroupName == "" && len(instanceInfo.DBParameterGroups) > 0 {
-		log.Printf("Database %s has parameter groups, but none are recorded in the broker database", rdsInstance.Database)
+		for _, parameterGroup := range instanceInfo.DBParameterGroups {
+			if strings.HasPrefix(*parameterGroup.DBParameterGroupName, "cg-aws-broker-") {
+				log.Printf("Database %s has custom parameter group %s, but none are recorded in the broker database", rdsInstance.Database, *parameterGroup.DBParameterGroupName)
+			}
+		}
 	}
 
 	if len(instanceInfo.DBParameterGroups) == 0 && rdsInstance.ParameterGroupName != "" {


### PR DESCRIPTION


## Changes proposed in this pull request:

- fix logic for reconcile parameter groups task to check for customer parameter groups matching the expected prefix
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No impactful security changes, just fixing logic conditions 
