### PR TITLE
remove duplicate workers from main routine

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,12 +97,6 @@ func run(ctx context.Context, out io.Writer) error {
 	river.AddWorker(workers, redis.NewDeleteWorker(
 		db, &settings, elasticacheClient, s3, logger,
 	))
-	river.AddWorker(workers, rds.NewModifyWorker(
-		db, &settings, rdsClient, logger, parameterGroupClient, &rds.RDSCredentialUtils{},
-	))
-	river.AddWorker(workers, rds.NewDeleteWorker(
-		db, &settings, rdsClient, logger, parameterGroupClient, &rds.RDSCredentialUtils{},
-	))
 
 	riverClient, err := jobs.NewClient(ctx, db, settings.DbConfig, logger, workers)
 	if err != nil {


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove duplicate workers from main routine

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. No change to broker implementation, just behavior
