### PR TITLE
Fix polling for snapshot creation on ES deletion

### DIFF
--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -480,8 +480,6 @@ func (d *dedicatedElasticsearchAdapter) asyncDeleteElasticSearchDomain(i *Elasti
 // in which we make the ES API call to take a snapshot
 // then poll for snapshot completetion, may block for a considerable time
 func (d *dedicatedElasticsearchAdapter) takeLastSnapshot(i *ElasticsearchInstance, password string) error {
-
-	var sleep = 10 * time.Second
 	var creds map[string]string
 	var err error
 
@@ -543,9 +541,16 @@ func (d *dedicatedElasticsearchAdapter) takeLastSnapshot(i *ElasticsearchInstanc
 		return err
 	}
 
-	// poll for snapshot completion and continue once no longer "IN_PROGRESS"
-	for {
-		snapshotState, err := esApi.GetSnapshotStatus(d.settings.SnapshotsRepoName, snapshotName)
+	return d.pollForSnapshotCreation(esApi, snapshotName)
+}
+
+func (d *dedicatedElasticsearchAdapter) pollForSnapshotCreation(esApi EsApiClient, snapshotName string) error {
+	var snapshotState string
+	var err error
+	attempts := 0
+
+	for attempts < int(d.settings.PollAwsMaxRetries) {
+		snapshotState, err = esApi.GetSnapshotStatus(d.settings.SnapshotsRepoName, snapshotName)
 		if err != nil {
 			d.logger.Error("GetSnapShotStatus failed", err)
 			return err
@@ -553,8 +558,14 @@ func (d *dedicatedElasticsearchAdapter) takeLastSnapshot(i *ElasticsearchInstanc
 		if snapshotState == "SUCCESS" {
 			break
 		}
-		time.Sleep(sleep)
+		attempts += 1
+		time.Sleep(d.settings.PollAwsMinDelay)
 	}
+
+	if snapshotState != "SUCCESS" {
+		return errors.New("Could not verify creation of snapshot")
+	}
+
 	return nil
 }
 

--- a/services/elasticsearch/elasticsearch.go
+++ b/services/elasticsearch/elasticsearch.go
@@ -547,9 +547,9 @@ func (d *dedicatedElasticsearchAdapter) takeLastSnapshot(i *ElasticsearchInstanc
 func (d *dedicatedElasticsearchAdapter) pollForSnapshotCreation(esApi EsApiClient, snapshotName string) error {
 	var snapshotState string
 	var err error
-	attempts := 0
+	attempts := 1
 
-	for attempts < int(d.settings.PollAwsMaxRetries) {
+	for attempts <= int(d.settings.PollAwsMaxRetries) {
 		snapshotState, err = esApi.GetSnapshotStatus(d.settings.SnapshotsRepoName, snapshotName)
 		if err != nil {
 			d.logger.Error("GetSnapShotStatus failed", err)

--- a/services/elasticsearch/elasticsearch_api.go
+++ b/services/elasticsearch/elasticsearch_api.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"code.cloudfoundry.org/lager"
@@ -17,6 +18,12 @@ import (
 	opensearchapi "github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 	requestsigner "github.com/opensearch-project/opensearch-go/v2/signer/awsv2"
 )
+
+type EsApiClient interface {
+	CreateSnapshotRepo(repositoryName string, bucketName string, path string, region string, roleArn string) (string, error)
+	CreateSnapshot(repositoryName string, snapshotName string) (string, error)
+	GetSnapshotStatus(repositoryName string, snapshotName string) (string, error)
+}
 
 type EsApiHandler struct {
 	opensearchClient *opensearch.Client
@@ -155,6 +162,12 @@ func (es *EsApiHandler) GetSnapshotStatus(repositoryName string, snapshotName st
 	}
 
 	defer res.Body.Close()
+
+	// A 404 response may indicate that the snapshot is not ready yet, not that
+	// anything has necessarily failed
+	if res.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
 
 	if res.IsError() {
 		return "", fmt.Errorf("failed to get snapshot %s: %s", repositoryName, res.String())

--- a/services/elasticsearch/elasticsearch_api_test.go
+++ b/services/elasticsearch/elasticsearch_api_test.go
@@ -130,6 +130,34 @@ func TestGetSnapshotStatus(t *testing.T) {
 	}
 }
 
+func TestGetSnapshotStatusNotFound(t *testing.T) {
+	mockResponse := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+		Header:     make(http.Header),
+	}
+	mockResponse.Header.Set("Content-Type", "application/json")
+
+	client, err := opensearch.NewClient(opensearch.Config{
+		Addresses: []string{"fake://url"},
+		Transport: &MockRoundTripper{Response: mockResponse, Err: nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	es := NewTestEsAPIHandler(client)
+
+	resp, err := es.GetSnapshotStatus(repoName, snapshotName)
+	if err != nil {
+		t.Errorf("Err is not nil: %v", err)
+	}
+
+	if resp != "" {
+		t.Errorf("Expected empty status, got %s", resp)
+	}
+}
+
 func TestGetSnapshotStatusNoSnapshots(t *testing.T) {
 	mockResponse := &http.Response{
 		StatusCode: http.StatusOK,

--- a/services/elasticsearch/elasticsearch_test.go
+++ b/services/elasticsearch/elasticsearch_test.go
@@ -1,9 +1,11 @@
 package elasticsearch
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cloud-gov/aws-broker/config"
 
@@ -13,8 +15,9 @@ import (
 )
 
 type mockEsApiClient struct {
-	getSnapshotStatusCalls     int
+	getSnapshotStatusCallNum   int
 	getSnapshotStatusResponses []string
+	getSnapshotStatusErrs      []error
 }
 
 func (m *mockEsApiClient) CreateSnapshotRepo(repositoryName string, bucketName string, path string, region string, roleArn string) (string, error) {
@@ -26,9 +29,13 @@ func (m *mockEsApiClient) CreateSnapshot(repositoryName string, snapshotName str
 }
 
 func (m *mockEsApiClient) GetSnapshotStatus(repositoryName string, snapshotName string) (string, error) {
-	resp := m.getSnapshotStatusResponses[m.getSnapshotStatusCalls]
-	m.getSnapshotStatusCalls += 1
-	return resp, nil
+	currentCallNum := m.getSnapshotStatusCallNum
+	m.getSnapshotStatusCallNum++
+	if len(m.getSnapshotStatusErrs) > 0 && m.getSnapshotStatusErrs[currentCallNum] != nil {
+		return "", m.getSnapshotStatusErrs[currentCallNum]
+	}
+	status := m.getSnapshotStatusResponses[currentCallNum]
+	return status, nil
 }
 
 func TestIsInvalidTypeException(t *testing.T) {
@@ -275,6 +282,20 @@ func TestPollForSnapshotCreation(t *testing.T) {
 			expectedGetSnapshotCalls: 3,
 			expectErr:                true,
 		},
+		"error getting snapshot status": {
+			esApiClient: &mockEsApiClient{
+				getSnapshotStatusErrs: []error{errors.New("error getting snapshot status")},
+			},
+			esAdapter: &dedicatedElasticsearchAdapter{
+				settings: config.Settings{
+					PollAwsMinDelay:   1 * time.Millisecond,
+					PollAwsMaxRetries: 1,
+				},
+				logger: lager.NewLogger("es-tests"),
+			},
+			expectedGetSnapshotCalls: 1,
+			expectErr:                true,
+		},
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -286,8 +307,8 @@ func TestPollForSnapshotCreation(t *testing.T) {
 				t.Fatal("expected error")
 			}
 			if mockEsApiClient, ok := test.esApiClient.(*mockEsApiClient); ok {
-				if mockEsApiClient.getSnapshotStatusCalls != test.expectedGetSnapshotCalls {
-					t.Fatalf("expected %d GetSnapshotStatus calls, got %d", test.expectedGetSnapshotCalls, mockEsApiClient.getSnapshotStatusCalls)
+				if mockEsApiClient.getSnapshotStatusCallNum != test.expectedGetSnapshotCalls {
+					t.Fatalf("expected %d GetSnapshotStatus calls, got %d", test.expectedGetSnapshotCalls, mockEsApiClient.getSnapshotStatusCallNum)
 				}
 			}
 		})

--- a/services/elasticsearch/elasticsearch_test.go
+++ b/services/elasticsearch/elasticsearch_test.go
@@ -2,13 +2,34 @@ package elasticsearch
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/cloud-gov/aws-broker/config"
 
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	opensearchTypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
 	"github.com/go-test/deep"
 )
+
+type mockEsApiClient struct {
+	getSnapshotStatusCalls     int
+	getSnapshotStatusResponses []string
+}
+
+func (m *mockEsApiClient) CreateSnapshotRepo(repositoryName string, bucketName string, path string, region string, roleArn string) (string, error) {
+	return "", nil
+}
+
+func (m *mockEsApiClient) CreateSnapshot(repositoryName string, snapshotName string) (string, error) {
+	return "", nil
+}
+
+func (m *mockEsApiClient) GetSnapshotStatus(repositoryName string, snapshotName string) (string, error) {
+	resp := m.getSnapshotStatusResponses[m.getSnapshotStatusCalls]
+	m.getSnapshotStatusCalls += 1
+	return resp, nil
+}
 
 func TestIsInvalidTypeException(t *testing.T) {
 	isInvalidType := isInvalidTypeException(&opensearchTypes.InvalidTypeException{})
@@ -205,6 +226,69 @@ func TestPrepareUpdateDomainConfigInput(t *testing.T) {
 			}
 			if diff := deep.Equal(params, test.expectedParams); diff != nil {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestPollForSnapshotCreation(t *testing.T) {
+	testCases := map[string]struct {
+		esApiClient              EsApiClient
+		esAdapter                *dedicatedElasticsearchAdapter
+		expectedGetSnapshotCalls int
+		expectErr                bool
+	}{
+		"success": {
+			esApiClient: &mockEsApiClient{
+				getSnapshotStatusResponses: []string{"SUCCESS"},
+			},
+			esAdapter: &dedicatedElasticsearchAdapter{
+				settings: config.Settings{
+					PollAwsMinDelay:   1 * time.Millisecond,
+					PollAwsMaxRetries: 1,
+				},
+			},
+			expectedGetSnapshotCalls: 1,
+		},
+		"success with retries": {
+			esApiClient: &mockEsApiClient{
+				getSnapshotStatusResponses: []string{"IN PROGRESS", "IN PROGRESS", "SUCCESS"},
+			},
+			esAdapter: &dedicatedElasticsearchAdapter{
+				settings: config.Settings{
+					PollAwsMinDelay:   1 * time.Millisecond,
+					PollAwsMaxRetries: 3,
+				},
+			},
+			expectedGetSnapshotCalls: 3,
+		},
+		"gives up after maximum retries": {
+			esApiClient: &mockEsApiClient{
+				getSnapshotStatusResponses: []string{"IN PROGRESS", "IN PROGRESS", "IN PROGRESS"},
+			},
+			esAdapter: &dedicatedElasticsearchAdapter{
+				settings: config.Settings{
+					PollAwsMinDelay:   1 * time.Millisecond,
+					PollAwsMaxRetries: 3,
+				},
+			},
+			expectedGetSnapshotCalls: 3,
+			expectErr:                true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := test.esAdapter.pollForSnapshotCreation(test.esApiClient, "foobar")
+			if err != nil && !test.expectErr {
+				t.Fatal(err)
+			}
+			if test.expectErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if mockEsApiClient, ok := test.esApiClient.(*mockEsApiClient); ok {
+				if mockEsApiClient.getSnapshotStatusCalls != test.expectedGetSnapshotCalls {
+					t.Fatalf("expected %d GetSnapshotStatus calls, got %d", test.expectedGetSnapshotCalls, mockEsApiClient.getSnapshotStatusCalls)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Changes proposed in this pull request:

There may be a brief period after a snapshot is created when the ES API will still return a 404 indicating that the snapshot does not exist. Rather than failing on this 404 response, this PR updates the logic so that it retries trying to get the snapshot status.

The PR adds tests for the new behavior.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Internal logic has changed, but nothing about the overall behavior of the broker or its security boundary has changed
