### PR TITLE
Fix database version update logic

### DIFF
--- a/ci/ci-utils.sh
+++ b/ci/ci-utils.sh
@@ -22,6 +22,8 @@ wait_for_service_instance() {
     sleep 60
     status=$(cf curl "/v2/service_instances/$guid" | jq -r '.entity.last_operation.state')
   done
+
+  echo "$status"
 }
 
 wait_for_service_instance_success() {

--- a/ci/ci-utils.sh
+++ b/ci/ci-utils.sh
@@ -24,6 +24,16 @@ wait_for_service_instance() {
   done
 }
 
+wait_for_service_instance_success() {
+  local status
+  status=$(wait_for_service_instance "$1")
+
+  if [ "$status" == "failed" ]; then
+    echo "failed to create $1"
+    exit 1
+  fi
+}
+
 function wait_for_deletion {
   while true; do
     if ! cf service "$1"; then

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -580,6 +580,7 @@ jobs:
                 DB_TYPE: postgres
                 OLD_VERSION: 14
                 NEW_VERSION: 16
+                ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-rotate-creds-replica
               file: aws-broker-app/ci/run-smoke-test-rotate-creds.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1021,6 +1021,7 @@ jobs:
                 DB_TYPE: postgres
                 OLD_VERSION: 14
                 NEW_VERSION: 16
+                ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-replica
               file: aws-broker-app/ci/run-smoke-tests.yml
@@ -1754,6 +1755,7 @@ jobs:
                 DB_TYPE: postgres
                 OLD_VERSION: 14
                 NEW_VERSION: 16
+                ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-replica
               file: aws-broker-app/ci/run-smoke-tests.yml

--- a/ci/run-smoke-tests-db-updates.sh
+++ b/ci/run-smoke-tests-db-updates.sh
@@ -59,7 +59,7 @@ fi
 cf update-service "${update_service_args[@]}"
 
 # Wait to make sure that the service instance has been successfully updated.
-wait_for_service_instance "$SERVICE_NAME"
+wait_for_service_instance_success "$SERVICE_NAME"
 
 # Clean up app and service
 cf delete -f "$APP_NAME"

--- a/ci/run-smoke-tests-db-updates.sh
+++ b/ci/run-smoke-tests-db-updates.sh
@@ -14,6 +14,7 @@ OLD_VERSION=${OLD_VERSION:-""}
 NEW_VERSION=${NEW_VERSION:-""}
 NEW_SERVICE_PLAN=${NEW_SERVICE_PLAN:-""}
 NEW_STORAGE=${NEW_STORAGE:-""}
+ALLOW_MAJOR_VERSION_UPGRADE=${ALLOW_MAJOR_VERSION_UPGRADE:-""}
 
 # Clean up existing app and service if present
 cf delete -f "smoke-tests-db-update-$SERVICE_PLAN"
@@ -49,7 +50,11 @@ if [ -n "$NEW_SERVICE_PLAN" ]; then
 fi
 
 if [ -n "$NEW_VERSION" ]; then
-  update_service_args+=(-c '{"version": "'"$NEW_VERSION"'"}')
+  if [ -n "$ALLOW_MAJOR_VERSION_UPGRADE" ]; then
+    update_service_args+=(-c '{"version": "'"$NEW_VERSION"'", "allow_major_version_upgrade": true}')
+  else
+    update_service_args+=(-c '{"version": "'"$NEW_VERSION"'"}')
+  fi
 fi
 
 if [ -n "$NEW_STORAGE" ]; then

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -35,6 +35,7 @@ type Options struct {
 	RotateCredentials               *bool    `json:"rotate_credentials"`
 	StorageType                     string   `json:"storage_type"`
 	EnableCloudWatchLogGroupExports []string `json:"enable_cloudwatch_log_groups_exports"`
+	AllowMajorVersionUpgrade        *bool    `json:"allow_major_version_upgrade"`
 }
 
 // Validate the custom parameters passed in via the "-c <JSON string or file>"

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -207,7 +207,7 @@ func (d *dedicatedDBAdapter) prepareModifyDbInstanceInput(
 		DBInstanceClass:          &plan.InstanceClass,
 		MultiAZ:                  &plan.Redundant,
 		DBInstanceIdentifier:     &database,
-		AllowMajorVersionUpgrade: aws.Bool(false),
+		AllowMajorVersionUpgrade: aws.Bool(i.AllowMajorVersionUpgrade),
 		BackupRetentionPeriod:    backupRetentionPeriod,
 	}
 

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -1757,6 +1757,41 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				BackupRetentionPeriod:    aws.Int32(14),
 			},
 		},
+		"allow major version upgrade": {
+			dbInstance: &RDSInstance{
+				dbUtils:                  &RDSDatabaseUtils{},
+				DbType:                   "mysql",
+				StorageType:              "gp3",
+				AllocatedStorage:         20,
+				Database:                 "db-name",
+				BackupRetentionPeriod:    14,
+				DbVersion:                "9.0",
+				AllowMajorVersionUpgrade: true,
+			},
+			dbAdapter: NewTestDedicatedDBAdapter(
+				&config.Settings{},
+				nil,
+				&mockRDSClient{},
+				&mockParameterGroupClient{
+					rds: &mockRDSClient{},
+				},
+			),
+			plan: &catalog.RDSPlan{
+				InstanceClass: "class",
+				Redundant:     true,
+			},
+			expectedParams: &rds.ModifyDBInstanceInput{
+				AllocatedStorage:         aws.Int32(20),
+				ApplyImmediately:         aws.Bool(true),
+				DBInstanceClass:          aws.String("class"),
+				MultiAZ:                  aws.Bool(true),
+				DBInstanceIdentifier:     aws.String("db-name"),
+				AllowMajorVersionUpgrade: aws.Bool(true),
+				BackupRetentionPeriod:    aws.Int32(14),
+				StorageType:              aws.String("gp3"),
+				EngineVersion:            aws.String("9.0"),
+			},
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -87,7 +87,9 @@ func (i RDSInstance) modify(options Options, currentPlan *catalog.RDSPlan, newPl
 	// needed to create an RDS read replica
 	modifiedInstance.SecGroup = newPlan.SecurityGroup
 
-	modifiedInstance.setEngineVersion(*newPlan, options)
+	if modifiedInstance.hasEngineVersionUpdate(options) {
+		modifiedInstance.DbVersion = options.Version
+	}
 
 	// Check to see if there is a storage size change and if so, check to make sure it's a valid change.
 	if options.AllocatedStorage > 0 {
@@ -236,10 +238,15 @@ func (i *RDSInstance) init(
 	return nil
 }
 
+func (i *RDSInstance) hasEngineVersionUpdate(options Options) bool {
+	// Currently only supported for MySQL and PostgreSQL instances.
+	return (i.DbType == "postgres" || i.DbType == "mysql") && options.Version != ""
+}
+
 func (i *RDSInstance) setEngineVersion(plan catalog.RDSPlan, options Options) {
 	// Set the DB Version
 	// Currently only supported for MySQL and PostgreSQL instances.
-	if (i.DbType == "postgres" || i.DbType == "mysql") && options.Version != "" {
+	if i.hasEngineVersionUpdate(options) {
 		i.DbVersion = options.Version
 	} else {
 		// Default to the version provided by the plan chosen in catalog.

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -48,10 +48,11 @@ type RDSInstance struct {
 
 	StorageType string `sql:"size(255)"`
 
-	AddReadReplica      bool   `gorm:"-"`
-	ReplicaDatabase     string `sql:"size(255)"`
-	ReplicaDatabaseHost string `sql:"size(255)"`
-	DeleteReadReplica   bool   `gorm:"-"`
+	AddReadReplica           bool   `gorm:"-"`
+	ReplicaDatabase          string `sql:"size(255)"`
+	ReplicaDatabaseHost      string `sql:"size(255)"`
+	DeleteReadReplica        bool   `gorm:"-"`
+	AllowMajorVersionUpgrade bool   `gorm:"-"`
 }
 
 func NewRDSInstance() *RDSInstance {
@@ -89,6 +90,10 @@ func (i RDSInstance) modify(options Options, currentPlan *catalog.RDSPlan, newPl
 
 	if modifiedInstance.hasEngineVersionUpdate(options) {
 		modifiedInstance.DbVersion = options.Version
+	}
+
+	if options.AllowMajorVersionUpgrade != nil && *options.AllowMajorVersionUpgrade {
+		modifiedInstance.AllowMajorVersionUpgrade = *options.AllowMajorVersionUpgrade
 	}
 
 	// Check to see if there is a storage size change and if so, check to make sure it's a valid change.

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -779,42 +779,6 @@ func TestModifyInstance(t *testing.T) {
 			expectedTags:  map[string]string{},
 			expectUpdates: true,
 		},
-		"update PostgreSQL database version from plan": {
-			options: Options{},
-			existingInstance: &RDSInstance{
-				DbType:    "postgres",
-				DbVersion: "8.0",
-			},
-			expectedInstance: &RDSInstance{
-				DbType:    "postgres",
-				DbVersion: "9.0",
-			},
-			currentPlan: &catalog.RDSPlan{},
-			newPlan: &catalog.RDSPlan{
-				DbVersion: "9.0",
-			},
-			settings:      &config.Settings{},
-			expectedTags:  map[string]string{},
-			expectUpdates: true,
-		},
-		"update MySQL database version from plan": {
-			options: Options{},
-			existingInstance: &RDSInstance{
-				DbType:    "mysql",
-				DbVersion: "8.0",
-			},
-			expectedInstance: &RDSInstance{
-				DbType:    "mysql",
-				DbVersion: "9.0",
-			},
-			currentPlan: &catalog.RDSPlan{},
-			newPlan: &catalog.RDSPlan{
-				DbVersion: "9.0",
-			},
-			settings:      &config.Settings{},
-			expectedTags:  map[string]string{},
-			expectUpdates: true,
-		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -815,6 +815,26 @@ func TestModifyInstance(t *testing.T) {
 			expectedTags:  map[string]string{},
 			expectUpdates: false,
 		},
+		"update allows major version upgrade": {
+			options: Options{
+				Version:                  "9.0",
+				AllowMajorVersionUpgrade: aws.Bool(true),
+			},
+			existingInstance: &RDSInstance{
+				DbType:    "postgres",
+				DbVersion: "8.0",
+			},
+			expectedInstance: &RDSInstance{
+				DbType:                   "postgres",
+				DbVersion:                "9.0",
+				AllowMajorVersionUpgrade: true,
+			},
+			currentPlan:   &catalog.RDSPlan{},
+			newPlan:       &catalog.RDSPlan{},
+			settings:      &config.Settings{},
+			expectedTags:  map[string]string{},
+			expectUpdates: true,
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -779,6 +779,42 @@ func TestModifyInstance(t *testing.T) {
 			expectedTags:  map[string]string{},
 			expectUpdates: true,
 		},
+		"update PostgreSQL database version from plan": {
+			options: Options{},
+			existingInstance: &RDSInstance{
+				DbType:    "postgres",
+				DbVersion: "8.0",
+			},
+			expectedInstance: &RDSInstance{
+				DbType:    "postgres",
+				DbVersion: "8.0",
+			},
+			currentPlan: &catalog.RDSPlan{},
+			newPlan: &catalog.RDSPlan{
+				DbVersion: "9.0",
+			},
+			settings:      &config.Settings{},
+			expectedTags:  map[string]string{},
+			expectUpdates: false,
+		},
+		"update MySQL database version from plan": {
+			options: Options{},
+			existingInstance: &RDSInstance{
+				DbType:    "mysql",
+				DbVersion: "8.0",
+			},
+			expectedInstance: &RDSInstance{
+				DbType:    "mysql",
+				DbVersion: "8.0",
+			},
+			currentPlan: &catalog.RDSPlan{},
+			newPlan: &catalog.RDSPlan{
+				DbVersion: "9.0",
+			},
+			settings:      &config.Settings{},
+			expectedTags:  map[string]string{},
+			expectUpdates: false,
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix database modify logic to only modify database version when a version is specified
- Fix bug in acceptance test scripts that was allowing failing updates to pass the tests
- Add unit tests for new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
