### PR TITLE
Fix CI script deletion behavior

### DIFF
--- a/ci/ci-utils.sh
+++ b/ci/ci-utils.sh
@@ -36,7 +36,7 @@ wait_for_service_instance_success() {
   fi
 }
 
-function wait_for_deletion {
+wait_for_deletion() {
   while true; do
     if ! cf service "$1"; then
       break
@@ -78,4 +78,11 @@ get_task_state() {
   fi
 
   echo "$task_state"
+}
+
+delete_existing_service() {
+  if cf service "$1"; then
+    cf delete-service -f "$1"
+    wait_for_deletion "$1"
+  fi
 }

--- a/ci/run-smoke-test-es-advanced-options.sh
+++ b/ci/run-smoke-test-es-advanced-options.sh
@@ -24,10 +24,7 @@ login
 
 # Clean up existing app and service if present
 cf delete -f "$TEST_APP"
-cf delete-service -f "$TEST_SERVICE"
-
-# Wait for service to be deleted
-wait_for_service_instance "$TEST_SERVICE"
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd "$TASK_DIRECTORY"

--- a/ci/run-smoke-test-rotate-creds.sh
+++ b/ci/run-smoke-test-rotate-creds.sh
@@ -12,7 +12,7 @@ SERVICE_NAME="rds-smoke-tests-db-rotate-creds-$SERVICE_PLAN"
 
 # Clean up existing app and service if present
 cf delete -f "$APP_NAME"
-cf delete-service -f "$SERVICE_NAME"
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds

--- a/ci/run-smoke-test-task.sh
+++ b/ci/run-smoke-test-task.sh
@@ -24,10 +24,7 @@ login
 
 # Clean up existing app and service if present
 cf delete -f "$TEST_APP"
-cf delete-service -f "$TEST_SERVICE"
-
-# Wait for service to be deleted
-wait_for_service_instance "$TEST_SERVICE"
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd "$TASK_DIRECTORY"

--- a/ci/run-smoke-test-unbound.sh
+++ b/ci/run-smoke-test-unbound.sh
@@ -20,11 +20,8 @@ TEST_SERVICE="smoke-test-$SERVICE_PLAN-unbound-service"
 # Log into CF
 login
 
-# Clean up existing app and service if present
-cf delete-service -f "$TEST_SERVICE"
-
-# Wait for service to be created
-wait_for_service_instance "$TEST_SERVICE"
+# Clean up existing service if present
+delete_existing_service "$SERVICE_NAME"
 
 # Create service
 cf create-service "$SERVICE_NAME" "$SERVICE_PLAN" "$TEST_SERVICE" -b "$BROKER_NAME"

--- a/ci/run-smoke-tests-db-updates.sh
+++ b/ci/run-smoke-tests-db-updates.sh
@@ -18,7 +18,7 @@ ALLOW_MAJOR_VERSION_UPGRADE=${ALLOW_MAJOR_VERSION_UPGRADE:-""}
 
 # Clean up existing app and service if present
 cf delete -f "smoke-tests-db-update-$SERVICE_PLAN"
-cf delete-service -f "$SERVICE_NAME"
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds

--- a/ci/run-smoke-tests-db-version.sh
+++ b/ci/run-smoke-tests-db-version.sh
@@ -12,7 +12,7 @@ SERVICE_NAME="rds-smoke-tests-db-version-$SERVICE_PLAN"
 
 # Clean up existing app and service if present
 cf delete -f "smoke-tests-db-version-$SERVICE_PLAN"
-cf delete-service -f "$SERVICE_NAME"
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds

--- a/ci/run-smoke-tests-update-redis.sh
+++ b/ci/run-smoke-tests-update-redis.sh
@@ -17,7 +17,7 @@ NEW_VERSION=${NEW_VERSION:-""}
 NEW_SERVICE_PLAN=${NEW_SERVICE_PLAN:-""}
 
 # Clean up existing service if present
-cf delete-service -f "$SERVICE_NAME"
+delete_existing_service "$SERVICE_NAME"
 
 # Create service
 create_service_args=(aws-elasticache-redis "$SERVICE_PLAN" "$SERVICE_NAME" -b "$BROKER_NAME")

--- a/ci/run-smoke-tests.sh
+++ b/ci/run-smoke-tests.sh
@@ -12,11 +12,7 @@ login
 
 # Clean up existing app and service if present
 cf delete -f "$APP_NAME"
-
-if cf service "$SERVICE_NAME"; then
-  cf delete-service -f "$SERVICE_NAME"
-  wait_for_deletion "$SERVICE_NAME"
-fi
+delete_existing_service "$SERVICE_NAME"
 
 # change into the directory and push the app without starting it.
 pushd aws-db-test/databases/aws-rds


### PR DESCRIPTION
## Changes proposed in this pull request:

- update CI scripts to delete existing instances and wait for deletion consistently. Currently there is a possible race condition where the script attempts to recreate the service instance before it has finished deleting, which these changes fix

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Just fixing behavior of CI acceptance test scripts
