### PR TITLE
remove plans mapped to instance types which do not exist

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -2260,7 +2260,7 @@ elasticsearch:
 # New larger plans for 2024 - these are NOT scoped to all ORGs/Spaces and needs to be manually scoped when requested by the customer
   - id: "efa909ab-0053-4da7-b7a3-a294ef2e67a7"
     name: "es-12xlarge-gp"
-    description: "12X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
+    description: "12X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 2 data nodes"
     metadata:
       bullets:
       - "12X-Large"
@@ -2278,6 +2278,43 @@ elasticsearch:
     - "Elasticsearch_7.10"
     masterCount: 3
     dataCount: 2
+    instanceType: m5.12xlarge.search
+    masterInstanceType: m5.12xlarge.search
+    volumeSize: 50
+    volumeType: gp3
+    masterEnabled: true
+    nodeToNodeEncryption: true
+    encryptAtRest: true
+    automatedSnapshotStartHour: 6
+    securityGroup: (( grab meta.elasticsearch.security_group ))
+    subnetID1az1: (( grab meta.elasticsearch.subnet_id1_az1 ))
+    subnetID2az2: (( grab meta.elasticsearch.subnet_id2_az2 ))
+    subnetID3az1: (( grab meta.elasticsearch.subnet_id3_az1 ))
+    subnetID4az2: (( grab meta.elasticsearch.subnet_id4_az2 ))
+    tags:
+      environment: (( grab meta.environment ))
+      client: "the client"
+      broker: "AWS broker"
+  - id: "5574be21-9d9b-46df-a9b5-9ac06af5da88"
+    name: "es-12xlarge-gp-ha"
+    description: "12X-Large General-Purpose Elasticsearch/OpenSearch - 3 master nodes with 4 data nodes"
+    metadata:
+      bullets:
+      - "12X-Large"
+      - "4 data nodes"
+      costs:
+      - amount:
+          usd: 33600.00
+        unit: "MONTHLY"
+      displayName: "12X-Large, General-Purpose, 3 master nodes, 4 data nodes"
+    free: false
+    elasticsearchVersion: Elasticsearch_7.10
+    approvedMajorVersions:
+    - "OpenSearch_2.11"
+    - "OpenSearch_1.3"
+    - "Elasticsearch_7.10"
+    masterCount: 3
+    dataCount: 4
     instanceType: m5.12xlarge.search
     masterInstanceType: m5.12xlarge.search
     volumeSize: 50


### PR DESCRIPTION
## Changes proposed in this pull request:

While working on #442, I noticed that one of our Elasticsearch service plans, `es-8xlarge-gp-ha`, was mapped to an instance type of `m5.8xlarge.search` [which is not a valid instance type supported by AWS OpenSearch](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html).

Upon further review, I found that all of these plans and their associated instance types are not supported by AWS OpenSearch:

- `es-8xlarge-gp`: `m5.8xlarge.search`
- `es-8xlarge-gp-ha`: `m5.8xlarge.search`
- `es-24xlarge-gp`: `m5.24xlarge.search`
- `es-24xlarge-gp-ha`: `m5.24xlarge.search`

Since these plans map to instance types that do not exist, they could never actually be used, so this PR removes them.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No direct impact, just removing unusable plans
