### PR TITLE
Drop old PG versions

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -35,8 +35,6 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 20
       approvedMajorVersions: &approved_rds_pg_versions
-        - "13"
-        - "14"
         - "15"
         - "16"
       dbVersion: "16"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -35,6 +35,7 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 20
       approvedMajorVersions: &approved_rds_pg_versions
+        - "14"
         - "15"
         - "16"
       dbVersion: "16"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -426,7 +426,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                DB_VERSION: 14
+                DB_VERSION: 15
 
             - task: smoke-tests-postgres-update-storage
               file: aws-broker-app/ci/run-smoke-tests-update-storage.yml
@@ -863,7 +863,7 @@ jobs:
                 CF_SPACE: ((staging-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                DB_VERSION: 14
+                DB_VERSION: 15
 
             - task: smoke-tests-postgres-update-micro-to-small
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -1424,7 +1424,7 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                DB_VERSION: 14
+                DB_VERSION: 15
 
             - task: smoke-tests-postgres-update-micro-to-small
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -1027,7 +1027,7 @@ func TestGetParameterGroupFamily(t *testing.T) {
 		"has db version": {
 			dbInstance: &RDSInstance{
 				DbType:    "postgres",
-				DbVersion: "13",
+				DbVersion: "15",
 			},
 			expectedPGroupFamily: "postgres13",
 			parameterGroupAdapter: &awsParameterGroupClient{


### PR DESCRIPTION
## Changes proposed in this pull request:

- drop support for PG versions 13, since AWS has already started charging extended support for using it: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just ensuring that customers cannot create resources that cost more money and which will reach end of life for support sooner
