### PR TITLE
Handle missing parameter group on RDS deletion

### DIFF
--- a/helpers/crypto_test.go
+++ b/helpers/crypto_test.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"crypto/aes"
-	"fmt"
 	"testing"
 )
 
@@ -59,8 +58,6 @@ func TestRandStringGeneration(t *testing.T) {
 		randstrings = append(randstrings, RandStr(10))
 	}
 
-	fmt.Println(randstrings[1])
-
 	dict := make(map[string]bool)
 	duplicatestrings := []string{}
 
@@ -83,7 +80,7 @@ func TestRandStringDistribution(t *testing.T) {
 		randstring := RandStr(1)
 		dict[randstring]++
 	}
-	fmt.Println(dict)
+
 	min := 1000000
 	max := 0
 	for _, value := range dict {
@@ -95,8 +92,6 @@ func TestRandStringDistribution(t *testing.T) {
 		}
 	}
 
-	fmt.Println("Min: ", min)
-	fmt.Println("Max: ", max)
 	if float32(min)/float32(max) < float32(.94) {
 		t.Error("The Deviation of random characters is too high", float32(min)/float32(max), float32(.95))
 	}

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func run(ctx context.Context, out io.Writer) error {
 
 	// RDS workers
 	rdsClient := awsRds.NewFromConfig(cfg)
-	parameterGroupClient := rds.NewAwsParameterGroupClient(ctx, rdsClient, &settings)
+	parameterGroupClient := rds.NewAwsParameterGroupClient(ctx, rdsClient, &settings, logger)
 	credentialUtils := &rds.RDSCredentialUtils{}
 	river.AddWorker(workers, rds.NewCreateWorker(
 		db, &settings, rdsClient, logger, parameterGroupClient, credentialUtils,

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -95,6 +95,9 @@ type mockRDSClient struct {
 	modifyDbCallNum                     int
 	modifyDbParamGroupErr               error
 	addTagsToResourceErr                error
+	describeDBParameterGroupsOutput     []*rds.DescribeDBParameterGroupsOutput
+	describeDBParameterGroupsCallNum    int
+	deleteDbParameterGroupErr           error
 }
 
 func (m *mockRDSClient) AddTagsToResource(ctx context.Context, params *rds.AddTagsToResourceInput, optFns ...func(*rds.Options)) (*rds.AddTagsToResourceOutput, error) {
@@ -140,7 +143,7 @@ func (m *mockRDSClient) DeleteDBInstance(ctx context.Context, params *rds.Delete
 }
 
 func (m *mockRDSClient) DeleteDBParameterGroup(ctx context.Context, params *rds.DeleteDBParameterGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBParameterGroupOutput, error) {
-	return nil, nil
+	return nil, m.deleteDbParameterGroupErr
 }
 
 func (m *mockRDSClient) DescribeDBEngineVersions(ctx context.Context, params *rds.DescribeDBEngineVersionsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBEngineVersionsOutput, error) {
@@ -165,7 +168,9 @@ func (m *mockRDSClient) DescribeDBInstances(ctx context.Context, params *rds.Des
 }
 
 func (m *mockRDSClient) DescribeDBParameterGroups(ctx context.Context, params *rds.DescribeDBParameterGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBParameterGroupsOutput, error) {
-	return nil, nil
+	output := m.describeDBParameterGroupsOutput[m.describeDBParameterGroupsCallNum]
+	m.describeDBParameterGroupsCallNum++
+	return output, nil
 }
 
 func (m *mockRDSClient) DescribeEngineDefaultParameters(ctx context.Context, params *rds.DescribeEngineDefaultParametersInput, optFns ...func(*rds.Options)) (*rds.DescribeEngineDefaultParametersOutput, error) {

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"regexp"
 	"slices"
 	"strings"
@@ -30,6 +31,7 @@ type awsParameterGroupClient struct {
 	rds                  RDSClientInterface
 	settings             *config.Settings
 	parameterGroupPrefix string
+	logger               *slog.Logger
 }
 
 type paramDetails struct {
@@ -37,7 +39,7 @@ type paramDetails struct {
 	applyMethod string
 }
 
-func NewAwsParameterGroupClient(ctx context.Context, rds RDSClientInterface, settings *config.Settings) *awsParameterGroupClient {
+func NewAwsParameterGroupClient(ctx context.Context, rds RDSClientInterface, settings *config.Settings, logger *slog.Logger) *awsParameterGroupClient {
 	return &awsParameterGroupClient{
 		ctx:                  ctx,
 		rds:                  rds,
@@ -94,13 +96,18 @@ func (p *awsParameterGroupClient) CleanupCustomParameterGroups() error {
 				}
 				_, err := p.rds.DeleteDBParameterGroup(p.ctx, deleteinput)
 				if err != nil {
-					var exception *rdsTypes.InvalidDBParameterGroupStateFault
-					if errors.As(err, &exception) {
+					var invalidParameterGroupStateErr *rdsTypes.InvalidDBParameterGroupStateFault
+					if errors.As(err, &invalidParameterGroupStateErr) {
 						// If you can't delete it because it's in use, that is fine.
 						// The db takes a while to delete, so we will clean it up the
-						// next time this is called.  Otherwise there is some sort of AWS error
-						// and we should log that.
-						log.Printf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err.Error())
+						// next time this is called.
+						p.logger.Debug(fmt.Sprintf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err))
+						continue
+					}
+
+					var notFoundErr *rdsTypes.DBParameterGroupNotFoundFault
+					if errors.As(err, &notFoundErr) {
+						p.logger.Debug(fmt.Sprintf("parameter group %s was not found, continuing", *pgroup.DBParameterGroupName))
 						continue
 					}
 

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -45,6 +45,7 @@ func NewAwsParameterGroupClient(ctx context.Context, rds RDSClientInterface, set
 		rds:                  rds,
 		settings:             settings,
 		parameterGroupPrefix: "cg-aws-broker-",
+		logger:               logger,
 	}
 }
 
@@ -101,7 +102,7 @@ func (p *awsParameterGroupClient) CleanupCustomParameterGroups() error {
 						// If you can't delete it because it's in use, that is fine.
 						// The db takes a while to delete, so we will clean it up the
 						// next time this is called.
-						p.logger.Debug(fmt.Sprintf("There was an error cleaning up the %s parameter group.  The error was: %s", *pgroup.DBParameterGroupName, err))
+						p.logger.Debug(fmt.Sprintf("There was an error cleaning up the %s parameter group. The error was: %s", *pgroup.DBParameterGroupName, err))
 						continue
 					}
 

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -2,6 +2,7 @@ package rds
 
 import (
 	"errors"
+	"log/slog"
 	"reflect"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloud-gov/aws-broker/config"
+	"github.com/cloud-gov/aws-broker/testutil"
 )
 
 func TestNewParameterGroupClient(t *testing.T) {
@@ -17,6 +19,7 @@ func TestNewParameterGroupClient(t *testing.T) {
 		t.Context(),
 		&mockRDSClient{},
 		&config.Settings{},
+		slog.New(&testutil.MockLogHandler{}),
 	)
 	if parameterGroupAdapter.ctx == nil {
 		t.Fatal("context should not be nil")

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -28,10 +28,13 @@ func TestNewParameterGroupClient(t *testing.T) {
 		t.Fatal("RDS client should not be nil")
 	}
 	if parameterGroupAdapter.settings == nil {
-		t.Fatal("RDS client should not be nil")
+		t.Fatal("settings should not be nil")
 	}
 	if parameterGroupAdapter.parameterGroupPrefix != "cg-aws-broker-" {
 		t.Errorf("actual prefix: %s", parameterGroupAdapter.parameterGroupPrefix)
+	}
+	if parameterGroupAdapter.logger == nil {
+		t.Fatal("logger should not be nil")
 	}
 }
 
@@ -1343,6 +1346,101 @@ func TestProvisionCustomParameterGroupIfNecessary(t *testing.T) {
 			}
 			if test.dbInstance.ParameterGroupName != test.expectedPGroupName {
 				t.Fatalf("unexpected group name: %s, expected: %s", test.dbInstance.ParameterGroupName, test.expectedPGroupName)
+			}
+		})
+	}
+}
+
+func TestCleanupCustomParameterGroups(t *testing.T) {
+	testCases := map[string]struct {
+		customParams          map[string]map[string]string
+		dbInstance            *RDSInstance
+		expectedPGroupName    string
+		expectErr             bool
+		dedicatedDBAdapter    *dedicatedDBAdapter
+		parameterGroupAdapter *awsParameterGroupClient
+	}{
+		"success": {
+			dbInstance: &RDSInstance{
+				DbType: "postgres",
+			},
+			expectedPGroupName: "",
+			parameterGroupAdapter: NewAwsParameterGroupClient(
+				t.Context(),
+				&mockRDSClient{
+					describeDBParameterGroupsOutput: []*rds.DescribeDBParameterGroupsOutput{
+						{
+							DBParameterGroups: []rdsTypes.DBParameterGroup{
+								{
+									DBParameterGroupName: aws.String("group-1"),
+								},
+							},
+						},
+					},
+				},
+				&config.Settings{},
+				slog.New(&testutil.MockLogHandler{}),
+			),
+		},
+		"skips invalid parameter group state error": {
+			dbInstance: &RDSInstance{
+				DbType: "postgres",
+			},
+			expectedPGroupName: "",
+			parameterGroupAdapter: &awsParameterGroupClient{
+				ctx: t.Context(),
+				rds: &mockRDSClient{
+					describeDBParameterGroupsOutput: []*rds.DescribeDBParameterGroupsOutput{
+						{
+							DBParameterGroups: []rdsTypes.DBParameterGroup{
+								{
+									DBParameterGroupName: aws.String("group-1"),
+								},
+							},
+						},
+					},
+					deleteDbParameterGroupErr: &rdsTypes.InvalidDBParameterGroupStateFault{},
+				},
+				settings:             &config.Settings{},
+				logger:               slog.New(&testutil.MockLogHandler{}),
+				parameterGroupPrefix: "group",
+			},
+		},
+		"skips not found error": {
+			dbInstance: &RDSInstance{
+				DbType: "postgres",
+			},
+			expectedPGroupName: "",
+			parameterGroupAdapter: &awsParameterGroupClient{
+				ctx: t.Context(),
+				rds: &mockRDSClient{
+					describeDBParameterGroupsOutput: []*rds.DescribeDBParameterGroupsOutput{
+						{
+							DBParameterGroups: []rdsTypes.DBParameterGroup{
+								{
+									DBParameterGroupName: aws.String("group-1"),
+								},
+							},
+						},
+					},
+					deleteDbParameterGroupErr: &rdsTypes.DBParameterGroupNotFoundFault{},
+				},
+				settings:             &config.Settings{},
+				logger:               slog.New(&testutil.MockLogHandler{}),
+				parameterGroupPrefix: "group",
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := test.parameterGroupAdapter.CleanupCustomParameterGroups()
+
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if test.expectErr && err == nil {
+				t.Error("expected error, got nil")
 			}
 		})
 	}

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -59,7 +59,7 @@ func initializeAdapter(
 
 	rdsClient := rds.NewFromConfig(cfg)
 
-	parameterGroupClient := NewAwsParameterGroupClient(ctx, rdsClient, s)
+	parameterGroupClient := NewAwsParameterGroupClient(ctx, rdsClient, s, logger)
 
 	dbAdapter := NewRdsDedicatedDBAdapter(ctx, s, db, rdsClient, parameterGroupClient, logger, riverClient)
 	return dbAdapter, nil


### PR DESCRIPTION
## Changes proposed in this pull request:

- Handle missing parameter group on RDS deletion
- Add tests for new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
