### PR TITLE
Fix handling of DB version on RDS modify

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -38,7 +38,7 @@ rds:
         - "14"
         - "15"
         - "16"
-      dbVersion: "16"
+      dbVersion: &default-pg-version "16.13"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -70,7 +70,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.micro
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -104,7 +104,7 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -138,7 +138,7 @@ rds:
       instanceClass: db.t3.small
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -171,7 +171,7 @@ rds:
       instanceClass: db.t3.small
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -205,7 +205,7 @@ rds:
       instanceClass: db.t3.small
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -239,7 +239,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -272,7 +272,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -306,7 +306,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -340,7 +340,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -373,7 +373,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -407,7 +407,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -441,7 +441,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -474,7 +474,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -507,7 +507,7 @@ rds:
       instanceClass: db.m5.large
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -542,7 +542,7 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -575,7 +575,7 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -609,7 +609,7 @@ rds:
       instanceClass: db.m5.xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -645,7 +645,7 @@ rds:
       instanceClass: db.m5.2xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -678,7 +678,7 @@ rds:
       instanceClass: db.m5.2xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -712,7 +712,7 @@ rds:
       instanceClass: db.m5.2xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -748,7 +748,7 @@ rds:
       instanceClass: &m6-xlarge db.m6g.xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -781,7 +781,7 @@ rds:
       instanceClass: *m6-xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -815,7 +815,7 @@ rds:
       instanceClass: *m6-xlarge
       allocatedStorage: 20
       approvedMajorVersions: *approved_rds_pg_versions
-      dbVersion: "16"
+      dbVersion: *default-pg-version
       dbType: postgres
       plan_updateable: true
       redundant: true
@@ -851,7 +851,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: &default-mysql-version "8.4.4"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -886,7 +886,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -921,7 +921,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -955,7 +955,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -990,7 +990,7 @@ rds:
       approvedMajorVersions:
         - "8.4"
       dbType: mysql
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       plan_updateable: true
       redundant: true
       encrypted: true
@@ -1025,7 +1025,7 @@ rds:
       approvedMajorVersions:
         - "8.4"
       dbType: mysql
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       plan_updateable: true
       redundant: true
       read_replica: true
@@ -1059,7 +1059,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -1093,7 +1093,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1128,7 +1128,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1163,7 +1163,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -1197,7 +1197,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1232,7 +1232,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1267,7 +1267,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -1301,7 +1301,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1336,7 +1336,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1371,7 +1371,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -1405,7 +1405,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true
@@ -1440,7 +1440,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: "8.4.4"
+      dbVersion: *default-mysql-version
       dbType: mysql
       plan_updateable: true
       redundant: true

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -276,6 +276,16 @@ func (broker *rdsBroker) ModifyInstance(id string, details domain.UpdateDetails)
 		return apiresponses.NewFailureResponse(err, http.StatusBadRequest, "fetch RDS plan")
 	}
 
+	// Check to make sure that we're not switching database engines; this is not
+	// allowed.
+	if newPlan.DbType != existingInstance.DbType {
+		return apiresponses.NewFailureResponse(
+			errors.New("cannot switch between database engines/types. Please select a plan with the same database engine/type"),
+			http.StatusBadRequest,
+			"modify RDS instance",
+		)
+	}
+
 	tags, err := broker.tagManager.GenerateTags(
 		brokertags.Update,
 		broker.catalog.RdsService.Name,
@@ -307,16 +317,6 @@ func (broker *rdsBroker) ModifyInstance(id string, details domain.UpdateDetails)
 		return apiresponses.NewFailureResponse(
 			fmt.Errorf("failed to modify instance. Error: %s", err),
 			http.StatusInternalServerError,
-			"modify RDS instance",
-		)
-	}
-
-	// Check to make sure that we're not switching database engines; this is not
-	// allowed.
-	if newPlan.DbType != existingInstance.DbType {
-		return apiresponses.NewFailureResponse(
-			errors.New("cannot switch between database engines/types. Please select a plan with the same database engine/type"),
-			http.StatusBadRequest,
 			"modify RDS instance",
 		)
 	}

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -293,7 +293,7 @@ func (broker *rdsBroker) ModifyInstance(id string, details domain.UpdateDetails)
 		)
 	}
 
-	reonciledInstance, err := broker.dbAdapter.reconcileDbState(broker.ctx, *existingInstance)
+	reconciledInstance, err := broker.dbAdapter.reconcileDbState(broker.ctx, *existingInstance)
 	if err != nil {
 		return apiresponses.NewFailureResponse(
 			fmt.Errorf("failed to reconcile instance. Error: %s", err),
@@ -302,7 +302,7 @@ func (broker *rdsBroker) ModifyInstance(id string, details domain.UpdateDetails)
 		)
 	}
 
-	modifiedInstance, err := reonciledInstance.modify(options, currentPlan, newPlan, broker.settings, tags)
+	modifiedInstance, err := reconciledInstance.modify(options, currentPlan, newPlan, broker.settings, tags)
 	if err != nil {
 		return apiresponses.NewFailureResponse(
 			fmt.Errorf("failed to modify instance. Error: %s", err),

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -293,7 +293,16 @@ func (broker *rdsBroker) ModifyInstance(id string, details domain.UpdateDetails)
 		)
 	}
 
-	modifiedInstance, err := existingInstance.modify(options, currentPlan, newPlan, broker.settings, tags)
+	reonciledInstance, err := broker.dbAdapter.reconcileDbState(broker.ctx, *existingInstance)
+	if err != nil {
+		return apiresponses.NewFailureResponse(
+			fmt.Errorf("failed to reconcile instance. Error: %s", err),
+			http.StatusInternalServerError,
+			"reconcile RDS instance",
+		)
+	}
+
+	modifiedInstance, err := reonciledInstance.modify(options, currentPlan, newPlan, broker.settings, tags)
 	if err != nil {
 		return apiresponses.NewFailureResponse(
 			fmt.Errorf("failed to modify instance. Error: %s", err),

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"code.cloudfoundry.org/brokerapi/v13/domain"
+	"code.cloudfoundry.org/brokerapi/v13/domain/apiresponses"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cloud-gov/aws-broker/asyncmessage"
 	"github.com/cloud-gov/aws-broker/base"
@@ -371,7 +372,6 @@ func TestModify(t *testing.T) {
 			dbAdapter: &mockDBAdapter{
 				db: brokerDB,
 			},
-			expectedResponseCode: http.StatusAccepted,
 		},
 		"success with version update": {
 			catalog: &catalog.Catalog{
@@ -422,7 +422,6 @@ func TestModify(t *testing.T) {
 			dbAdapter: &mockDBAdapter{
 				db: brokerDB,
 			},
-			expectedResponseCode: http.StatusAccepted,
 		},
 		"success with replica": {
 			catalog: &catalog.Catalog{
@@ -475,7 +474,6 @@ func TestModify(t *testing.T) {
 			dbAdapter: &mockDBAdapter{
 				db: brokerDB,
 			},
-			expectedResponseCode: http.StatusAccepted,
 		},
 		"reconciled db version": {
 			catalog: &catalog.Catalog{
@@ -538,7 +536,6 @@ func TestModify(t *testing.T) {
 					DbVersion: "15.14",
 				},
 			},
-			expectedResponseCode: http.StatusAccepted,
 		},
 		"reconcile db version and update version": {
 			catalog: &catalog.Catalog{
@@ -604,7 +601,6 @@ func TestModify(t *testing.T) {
 					DbType:    "postgres",
 				},
 			},
-			expectedResponseCode: http.StatusAccepted,
 		},
 		"changing database type": {
 			catalog: &catalog.Catalog{
@@ -659,6 +655,59 @@ func TestModify(t *testing.T) {
 			expectErr:            true,
 			expectedResponseCode: http.StatusBadRequest,
 		},
+		"changing to non-updateable plan": {
+			catalog: &catalog.Catalog{
+				RdsService: catalog.RDSService{
+					RDSPlans: []catalog.RDSPlan{
+						{
+							ServicePlan: domain.ServicePlan{
+								ID:            "123",
+								PlanUpdatable: aws.Bool(false),
+							},
+							DbType: "postgres",
+						},
+						{
+							ServicePlan: domain.ServicePlan{
+								ID: "456",
+							},
+						},
+					},
+				},
+			},
+			dbInstance: createTestRdsInstance(&RDSInstance{
+				Instance: base.Instance{
+					Uuid: uuid.NewString(),
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+				DbType:    "postgres",
+			}),
+			expectedDbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+				DbType:    "postgres",
+			},
+			tagManager: &mocks.MockTagGenerator{},
+			settings: &config.Settings{
+				EncryptionKey: helpers.RandStr(32),
+			},
+			updateDetails: domain.UpdateDetails{
+				PlanID: "123",
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
+			},
+			expectErr:            true,
+			expectedResponseCode: http.StatusUnprocessableEntity,
+		},
 	}
 
 	for name, test := range testCases {
@@ -677,8 +726,15 @@ func TestModify(t *testing.T) {
 			}
 
 			err = broker.ModifyInstance(test.dbInstance.Uuid, test.updateDetails)
-			if err != nil && !test.expectErr {
-				t.Fatal(err)
+			if err != nil {
+				if !test.expectErr {
+					t.Fatal(err)
+				}
+				if responseErr, ok := err.(*apiresponses.FailureResponse); ok {
+					if responseErr.ValidatedStatusCode(nil) != test.expectedResponseCode {
+						t.Fatalf("expected error code: %d, got: %d", test.expectedResponseCode, responseErr.ValidatedStatusCode(nil))
+					}
+				}
 			}
 			if err == nil && test.expectErr {
 				t.Fatal("expected error, received nil")

--- a/services/rds/broker_test.go
+++ b/services/rds/broker_test.go
@@ -303,6 +303,14 @@ func TestCreateInstanceSuccess(t *testing.T) {
 }
 
 func TestModify(t *testing.T) {
+	brokerDB, err := testDBInit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileDbStateRDSInstanceUUID := uuid.NewString()
+	reconcileUpdateDbVersionRDSInstanceUUID := uuid.NewString()
+
 	testCases := map[string]struct {
 		dbInstance           *RDSInstance
 		expectedResponseCode int
@@ -313,6 +321,7 @@ func TestModify(t *testing.T) {
 		updateDetails        domain.UpdateDetails
 		expectedDbInstance   *RDSInstance
 		dbAdapter            dbAdapter
+		expectErr            bool
 	}{
 		"success": {
 			catalog: &catalog.Catalog{
@@ -358,6 +367,9 @@ func TestModify(t *testing.T) {
 			},
 			updateDetails: domain.UpdateDetails{
 				PlanID: "123",
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
 			},
 			expectedResponseCode: http.StatusAccepted,
 		},
@@ -406,6 +418,9 @@ func TestModify(t *testing.T) {
 			updateDetails: domain.UpdateDetails{
 				PlanID:        "123",
 				RawParameters: json.RawMessage(`{"version": "9.0"}`),
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
 			},
 			expectedResponseCode: http.StatusAccepted,
 		},
@@ -457,25 +472,203 @@ func TestModify(t *testing.T) {
 			updateDetails: domain.UpdateDetails{
 				PlanID: "123",
 			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
+			},
 			expectedResponseCode: http.StatusAccepted,
+		},
+		"reconciled db version": {
+			catalog: &catalog.Catalog{
+				RdsService: catalog.RDSService{
+					RDSPlans: []catalog.RDSPlan{
+						{
+							ServicePlan: domain.ServicePlan{
+								ID:            "123",
+								PlanUpdatable: aws.Bool(true),
+							},
+							Redundant:   true,
+							ReadReplica: true,
+						},
+						{
+							ServicePlan: domain.ServicePlan{
+								ID: "456",
+							},
+						},
+					},
+				},
+			},
+			dbInstance: createTestRdsInstance(&RDSInstance{
+				Instance: base.Instance{
+					Uuid: reconcileDbStateRDSInstanceUUID,
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+			}),
+			expectedDbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "123",
+					},
+					State: base.InstanceInProgress,
+				},
+				DbVersion: "15.14",
+				Tags:      map[string]string{},
+			},
+			tagManager: &mocks.MockTagGenerator{},
+			settings: &config.Settings{
+				EncryptionKey: helpers.RandStr(32),
+			},
+			updateDetails: domain.UpdateDetails{
+				PlanID: "123",
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
+				reconciledInstance: &RDSInstance{
+					Instance: base.Instance{
+						Uuid: reconcileDbStateRDSInstanceUUID,
+						Request: request.Request{
+							ServiceID: "service-1",
+							PlanID:    "456",
+						},
+					},
+					DbVersion: "15.14",
+				},
+			},
+			expectedResponseCode: http.StatusAccepted,
+		},
+		"reconcile db version and update version": {
+			catalog: &catalog.Catalog{
+				RdsService: catalog.RDSService{
+					RDSPlans: []catalog.RDSPlan{
+						{
+							ServicePlan: domain.ServicePlan{
+								ID:            "123",
+								PlanUpdatable: aws.Bool(true),
+							},
+							DbType: "postgres",
+						},
+						{
+							ServicePlan: domain.ServicePlan{
+								ID: "456",
+							},
+						},
+					},
+				},
+			},
+			dbInstance: createTestRdsInstance(&RDSInstance{
+				Instance: base.Instance{
+					Uuid: reconcileUpdateDbVersionRDSInstanceUUID,
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+				DbType:    "postgres",
+			}),
+			expectedDbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "123",
+					},
+					State: base.InstanceInProgress,
+				},
+				DbVersion: "15.16",
+				DbType:    "postgres",
+				Tags:      map[string]string{},
+			},
+			tagManager: &mocks.MockTagGenerator{},
+			settings: &config.Settings{
+				EncryptionKey: helpers.RandStr(32),
+			},
+			updateDetails: domain.UpdateDetails{
+				PlanID:        "123",
+				RawParameters: json.RawMessage(`{"version": "15.16"}`),
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
+				reconciledInstance: &RDSInstance{
+					Instance: base.Instance{
+						Uuid: reconcileUpdateDbVersionRDSInstanceUUID,
+						Request: request.Request{
+							ServiceID: "service-1",
+							PlanID:    "456",
+						},
+					},
+					DbVersion: "15.14",
+					DbType:    "postgres",
+				},
+			},
+			expectedResponseCode: http.StatusAccepted,
+		},
+		"changing database type": {
+			catalog: &catalog.Catalog{
+				RdsService: catalog.RDSService{
+					RDSPlans: []catalog.RDSPlan{
+						{
+							ServicePlan: domain.ServicePlan{
+								ID:            "123",
+								PlanUpdatable: aws.Bool(true),
+							},
+							DbType: "mysql",
+						},
+						{
+							ServicePlan: domain.ServicePlan{
+								ID: "456",
+							},
+						},
+					},
+				},
+			},
+			dbInstance: createTestRdsInstance(&RDSInstance{
+				Instance: base.Instance{
+					Uuid: uuid.NewString(),
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+				DbType:    "postgres",
+			}),
+			expectedDbInstance: &RDSInstance{
+				Instance: base.Instance{
+					Request: request.Request{
+						ServiceID: "service-1",
+						PlanID:    "456",
+					},
+				},
+				DbVersion: "15",
+				DbType:    "postgres",
+			},
+			tagManager: &mocks.MockTagGenerator{},
+			settings: &config.Settings{
+				EncryptionKey: helpers.RandStr(32),
+			},
+			updateDetails: domain.UpdateDetails{
+				PlanID: "123",
+			},
+			dbAdapter: &mockDBAdapter{
+				db: brokerDB,
+			},
+			expectErr:            true,
+			expectedResponseCode: http.StatusBadRequest,
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			brokerDB, err := testDBInit()
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			broker := &rdsBroker{
 				brokerDB:   brokerDB,
 				catalog:    test.catalog,
 				settings:   test.settings,
 				tagManager: test.tagManager,
-				dbAdapter: &mockDBAdapter{
-					db: brokerDB,
-				},
+				dbAdapter:  test.dbAdapter,
 			}
 
 			err = brokerDB.Create(test.dbInstance).Error
@@ -484,8 +677,11 @@ func TestModify(t *testing.T) {
 			}
 
 			err = broker.ModifyInstance(test.dbInstance.Uuid, test.updateDetails)
-			if err != nil {
+			if err != nil && !test.expectErr {
 				t.Fatal(err)
+			}
+			if err == nil && test.expectErr {
+				t.Fatal("expected error, received nil")
 			}
 
 			updatedInstance := &RDSInstance{}

--- a/services/rds/modify_worker.go
+++ b/services/rds/modify_worker.go
@@ -151,53 +151,28 @@ func (w *ModifyWorker) asyncModifyDbInstance(ctx context.Context, operation base
 	return nil
 }
 
-func (w *ModifyWorker) reconcileDbState(ctx context.Context, i RDSInstance, operation base.Operation) (*RDSInstance, error) {
-	output, err := w.rds.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: &i.Database,
-	})
-	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error describing database: %s", err))
-		return nil, fmt.Errorf("asyncModifyDb: reconcileDbState error %w", err)
-	}
-
-	modifiedInstance := i
-	if modifiedInstance.DbVersion != *output.DBInstances[0].EngineVersion {
-		modifiedInstance.DbVersion = *output.DBInstances[0].EngineVersion
-	}
-
-	return &modifiedInstance, nil
-}
-
 func (w *ModifyWorker) asyncModifyDb(ctx context.Context, i *RDSInstance, plan *catalog.RDSPlan) error {
 	operation := base.ModifyOp
+	serviceID := i.ServiceID
+	uuid := i.Uuid
 
-	modifiedInstance, err := w.reconcileDbState(ctx, *i, operation)
-	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error describing database: %s", err))
-		w.logger.Error("asyncModifyDb: asyncModifyDbInstance error", "err", err)
-		return river.JobCancel(fmt.Errorf("asyncModifyDb: error describing database instance %w ", err))
-	}
-
-	serviceID := modifiedInstance.ServiceID
-	uuid := modifiedInstance.Uuid
-
-	err = w.asyncModifyDbInstance(ctx, operation, modifiedInstance, plan, modifiedInstance.Database, false)
+	err := w.asyncModifyDbInstance(ctx, operation, i, plan, i.Database, false)
 	if err != nil {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database: %s", err))
 		w.logger.Error("asyncModifyDb: asyncModifyDbInstance error", "err", err)
 		return river.JobCancel(fmt.Errorf("asyncModifyDb: error modifying database instance %w ", err))
 	}
 
-	if modifiedInstance.AddReadReplica {
+	if i.AddReadReplica {
 		// Add new read replica
-		err = waitAndCreateDBReadReplica(ctx, w.db, w.settings, w.rds, w.logger, operation, modifiedInstance, plan)
+		err = waitAndCreateDBReadReplica(ctx, w.db, w.settings, w.rds, w.logger, operation, i, plan)
 		if err != nil {
 			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error creating database replica: %s", err))
 			w.logger.Error("asyncModifyDb: waitAndCreateDBReadReplica error", "err", err)
 			return river.JobCancel(fmt.Errorf("asyncModifyDb: error creating database replica %w ", err))
 		}
-	} else if !modifiedInstance.DeleteReadReplica && !modifiedInstance.AddReadReplica && modifiedInstance.ReplicaDatabase != "" {
-		err := w.asyncModifyDbInstance(ctx, operation, modifiedInstance, plan, modifiedInstance.ReplicaDatabase, true)
+	} else if !i.DeleteReadReplica && !i.AddReadReplica && i.ReplicaDatabase != "" {
+		err := w.asyncModifyDbInstance(ctx, operation, i, plan, i.ReplicaDatabase, true)
 		if err != nil {
 			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))
 			w.logger.Error("asyncModifyDb: asyncModifyDbInstance read replica error", "err", err)
@@ -205,8 +180,8 @@ func (w *ModifyWorker) asyncModifyDb(ctx context.Context, i *RDSInstance, plan *
 		}
 	}
 
-	if modifiedInstance.DeleteReadReplica {
-		err = deleteDatabaseReadReplica(ctx, w.db, w.settings, w.rds, w.logger, modifiedInstance, operation)
+	if i.DeleteReadReplica {
+		err = deleteDatabaseReadReplica(ctx, w.db, w.settings, w.rds, w.logger, i, operation)
 		if err != nil {
 			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting database replica: %s", err))
 			w.logger.Error("asyncModifyDb: deleteDatabaseReadReplica error", "err", err)
@@ -214,7 +189,7 @@ func (w *ModifyWorker) asyncModifyDb(ctx context.Context, i *RDSInstance, plan *
 		}
 	}
 
-	err = w.db.Save(modifiedInstance).Error
+	err = w.db.Save(i).Error
 	if err != nil {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error saving record: %s", err))
 		w.logger.Error("asyncModifyDb: error saving record", "err", err)

--- a/services/rds/modify_worker.go
+++ b/services/rds/modify_worker.go
@@ -151,49 +151,76 @@ func (w *ModifyWorker) asyncModifyDbInstance(ctx context.Context, operation base
 	return nil
 }
 
+func (w *ModifyWorker) reconcileDbState(ctx context.Context, i RDSInstance, operation base.Operation) (*RDSInstance, error) {
+	output, err := w.rds.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: &i.Database,
+	})
+	if err != nil {
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error describing database: %s", err))
+		return nil, fmt.Errorf("asyncModifyDb: reconcileDbState error %w", err)
+	}
+
+	modifiedInstance := i
+	if modifiedInstance.DbVersion != *output.DBInstances[0].EngineVersion {
+		modifiedInstance.DbVersion = *output.DBInstances[0].EngineVersion
+	}
+
+	return &modifiedInstance, nil
+}
+
 func (w *ModifyWorker) asyncModifyDb(ctx context.Context, i *RDSInstance, plan *catalog.RDSPlan) error {
 	operation := base.ModifyOp
 
-	err := w.asyncModifyDbInstance(ctx, operation, i, plan, i.Database, false)
+	modifiedInstance, err := w.reconcileDbState(ctx, *i, operation)
 	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database: %s", err))
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error describing database: %s", err))
+		w.logger.Error("asyncModifyDb: asyncModifyDbInstance error", "err", err)
+		return river.JobCancel(fmt.Errorf("asyncModifyDb: error describing database instance %w ", err))
+	}
+
+	serviceID := modifiedInstance.ServiceID
+	uuid := modifiedInstance.Uuid
+
+	err = w.asyncModifyDbInstance(ctx, operation, modifiedInstance, plan, modifiedInstance.Database, false)
+	if err != nil {
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database: %s", err))
 		w.logger.Error("asyncModifyDb: asyncModifyDbInstance error", "err", err)
 		return river.JobCancel(fmt.Errorf("asyncModifyDb: error modifying database instance %w ", err))
 	}
 
-	if i.AddReadReplica {
+	if modifiedInstance.AddReadReplica {
 		// Add new read replica
-		err = waitAndCreateDBReadReplica(ctx, w.db, w.settings, w.rds, w.logger, operation, i, plan)
+		err = waitAndCreateDBReadReplica(ctx, w.db, w.settings, w.rds, w.logger, operation, modifiedInstance, plan)
 		if err != nil {
-			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error creating database replica: %s", err))
+			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error creating database replica: %s", err))
 			w.logger.Error("asyncModifyDb: waitAndCreateDBReadReplica error", "err", err)
 			return river.JobCancel(fmt.Errorf("asyncModifyDb: error creating database replica %w ", err))
 		}
-	} else if !i.DeleteReadReplica && !i.AddReadReplica && i.ReplicaDatabase != "" {
-		err := w.asyncModifyDbInstance(ctx, operation, i, plan, i.ReplicaDatabase, true)
+	} else if !modifiedInstance.DeleteReadReplica && !modifiedInstance.AddReadReplica && modifiedInstance.ReplicaDatabase != "" {
+		err := w.asyncModifyDbInstance(ctx, operation, modifiedInstance, plan, modifiedInstance.ReplicaDatabase, true)
 		if err != nil {
-			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))
+			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error modifying database replica: %s", err))
 			w.logger.Error("asyncModifyDb: asyncModifyDbInstance read replica error", "err", err)
 			return river.JobCancel(fmt.Errorf("asyncModifyDb: error modifying database replica %w ", err))
 		}
 	}
 
-	if i.DeleteReadReplica {
-		err = deleteDatabaseReadReplica(ctx, w.db, w.settings, w.rds, w.logger, i, operation)
+	if modifiedInstance.DeleteReadReplica {
+		err = deleteDatabaseReadReplica(ctx, w.db, w.settings, w.rds, w.logger, modifiedInstance, operation)
 		if err != nil {
-			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting database replica: %s", err))
+			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting database replica: %s", err))
 			w.logger.Error("asyncModifyDb: deleteDatabaseReadReplica error", "err", err)
 			return river.JobCancel(fmt.Errorf("asyncModifyDb: error deleting database replica %w ", err))
 		}
 	}
 
-	err = w.db.Save(i).Error
+	err = w.db.Save(modifiedInstance).Error
 	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error saving record: %s", err))
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error saving record: %s", err))
 		w.logger.Error("asyncModifyDb: error saving record", "err", err)
 		return river.JobCancel(fmt.Errorf("asyncModifyDb: error saving database record %w ", err))
 	}
 
-	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceReady, "Finished modifying database resources")
+	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, serviceID, uuid, operation, base.InstanceReady, "Finished modifying database resources")
 	return nil
 }

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -32,6 +32,7 @@ type dbAdapter interface {
 	bindDBToApp(i *RDSInstance, password string) (map[string]string, error)
 	deleteDB(i *RDSInstance) (base.InstanceState, error)
 	describeDatabaseInstance(database string) (*rdsTypes.DBInstance, error)
+	reconcileDbState(ctx context.Context, i RDSInstance) (*RDSInstance, error)
 }
 
 // initializeAdapter is the main function to create database instances
@@ -123,6 +124,10 @@ func (d *mockDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error) {
 
 func (d *mockDBAdapter) describeDatabaseInstance(database string) (*rdsTypes.DBInstance, error) {
 	return nil, nil
+}
+
+func (d *mockDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance) (*RDSInstance, error) {
+	return &i, nil
 }
 
 // END MockDBAdpater
@@ -326,6 +331,22 @@ func (d *dedicatedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error
 	}
 
 	return base.InstanceInProgress, nil
+}
+
+func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance) (*RDSInstance, error) {
+	output, err := d.rds.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: &i.Database,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("asyncModifyDb: reconcileDbState error %w", err)
+	}
+
+	modifiedInstance := i
+	if modifiedInstance.DbVersion != *output.DBInstances[0].EngineVersion {
+		modifiedInstance.DbVersion = *output.DBInstances[0].EngineVersion
+	}
+
+	return &modifiedInstance, nil
 }
 
 func getRetryMultiplier(storageSize int64) int64 {

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -91,8 +91,9 @@ func NewRdsDedicatedDBAdapter(
 // It is only here because *_test.go files are only compiled during "go test"
 // and it's referenced in non *_test.go code eg. InitializeAdapter in main.go.
 type mockDBAdapter struct {
-	db            *gorm.DB
-	createDBState *base.InstanceState
+	db                 *gorm.DB
+	createDBState      *base.InstanceState
+	reconciledInstance *RDSInstance
 }
 
 func (d *mockDBAdapter) createDB(i *RDSInstance, plan *catalog.RDSPlan) (base.InstanceState, error) {
@@ -127,6 +128,9 @@ func (d *mockDBAdapter) describeDatabaseInstance(database string) (*rdsTypes.DBI
 }
 
 func (d *mockDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance) (*RDSInstance, error) {
+	if d.reconciledInstance != nil {
+		return d.reconciledInstance, nil
+	}
 	return &i, nil
 }
 

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -334,19 +334,21 @@ func (d *dedicatedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error
 }
 
 func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance) (*RDSInstance, error) {
-	output, err := d.rds.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: &i.Database,
-	})
+	dbInstanceState, err := d.describeDatabaseInstance(i.Database)
 	if err != nil {
-		return nil, fmt.Errorf("asyncModifyDb: reconcileDbState error %w", err)
+		return nil, fmt.Errorf("reconcileDbState error: %w", err)
 	}
 
-	modifiedInstance := i
-	if modifiedInstance.DbVersion != *output.DBInstances[0].EngineVersion {
-		modifiedInstance.DbVersion = *output.DBInstances[0].EngineVersion
+	reconciledInstance := i
+
+	// Sometimes, the database version tracked by the broker may be out of sync
+	// with the actual version of the database. If that is the case, then update
+	// the database version tracked by the broker
+	if reconciledInstance.DbVersion != *dbInstanceState.EngineVersion {
+		reconciledInstance.DbVersion = *dbInstanceState.EngineVersion
 	}
 
-	return &modifiedInstance, nil
+	return &reconciledInstance, nil
 }
 
 func getRetryMultiplier(storageSize int64) int64 {

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -657,6 +657,79 @@ func TestDeleteDb(t *testing.T) {
 	}
 }
 
+func TestReconcileDbState(t *testing.T) {
+	brokerDB, err := testDBInit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := map[string]struct {
+		ctx              context.Context
+		dbAdapter        dbAdapter
+		expectErr        bool
+		dbInstance       RDSInstance
+		expectedInstance *RDSInstance
+	}{
+		"success": {
+			ctx: t.Context(),
+			dbAdapter: NewTestDedicatedDBAdapter(
+				t.Context(),
+				brokerDB,
+				&config.Settings{},
+				&mockRDSClient{
+					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
+						{
+							DBInstances: []rdsTypes.DBInstance{
+								{
+									EngineVersion: aws.String("15.14"),
+								},
+							},
+						},
+					},
+				},
+				&mockParameterGroupClient{},
+			),
+			dbInstance: RDSInstance{
+				DbVersion: "15",
+			},
+			expectedInstance: &RDSInstance{
+				DbVersion: "15.14",
+			},
+		},
+		"error describing database": {
+			dbAdapter: NewTestDedicatedDBAdapter(
+				t.Context(),
+				brokerDB,
+				&config.Settings{},
+				&mockRDSClient{
+					describeDbInstancesErrs: []error{errors.New("error describing database")},
+				},
+				&mockParameterGroupClient{},
+			),
+			dbInstance: RDSInstance{},
+			expectErr:  true,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			reconciledInstance, err := test.dbAdapter.reconcileDbState(test.ctx, test.dbInstance)
+			if err != nil && !test.expectErr {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err == nil && test.expectErr {
+				t.Fatal("expected error but received none")
+			}
+			if diff := deep.Equal(reconciledInstance, test.expectedInstance); diff != nil {
+				t.Error(diff)
+			}
+			if diff := deep.Equal(test.expectedInstance, test.dbInstance); diff == nil {
+				t.Fatal("instance passed as argument to reconcileDbState() should not have been mutated")
+			}
+		})
+	}
+}
+
 func TestGetRetryMultiplier(t *testing.T) {
 	testCases := map[string]struct {
 		storageSize        int64


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add logic to reconcile RDS database version with the version tracked by the broker in case there is drift
- Add tests to ensure reconcilIation of RDS database version works as expected and to ensure that updating the RDS database version still works
- Update Postgres database plans in catalog to specify the minor version for databases on creation 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug related to drift between the broker's tracking of database state and the actual database resource state
