### PR TITLE
Support replica credential rotation

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -580,6 +580,19 @@ jobs:
                 DB_TYPE: postgres
                 OLD_VERSION: 14
                 NEW_VERSION: 16
+
+            - task: smoke-tests-postgres-rotate-creds-replica
+              file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+              image: general-task
+              params:
+                BROKER_NAME: ((development-broker-name))
+                CF_API_URL: ((development-cf-api-url))
+                CF_USERNAME: ((development-cf-deploy-username))
+                CF_PASSWORD: ((development-cf-deploy-password))
+                CF_ORGANIZATION: ((development-tests-cf-organization))
+                CF_SPACE: ((development-tests-cf-space))
+                SERVICE_PLAN: micro-psql-replica
+                DB_TYPE: postgres
     on_failure:
       put: slack
       params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1047,6 +1047,19 @@ jobs:
                 SERVICE_PLAN: micro-psql
                 NEW_SERVICE_PLAN: micro-psql-replica
                 DB_TYPE: postgres
+
+            - task: smoke-tests-postgres-rotate-creds-replica
+              file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+              image: general-task
+              params:
+                BROKER_NAME: ((staging-broker-name))
+                CF_API_URL: ((staging-cf-api-url))
+                CF_USERNAME: ((staging-cf-deploy-username))
+                CF_PASSWORD: ((staging-cf-deploy-password))
+                CF_ORGANIZATION: ((staging-tests-cf-organization))
+                CF_SPACE: ((staging-tests-cf-space))
+                SERVICE_PLAN: micro-psql-replica
+                DB_TYPE: postgres
     on_failure:
       put: slack
       params:
@@ -1766,6 +1779,19 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 NEW_SERVICE_PLAN: micro-psql-replica
+                DB_TYPE: postgres
+
+            - task: smoke-tests-postgres-rotate-creds-replica
+              file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml
+              image: general-task
+              params:
+                BROKER_NAME: ((prod-broker-name))
+                CF_API_URL: ((prod-cf-api-url))
+                CF_USERNAME: ((prod-cf-deploy-username))
+                CF_PASSWORD: ((prod-cf-deploy-password))
+                CF_ORGANIZATION: ((prod-tests-cf-organization))
+                CF_SPACE: ((prod-tests-cf-space))
+                SERVICE_PLAN: micro-psql-replica
                 DB_TYPE: postgres
 
     on_failure:

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -183,7 +183,12 @@ func (d *dedicatedDBAdapter) prepareCreateDbInput(
 	return params, nil
 }
 
-func (d *dedicatedDBAdapter) prepareModifyDbInstanceInput(i *RDSInstance, plan *catalog.RDSPlan, database string) (*rds.ModifyDBInstanceInput, error) {
+func (d *dedicatedDBAdapter) prepareModifyDbInstanceInput(
+	i *RDSInstance,
+	plan *catalog.RDSPlan,
+	database string,
+	isReplica bool,
+) (*rds.ModifyDBInstanceInput, error) {
 	// Standard parameters (https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#RDS.ModifyDBInstance)
 	// These actions are applied immediately.
 	allocatedStorage, err := common.ConvertInt64ToInt32Safely(i.AllocatedStorage)
@@ -214,7 +219,7 @@ func (d *dedicatedDBAdapter) prepareModifyDbInstanceInput(i *RDSInstance, plan *
 		params.StorageType = aws.String(i.StorageType)
 	}
 
-	if i.ClearPassword != "" {
+	if i.ClearPassword != "" && !isReplica {
 		params.MasterUserPassword = aws.String(i.ClearPassword)
 	}
 
@@ -391,8 +396,8 @@ func (d *dedicatedDBAdapter) createDB(i *RDSInstance, plan *catalog.RDSPlan, pas
 	return base.InstanceInProgress, nil
 }
 
-func (d *dedicatedDBAdapter) asyncModifyDbInstance(operation base.Operation, i *RDSInstance, plan *catalog.RDSPlan, database string) error {
-	modifyParams, err := d.prepareModifyDbInstanceInput(i, plan, database)
+func (d *dedicatedDBAdapter) asyncModifyDbInstance(operation base.Operation, i *RDSInstance, plan *catalog.RDSPlan, database string, isReplica bool) error {
+	modifyParams, err := d.prepareModifyDbInstanceInput(i, plan, database, isReplica)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error preparing database modify parameters: %s", err))
 		return fmt.Errorf("asyncModifyDb, error preparing modify database input: %w", err)
@@ -401,10 +406,10 @@ func (d *dedicatedDBAdapter) asyncModifyDbInstance(operation base.Operation, i *
 	err = d.waitForDbReady(operation, i, database)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error waiting for database to become available: %s", err))
-		return fmt.Errorf("waitAndCreateDBReadReplica, error waiting for database to be ready: %w", err)
+		return fmt.Errorf("asyncModifyDbInstance, error waiting for database to be ready: %w", err)
 	}
 
-	modifyReplicaOutput, err := d.rds.ModifyDBInstance(context.TODO(), modifyParams)
+	modifyOutput, err := d.rds.ModifyDBInstance(context.TODO(), modifyParams)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database: %s", err))
 		return fmt.Errorf("asyncModifyDb, error modifying database instance: %w", err)
@@ -413,10 +418,10 @@ func (d *dedicatedDBAdapter) asyncModifyDbInstance(operation base.Operation, i *
 	err = d.waitForDbReady(operation, i, database)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error waiting for database to become available: %s", err))
-		return fmt.Errorf("waitAndCreateDBReadReplica, error waiting for database to be ready: %w", err)
+		return fmt.Errorf("asyncModifyDbInstance, error waiting for database to be ready: %w", err)
 	}
 
-	err = d.updateDBTags(i, *modifyReplicaOutput.DBInstance.DBInstanceArn)
+	err = d.updateDBTags(i, *modifyOutput.DBInstance.DBInstanceArn)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error updating tags for database replica: %s", err))
 		return fmt.Errorf("asyncModifyDb, error updating replica tags: %w", err)
@@ -428,7 +433,7 @@ func (d *dedicatedDBAdapter) asyncModifyDbInstance(operation base.Operation, i *
 func (d *dedicatedDBAdapter) asyncModifyDb(i *RDSInstance, plan *catalog.RDSPlan) {
 	operation := base.ModifyOp
 
-	err := d.asyncModifyDbInstance(operation, i, plan, i.Database)
+	err := d.asyncModifyDbInstance(operation, i, plan, i.Database, false)
 	if err != nil {
 		jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database: %s", err))
 		d.logger.Error("asyncModifyDb: asyncModifyDbInstance error", err)
@@ -444,7 +449,7 @@ func (d *dedicatedDBAdapter) asyncModifyDb(i *RDSInstance, plan *catalog.RDSPlan
 			return
 		}
 	} else if !i.DeleteReadReplica && !i.AddReadReplica && i.ReplicaDatabase != "" {
-		err := d.asyncModifyDbInstance(operation, i, plan, i.ReplicaDatabase)
+		err := d.asyncModifyDbInstance(operation, i, plan, i.ReplicaDatabase, true)
 		if err != nil {
 			jobs.ShouldWriteAsyncJobMessage(d.db, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))
 			d.logger.Error("asyncModifyDb: asyncModifyDbInstance read replica error", err)

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -1563,6 +1563,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 		expectedErr       error
 		expectedParams    *rds.ModifyDBInstanceInput
 		plan              *catalog.RDSPlan
+		isReplica         bool
 	}{
 		"expect returned group name": {
 			dbInstance: &RDSInstance{
@@ -1723,11 +1724,44 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				EngineVersion:            aws.String("9.0"),
 			},
 		},
+		"does not update password for replica": {
+			dbInstance: &RDSInstance{
+				BinaryLogFormat:       "ROW",
+				DbType:                "mysql",
+				ClearPassword:         "fake-pw",
+				dbUtils:               &RDSDatabaseUtils{},
+				AllocatedStorage:      20,
+				Database:              "db-name",
+				BackupRetentionPeriod: 14,
+			},
+			dbAdapter: NewTestDedicatedDBAdapter(
+				&config.Settings{},
+				nil,
+				&mockRDSClient{},
+				&mockParameterGroupClient{
+					rds: &mockRDSClient{},
+				},
+			),
+			plan: &catalog.RDSPlan{
+				InstanceClass: "class",
+				Redundant:     true,
+			},
+			isReplica: true,
+			expectedParams: &rds.ModifyDBInstanceInput{
+				AllocatedStorage:         aws.Int32(20),
+				ApplyImmediately:         aws.Bool(true),
+				DBInstanceClass:          aws.String("class"),
+				MultiAZ:                  aws.Bool(true),
+				DBInstanceIdentifier:     aws.String("db-name"),
+				AllowMajorVersionUpgrade: aws.Bool(false),
+				BackupRetentionPeriod:    aws.Int32(14),
+			},
+		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			params, err := test.dbAdapter.prepareModifyDbInstanceInput(test.dbInstance, test.plan, test.dbInstance.Database)
+			params, err := test.dbAdapter.prepareModifyDbInstanceInput(test.dbInstance, test.plan, test.dbInstance.Database, test.isReplica)
 			if !errors.Is(test.expectedErr, err) {
 				t.Errorf("unexpected error: %s", err)
 			}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix logic for handling credential rotation on databases with replicas
- Add acceptance tests for rotating credentials on replica databases
- Update unit tests to validate new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
