### PR TITLE
update uri connection string in credentials for Redis instances 

### DIFF
--- a/services/redis/redisinstance.go
+++ b/services/redis/redisinstance.go
@@ -82,7 +82,7 @@ func (i *RedisInstance) getPassword(key string) (string, error) {
 func (i *RedisInstance) getCredentials(password string) (map[string]string, error) {
 	var credentials map[string]string
 
-	uri := fmt.Sprintf("redis://:%s@%s:%d",
+	uri := fmt.Sprintf("rediss://:%s@%s:%d",
 		password,
 		i.Host,
 		i.Port)

--- a/services/redis/redisinstance_test.go
+++ b/services/redis/redisinstance_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"testing"
 
+	"github.com/cloud-gov/aws-broker/base"
 	"github.com/cloud-gov/aws-broker/catalog"
 	"github.com/cloud-gov/aws-broker/config"
 	"github.com/cloud-gov/aws-broker/helpers"
@@ -39,6 +40,33 @@ func TestInitInstanceTags(t *testing.T) {
 	}
 
 	if diff := deep.Equal(instance.Tags, expectedTags); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestGetCredentials(t *testing.T) {
+	instance := &RedisInstance{
+		Instance: base.Instance{
+			Host: "host",
+			Port: 6379,
+		},
+		EngineVersion: "5",
+	}
+
+	credentials, err := instance.getCredentials("foobar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCredentials := map[string]string{
+		"uri":                          "rediss://:foobar@host:6379",
+		"password":                     "foobar",
+		"host":                         "host",
+		"hostname":                     "host",
+		"current_redis_engine_version": "5",
+		"port":                         "6379",
+	}
+
+	if diff := deep.Equal(credentials, expectedCredentials); diff != nil {
 		t.Error(diff)
 	}
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

[This broker has enforced that encryption in transit is enabled for Redis instances for at least 5 years](https://github.com/cloud-gov/aws-broker/blame/a6186b23483f6a833c4863f1005d5836c2abbcb8/services/redis/redis.go#L116). And when connecting to Redis over TLS using a connection URL, the required protocol is `rediss://` (with two `s`), but the broker is still generating credentials where the protocol is `redis://` (with one `s`). 

If you try to use a connection string beginning with `redis://` to connect to a Redis instance with encryption in transit enabled, the connection will never successfully be made.

[This change is in line with a similar change made to the `cf-service-connect` plugin to include a TLS flag when creating connections to Redis instances](https://github.com/cloud-gov/cf-service-connect/pull/67).

- update uri connection string in credentials for Redis instances to use `rediss://` instead of `redis://`
- add unit test

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There is no security change here. The Redis instances provisioned by this broker already have TLS enabled for encryption in transit, going back at least 5 years. This PR merely ensures that the broker generates the correct URI credential for connecting to a Redis instance with encryption in transit enabled.
