### PR TITLE
fix logic in RDS task

### DIFF
--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -24,7 +24,7 @@ func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix 
 				continue
 			}
 			var rdsDatabase rds.RDSInstance
-			err := db.Where(&rds.RDSInstance{Database: instanceName}).First(&rdsDatabase).Error
+			err := db.Where("database = ? OR replica_database = ?", instanceName).First(&rdsDatabase).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					log.Printf("database %s does not exist in the broker database", instanceName)

--- a/cmd/tasks/rds/databases.go
+++ b/cmd/tasks/rds/databases.go
@@ -24,7 +24,7 @@ func FindOrphanedInstances(rdsClient rdsiface.RDSAPI, db *gorm.DB, dbNamePrefix 
 				continue
 			}
 			var rdsDatabase rds.RDSInstance
-			err := db.Where("database = ? OR replica_database = ?", instanceName).First(&rdsDatabase).Error
+			err := db.Where("database = ? OR replica_database = ?", instanceName, instanceName).First(&rdsDatabase).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					log.Printf("database %s does not exist in the broker database", instanceName)


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix logic in task for finding orphaned instances to check for match on database or replica database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The updated SQL command still uses parameter escaping for input: https://gorm.io/docs/query.html#String-Conditions