### PR TITLE
Fix read replica delete

### DIFF
--- a/base/instance.go
+++ b/base/instance.go
@@ -75,8 +75,8 @@ type Instance struct {
 
 	State InstanceState
 
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	CreatedAt time.Time `deep:"-"`
+	UpdatedAt time.Time `deep:"-"`
 }
 
 // FindBaseInstance is a helper function to find the base instance of the

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -243,13 +243,19 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 		return response.NewErrorResponse(http.StatusBadRequest, "Invalid parameters. Error: "+err.Error())
 	}
 
-	// Fetch the new plan that has been requested.
-	newPlan, newPlanErr := c.RdsService.FetchPlan(modifyRequest.PlanID)
-	if newPlanErr != nil {
-		return newPlanErr
+	// Fetch the current plan.
+	currentPlan, errResponse := c.RdsService.FetchPlan(existingInstance.PlanID)
+	if errResponse != nil {
+		return errResponse
 	}
 
-	modifiedInstance, err := existingInstance.modify(options, newPlan, broker.settings)
+	// Fetch the new plan that has been requested.
+	newPlan, errResponse := c.RdsService.FetchPlan(modifyRequest.PlanID)
+	if errResponse != nil {
+		return errResponse
+	}
+
+	modifiedInstance, err := existingInstance.modify(options, currentPlan, newPlan, broker.settings)
 	if err != nil {
 		return response.NewErrorResponse(http.StatusBadRequest, "Failed to modify instance. Error: "+err.Error())
 	}

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -310,10 +310,6 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 		return response.NewErrorResponse(http.StatusBadRequest, desc)
 	}
 
-	if existingInstance.DeleteReadReplica {
-		existingInstance.ReplicaDatabase = ""
-	}
-
 	// Update the existing instance in the broker.
 	existingInstance.State = status
 	err = broker.brokerDB.Save(existingInstance).Error

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -310,6 +310,10 @@ func (broker *rdsBroker) ModifyInstance(c *catalog.Catalog, id string, modifyReq
 		return response.NewErrorResponse(http.StatusBadRequest, desc)
 	}
 
+	if existingInstance.DeleteReadReplica {
+		existingInstance.ReplicaDatabase = ""
+	}
+
 	// Update the existing instance in the broker.
 	existingInstance.State = status
 	err = broker.brokerDB.Save(existingInstance).Error

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -311,6 +311,53 @@ func TestModify(t *testing.T) {
 		modifyRequest        request.Request
 		expectedDbInstance   *RDSInstance
 	}{
+		"success": {
+			catalog: &catalog.Catalog{
+				RdsService: catalog.RDSService{
+					Plans: []catalog.RDSPlan{
+						{
+							Plan: catalog.Plan{
+								ID:             "123",
+								PlanUpdateable: true,
+							},
+						},
+						{
+							Plan: catalog.Plan{
+								ID: "456",
+							},
+						},
+					},
+				},
+			},
+			dbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Uuid: "uuid-1",
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+			},
+			expectedDbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Uuid: "uuid-1",
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "123",
+					},
+					State: base.InstanceReady,
+				},
+			},
+			tagManager: &mocks.MockTagGenerator{},
+			settings: &config.Settings{
+				EncryptionKey: helpers.RandStr(32),
+				Environment:   "test", // use the mock adapter
+			},
+			modifyRequest: request.Request{
+				PlanID: "123",
+			},
+			expectedResponseCode: http.StatusAccepted,
+		},
 		"success with replica": {
 			catalog: &catalog.Catalog{
 				RdsService: catalog.RDSService{

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -408,56 +408,6 @@ func TestModify(t *testing.T) {
 			},
 			expectedResponseCode: http.StatusAccepted,
 		},
-		"success with deleting replica": {
-			catalog: &catalog.Catalog{
-				RdsService: catalog.RDSService{
-					Plans: []catalog.RDSPlan{
-						{
-							Plan: catalog.Plan{
-								ID:             "123",
-								PlanUpdateable: true,
-							},
-						},
-						{
-							Plan: catalog.Plan{
-								ID: "456",
-							},
-							Redundant:   true,
-							ReadReplica: true,
-						},
-					},
-				},
-			},
-			dbInstance: &RDSInstance{
-				Instance: base.Instance{
-					Uuid: "uuid-2",
-					Request: request.Request{
-						ServiceID: "service-1",
-						PlanID:    "456",
-					},
-				},
-				ReplicaDatabase: "replica",
-			},
-			expectedDbInstance: &RDSInstance{
-				Instance: base.Instance{
-					Uuid: "uuid-2",
-					Request: request.Request{
-						ServiceID: "service-1",
-						PlanID:    "123",
-					},
-					State: base.InstanceReady,
-				},
-			},
-			tagManager: &mocks.MockTagGenerator{},
-			settings: &config.Settings{
-				EncryptionKey: helpers.RandStr(32),
-				Environment:   "test", // use the mock adapter
-			},
-			modifyRequest: request.Request{
-				PlanID: "123",
-			},
-			expectedResponseCode: http.StatusAccepted,
-		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -324,8 +324,7 @@ func TestModify(t *testing.T) {
 						},
 						{
 							Plan: catalog.Plan{
-								ID:             "456",
-								PlanUpdateable: true,
+								ID: "456",
 							},
 						},
 					},

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -322,6 +322,12 @@ func TestModify(t *testing.T) {
 							Redundant:   true,
 							ReadReplica: true,
 						},
+						{
+							Plan: catalog.Plan{
+								ID:             "456",
+								PlanUpdateable: true,
+							},
+						},
 					},
 				},
 			},

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/cloud-gov/aws-broker/base"
@@ -95,6 +96,7 @@ type mockRDSClient struct {
 	modifyDbErrs                        []error
 	modifyDbCallNum                     int
 	modifyDbParamGroupErr               error
+	addTagsToResourceErr                error
 }
 
 func (m *mockRDSClient) CreateDBInstance(*rds.CreateDBInstanceInput) (*rds.CreateDBInstanceOutput, error) {
@@ -175,7 +177,11 @@ func (m *mockRDSClient) DescribeDBInstances(input *rds.DescribeDBInstancesInput)
 }
 
 func (m *mockRDSClient) CreateDBInstanceReadReplica(*rds.CreateDBInstanceReadReplicaInput) (*rds.CreateDBInstanceReadReplicaOutput, error) {
-	return nil, m.createDBInstanceReadReplicaErr
+	return &rds.CreateDBInstanceReadReplicaOutput{
+		DBInstance: &rds.DBInstance{
+			DBInstanceArn: aws.String("arn"),
+		},
+	}, m.createDBInstanceReadReplicaErr
 }
 
 func (m *mockRDSClient) ModifyDBInstance(*rds.ModifyDBInstanceInput) (*rds.ModifyDBInstanceOutput, error) {
@@ -191,5 +197,12 @@ func (m *mockRDSClient) DeleteDBInstance(*rds.DeleteDBInstanceInput) (*rds.Delet
 		return nil, m.deleteDbInstancesErrs[m.deleteDBInstancesCallNum]
 	}
 	m.deleteDBInstancesCallNum++
+	return nil, nil
+}
+
+func (m *mockRDSClient) AddTagsToResource(*rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
+	if m.addTagsToResourceErr != nil {
+		return nil, m.addTagsToResourceErr
+	}
 	return nil, nil
 }

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -189,7 +189,11 @@ func (m *mockRDSClient) ModifyDBInstance(*rds.ModifyDBInstanceInput) (*rds.Modif
 		return nil, m.modifyDbErrs[m.modifyDbCallNum]
 	}
 	m.modifyDbCallNum++
-	return nil, nil
+	return &rds.ModifyDBInstanceOutput{
+		DBInstance: &rds.DBInstance{
+			DBInstanceArn: aws.String("arn"),
+		},
+	}, nil
 }
 
 func (m *mockRDSClient) DeleteDBInstance(*rds.DeleteDBInstanceInput) (*rds.DeleteDBInstanceOutput, error) {

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -534,14 +534,14 @@ func (d *dedicatedDBAdapter) deleteDatabaseReadReplica(i *RDSInstance, operation
 	_, err := d.rds.DeleteDBInstance(params)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("Failed to delete replica database: %s", err))
-		fmt.Printf("asyncDeleteDB: %s\n", err)
+		fmt.Printf("deleteDatabaseReadReplica: %s\n", err)
 		return
 	}
 
 	err = d.waitForDbDeleted(operation, i, i.ReplicaDatabase)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("Failed to confirm replica database deletion: %s", err))
-		fmt.Printf("asyncDeleteDB: %s\n", err)
+		fmt.Printf("deleteDatabaseReadReplica: %s\n", err)
 		return
 	}
 }

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -345,10 +345,17 @@ func (d *dedicatedDBAdapter) asyncModifyDb(i *RDSInstance) {
 			return
 		}
 
-		_, err = d.rds.ModifyDBInstance(replicaModifyParams)
+		modifyReplicaOutput, err := d.rds.ModifyDBInstance(replicaModifyParams)
 		if err != nil {
 			jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))
 			fmt.Printf("asyncModifyDb, error modifying read replica: %s\n", err)
+			return
+		}
+
+		err = d.updateDBTags(i, *modifyReplicaOutput.DBInstance.DBInstanceArn)
+		if err != nil {
+			jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error updating tags for database replica: %s", err))
+			fmt.Printf("asyncModifyDb, error updating replica tags: %s\n", err)
 			return
 		}
 	}

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -548,6 +548,8 @@ func (d *dedicatedDBAdapter) deleteDatabaseReadReplica(i *RDSInstance, operation
 		return fmt.Errorf("deleteDatabaseReadReplica: %w", err)
 	}
 
+	i.ReplicaDatabase = ""
+
 	return nil
 }
 

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -350,7 +350,7 @@ func (d *dedicatedDBAdapter) asyncModifyDb(i *RDSInstance) {
 			fmt.Printf("asyncModifyDb, error creating read replica: %s\n", err)
 			return
 		}
-	} else if !i.AddReadReplica && i.ReplicaDatabase != "" {
+	} else if !i.DeleteReadReplica && !i.AddReadReplica && i.ReplicaDatabase != "" {
 		err := d.asyncModifyDbInstance(operation, i, i.ReplicaDatabase)
 		if err != nil {
 			jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -1605,8 +1605,6 @@ func TestBindDBToApp(t *testing.T) {
 			}
 
 			test.expectedInstance.Uuid = test.rdsInstance.Uuid
-			test.expectedInstance.CreatedAt = test.rdsInstance.CreatedAt
-			test.expectedInstance.UpdatedAt = test.rdsInstance.UpdatedAt
 
 			if diff := deep.Equal(test.rdsInstance, test.expectedInstance); diff != nil {
 				t.Error(diff)

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -781,6 +781,39 @@ func TestWaitAndCreateDBReadReplica(t *testing.T) {
 			expectedState: base.InstanceNotCreated,
 			expectErr:     true,
 		},
+		"error adding tags": {
+			dbAdapter: &dedicatedDBAdapter{
+				rds: &mockRDSClient{
+					addTagsToResourceErr: errors.New("error adding tags to read replica"),
+					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
+						{
+							DBInstances: []*rds.DBInstance{
+								{
+									DBInstanceStatus: aws.String("available"),
+								},
+							},
+						},
+					},
+				},
+				parameterGroupClient: &mockParameterGroupClient{},
+				settings: config.Settings{
+					PollAwsRetryDelaySeconds: 0,
+					PollAwsMaxRetries:        5,
+				},
+				db: brokerDB,
+			},
+			dbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Request: request.Request{
+						ServiceID: helpers.RandStr(10),
+					},
+					Uuid: helpers.RandStr(10),
+				},
+				Database: helpers.RandStr(10),
+			},
+			expectedState: base.InstanceNotCreated,
+			expectErr:     true,
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -152,7 +152,7 @@ func (i *RDSInstance) modify(options Options, currentPlan catalog.RDSPlan, newPl
 		modifiedInstance.ReplicaDatabase = modifiedInstance.generateDatabaseReplicaName()
 	}
 
-	if currentPlan.ReadReplica && !newPlan.ReadReplica {
+	if modifiedInstance.ReplicaDatabase != "" && currentPlan.ReadReplica && !newPlan.ReadReplica {
 		modifiedInstance.DeleteReadReplica = true
 	}
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -49,6 +49,7 @@ type RDSInstance struct {
 	AddReadReplica      bool   `gorm:"-"`
 	ReplicaDatabase     string `sql:"size(255)"`
 	ReplicaDatabaseHost string `sql:"size(255)"`
+	DeleteReadReplica   bool   `gorm:"-"`
 }
 
 func NewRDSInstance() *RDSInstance {
@@ -76,13 +77,13 @@ func (i *RDSInstance) generateCredentials(settings *config.Settings) error {
 	return nil
 }
 
-func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *config.Settings) (*RDSInstance, error) {
+func (i *RDSInstance) modify(options Options, currentPlan catalog.RDSPlan, newPlan catalog.RDSPlan, settings *config.Settings) (*RDSInstance, error) {
 	// Copy the existing instance so that we can return a modified instance rather than mutating the instance
 	modifiedInstance := i
-	modifiedInstance.PlanID = plan.ID
+	modifiedInstance.PlanID = newPlan.ID
 
 	// needed to create an RDS read replica
-	modifiedInstance.SecGroup = plan.SecurityGroup
+	modifiedInstance.SecGroup = newPlan.SecurityGroup
 
 	// Check to see if there is a storage size change and if so, check to make sure it's a valid change.
 	if options.AllocatedStorage > 0 {
@@ -104,7 +105,7 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *co
 	}
 
 	if modifiedInstance.StorageType == "" {
-		modifiedInstance.StorageType = plan.StorageType
+		modifiedInstance.StorageType = newPlan.StorageType
 	}
 
 	// Check if there is a backup retention change
@@ -142,13 +143,17 @@ func (i *RDSInstance) modify(options Options, plan catalog.RDSPlan, settings *co
 
 	modifiedInstance.setEnabledCloudwatchLogGroupExports(options.EnableCloudWatchLogGroupExports)
 
-	if plan.ReadReplica && !plan.Redundant {
+	if newPlan.ReadReplica && !newPlan.Redundant {
 		return nil, errors.New("database plan must be multi-AZ in order to support read replicas")
 	}
 
-	if plan.Redundant && plan.ReadReplica && modifiedInstance.ReplicaDatabase == "" {
+	if newPlan.Redundant && newPlan.ReadReplica && modifiedInstance.ReplicaDatabase == "" {
 		modifiedInstance.AddReadReplica = true
 		modifiedInstance.ReplicaDatabase = modifiedInstance.generateDatabaseReplicaName()
+	}
+
+	if currentPlan.ReadReplica && !newPlan.ReadReplica {
+		modifiedInstance.DeleteReadReplica = true
 	}
 
 	return modifiedInstance, nil

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -77,7 +77,7 @@ func (i *RDSInstance) generateCredentials(settings *config.Settings) error {
 	return nil
 }
 
-func (i *RDSInstance) modify(options Options, currentPlan catalog.RDSPlan, newPlan catalog.RDSPlan, settings *config.Settings) (*RDSInstance, error) {
+func (i *RDSInstance) modify(options Options, currentPlan catalog.RDSPlan, newPlan catalog.RDSPlan, settings *config.Settings, tags map[string]string) (*RDSInstance, error) {
 	// Copy the existing instance so that we can return a modified instance rather than mutating the instance
 	modifiedInstance := i
 	modifiedInstance.PlanID = newPlan.ID
@@ -155,6 +155,8 @@ func (i *RDSInstance) modify(options Options, currentPlan catalog.RDSPlan, newPl
 	if modifiedInstance.ReplicaDatabase != "" && currentPlan.ReadReplica && !newPlan.ReadReplica {
 		modifiedInstance.DeleteReadReplica = true
 	}
+
+	i.setTags(newPlan, tags)
 
 	return modifiedInstance, nil
 }

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -698,6 +698,34 @@ func TestModifyInstance(t *testing.T) {
 				Tags:              map[string]string{},
 			},
 		},
+		"updates tags": {
+			options: Options{},
+			existingInstance: &RDSInstance{
+				Database:        "db",
+				ReplicaDatabase: "replica",
+			},
+			currentPlan: catalog.RDSPlan{
+				ReadReplica: true,
+			},
+			newPlan: catalog.RDSPlan{
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			tags: map[string]string{
+				"foo2": "baz",
+			},
+			settings: &config.Settings{},
+			expectedInstance: &RDSInstance{
+				Database:          "db",
+				DeleteReadReplica: true,
+				ReplicaDatabase:   "replica",
+				Tags: map[string]string{
+					"foo":  "bar",
+					"foo2": "baz",
+				},
+			},
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -436,6 +436,7 @@ func TestModifyInstance(t *testing.T) {
 		newPlan          catalog.RDSPlan
 		settings         *config.Settings
 		expectedErr      error
+		tags             map[string]string
 	}{
 		"sets plan properties": {
 			options: Options{},
@@ -685,7 +686,7 @@ func TestModifyInstance(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			modifiedInstance, err := test.existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings)
+			modifiedInstance, err := test.existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings, test.tags)
 			if !test.expectErr && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -709,6 +710,7 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 		originalSalt            string
 		username                string
 		shouldRotateCredentials bool
+		tags                    map[string]string
 	}{
 		"rotate credentials": {
 			options: Options{
@@ -760,7 +762,7 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 				Salt:          test.originalSalt,
 				dbUtils:       &RDSDatabaseUtils{},
 			}
-			modifiedInstance, err := existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings)
+			modifiedInstance, err := existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings, test.tags)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -432,7 +432,8 @@ func TestModifyInstance(t *testing.T) {
 		existingInstance *RDSInstance
 		expectedInstance *RDSInstance
 		expectErr        bool
-		plan             catalog.RDSPlan
+		currentPlan      catalog.RDSPlan
+		newPlan          catalog.RDSPlan
 		settings         *config.Settings
 		expectedErr      error
 	}{
@@ -455,7 +456,8 @@ func TestModifyInstance(t *testing.T) {
 				},
 				SecGroup: "sec-group1",
 			},
-			plan: catalog.RDSPlan{
+			currentPlan: catalog.RDSPlan{},
+			newPlan: catalog.RDSPlan{
 				Plan: catalog.Plan{
 					ID: "plan-2",
 				},
@@ -473,8 +475,9 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"allocated storage option less than existing, does not update": {
 			options: Options{
@@ -483,9 +486,10 @@ func TestModifyInstance(t *testing.T) {
 			existingInstance: &RDSInstance{
 				AllocatedStorage: 20,
 			},
-			expectErr: true,
-			plan:      catalog.RDSPlan{},
-			settings:  &config.Settings{},
+			expectErr:   true,
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"allocated storage empty, does not update": {
 			options: Options{
@@ -497,8 +501,9 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"update backup retention period": {
 			options: Options{
@@ -510,8 +515,9 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"does not update backup retention period": {
 			options: Options{
@@ -523,8 +529,9 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"update binary log format": {
 			options: Options{
@@ -534,8 +541,9 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BinaryLogFormat: "ROW",
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"enable PG cron": {
 			options: Options{
@@ -545,14 +553,16 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				EnablePgCron: aws.Bool(true),
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"enable PG cron not specified": {
 			options:          Options{},
 			existingInstance: &RDSInstance{},
 			expectedInstance: &RDSInstance{},
-			plan:             catalog.RDSPlan{},
+			currentPlan:      catalog.RDSPlan{},
+			newPlan:          catalog.RDSPlan{},
 			settings:         &config.Settings{},
 		},
 		"enable PG cron not specified on options, true on existing instance": {
@@ -561,7 +571,8 @@ func TestModifyInstance(t *testing.T) {
 				EnablePgCron: aws.Bool(true),
 			},
 			expectedInstance: &RDSInstance{},
-			plan:             catalog.RDSPlan{},
+			currentPlan:      catalog.RDSPlan{},
+			newPlan:          catalog.RDSPlan{},
 			settings:         &config.Settings{},
 		},
 		"gp3 fails for allocated storage < 20": {
@@ -571,9 +582,10 @@ func TestModifyInstance(t *testing.T) {
 			existingInstance: &RDSInstance{
 				AllocatedStorage: 10,
 			},
-			plan:      catalog.RDSPlan{},
-			settings:  &config.Settings{},
-			expectErr: true,
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
+			expectErr:   true,
 		},
 		"gp3 upgrade succeeds": {
 			options: Options{
@@ -587,8 +599,9 @@ func TestModifyInstance(t *testing.T) {
 				AllocatedStorage: 20,
 				StorageType:      "gp3",
 			},
-			plan:     catalog.RDSPlan{},
-			settings: &config.Settings{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"does not allow backup retention less than minimum backup retention": {
 			options: Options{},
@@ -598,7 +611,8 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 14,
 			},
-			plan: catalog.RDSPlan{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
 			settings: &config.Settings{
 				MinBackupRetention: 14,
 			},
@@ -613,7 +627,8 @@ func TestModifyInstance(t *testing.T) {
 				ReplicaDatabase: "db-replica",
 				AddReadReplica:  true,
 			},
-			plan: catalog.RDSPlan{
+			currentPlan: catalog.RDSPlan{},
+			newPlan: catalog.RDSPlan{
 				ReadReplica: true,
 				Redundant:   true,
 			},
@@ -629,7 +644,8 @@ func TestModifyInstance(t *testing.T) {
 				Database:        "db",
 				ReplicaDatabase: "db-replica",
 			},
-			plan: catalog.RDSPlan{
+			currentPlan: catalog.RDSPlan{},
+			newPlan: catalog.RDSPlan{
 				ReadReplica: true,
 				Redundant:   true,
 			},
@@ -640,7 +656,8 @@ func TestModifyInstance(t *testing.T) {
 			existingInstance: &RDSInstance{
 				Database: "db",
 			},
-			plan: catalog.RDSPlan{
+			currentPlan: catalog.RDSPlan{},
+			newPlan: catalog.RDSPlan{
 				ReadReplica: true,
 				Redundant:   false,
 			},
@@ -651,7 +668,7 @@ func TestModifyInstance(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			modifiedInstance, err := test.existingInstance.modify(test.options, test.plan, test.settings)
+			modifiedInstance, err := test.existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings)
 			if !test.expectErr && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -668,7 +685,8 @@ func TestModifyInstance(t *testing.T) {
 func TestModifyInstanceRotateCredentials(t *testing.T) {
 	testCases := map[string]struct {
 		options                 Options
-		plan                    catalog.RDSPlan
+		currentPlan             catalog.RDSPlan
+		newPlan                 catalog.RDSPlan
 		settings                *config.Settings
 		originalPassword        string
 		originalSalt            string
@@ -679,7 +697,8 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 			options: Options{
 				RotateCredentials: aws.Bool(true),
 			},
-			plan: catalog.RDSPlan{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
 			settings: &config.Settings{
 				EncryptionKey: helpers.RandStr(32),
 			},
@@ -692,7 +711,8 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 			options: Options{
 				RotateCredentials: aws.Bool(false),
 			},
-			plan: catalog.RDSPlan{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
 			settings: &config.Settings{
 				EncryptionKey: helpers.RandStr(32),
 			},
@@ -702,8 +722,9 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 			shouldRotateCredentials: false,
 		},
 		"rotate credentials not specified": {
-			options: Options{},
-			plan:    catalog.RDSPlan{},
+			options:     Options{},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
 			settings: &config.Settings{
 				EncryptionKey: helpers.RandStr(32),
 			},
@@ -722,7 +743,7 @@ func TestModifyInstanceRotateCredentials(t *testing.T) {
 				Salt:          test.originalSalt,
 				dbUtils:       &RDSDatabaseUtils{},
 			}
-			modifiedInstance, err := existingInstance.modify(test.options, test.plan, test.settings)
+			modifiedInstance, err := existingInstance.modify(test.options, test.currentPlan, test.newPlan, test.settings)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -667,7 +667,8 @@ func TestModifyInstance(t *testing.T) {
 		"update from plan with read replica enabled to non read-replica plan": {
 			options: Options{},
 			existingInstance: &RDSInstance{
-				Database: "db",
+				Database:        "db",
+				ReplicaDatabase: "replica",
 			},
 			currentPlan: catalog.RDSPlan{
 				ReadReplica: true,
@@ -677,6 +678,7 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				Database:          "db",
 				DeleteReadReplica: true,
+				ReplicaDatabase:   "replica",
 			},
 		},
 	}

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -456,6 +456,7 @@ func TestModifyInstance(t *testing.T) {
 					},
 				},
 				SecGroup: "sec-group1",
+				Tags:     map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan: catalog.RDSPlan{
@@ -475,6 +476,7 @@ func TestModifyInstance(t *testing.T) {
 			},
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
+				Tags:             map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -501,6 +503,7 @@ func TestModifyInstance(t *testing.T) {
 			},
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
+				Tags:             map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -515,6 +518,7 @@ func TestModifyInstance(t *testing.T) {
 			},
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
+				Tags:                  map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -529,6 +533,7 @@ func TestModifyInstance(t *testing.T) {
 			},
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 20,
+				Tags:                  map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -541,6 +546,7 @@ func TestModifyInstance(t *testing.T) {
 			existingInstance: &RDSInstance{},
 			expectedInstance: &RDSInstance{
 				BinaryLogFormat: "ROW",
+				Tags:            map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -553,6 +559,7 @@ func TestModifyInstance(t *testing.T) {
 			existingInstance: &RDSInstance{},
 			expectedInstance: &RDSInstance{
 				EnablePgCron: aws.Bool(true),
+				Tags:         map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -561,20 +568,24 @@ func TestModifyInstance(t *testing.T) {
 		"enable PG cron not specified": {
 			options:          Options{},
 			existingInstance: &RDSInstance{},
-			expectedInstance: &RDSInstance{},
-			currentPlan:      catalog.RDSPlan{},
-			newPlan:          catalog.RDSPlan{},
-			settings:         &config.Settings{},
+			expectedInstance: &RDSInstance{
+				Tags: map[string]string{},
+			},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"enable PG cron not specified on options, true on existing instance": {
 			options: Options{},
 			existingInstance: &RDSInstance{
 				EnablePgCron: aws.Bool(true),
 			},
-			expectedInstance: &RDSInstance{},
-			currentPlan:      catalog.RDSPlan{},
-			newPlan:          catalog.RDSPlan{},
-			settings:         &config.Settings{},
+			expectedInstance: &RDSInstance{
+				Tags: map[string]string{},
+			},
+			currentPlan: catalog.RDSPlan{},
+			newPlan:     catalog.RDSPlan{},
+			settings:    &config.Settings{},
 		},
 		"gp3 fails for allocated storage < 20": {
 			options: Options{
@@ -599,6 +610,7 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				AllocatedStorage: 20,
 				StorageType:      "gp3",
+				Tags:             map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -611,6 +623,7 @@ func TestModifyInstance(t *testing.T) {
 			},
 			expectedInstance: &RDSInstance{
 				BackupRetentionPeriod: 14,
+				Tags:                  map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan:     catalog.RDSPlan{},
@@ -627,6 +640,7 @@ func TestModifyInstance(t *testing.T) {
 				Database:        "db",
 				ReplicaDatabase: "db-replica",
 				AddReadReplica:  true,
+				Tags:            map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan: catalog.RDSPlan{
@@ -644,6 +658,7 @@ func TestModifyInstance(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				Database:        "db",
 				ReplicaDatabase: "db-replica",
+				Tags:            map[string]string{},
 			},
 			currentPlan: catalog.RDSPlan{},
 			newPlan: catalog.RDSPlan{
@@ -680,6 +695,7 @@ func TestModifyInstance(t *testing.T) {
 				Database:          "db",
 				DeleteReadReplica: true,
 				ReplicaDatabase:   "replica",
+				Tags:              map[string]string{},
 			},
 		},
 	}

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -664,6 +664,21 @@ func TestModifyInstance(t *testing.T) {
 			settings:  &config.Settings{},
 			expectErr: true,
 		},
+		"update from plan with read replica enabled to non read-replica plan": {
+			options: Options{},
+			existingInstance: &RDSInstance{
+				Database: "db",
+			},
+			currentPlan: catalog.RDSPlan{
+				ReadReplica: true,
+			},
+			newPlan:  catalog.RDSPlan{},
+			settings: &config.Settings{},
+			expectedInstance: &RDSInstance{
+				Database:          "db",
+				DeleteReadReplica: true,
+			},
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix modify database logic to delete read replica when moving from a replica to a non-replica plan
- Add logic to update tags on databases and read replicas
- Add and update tests
- Add logic for reconciling tags on replica databases

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
