### PR TITLE
Fix typo in PgQueryLoggingOptions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -485,7 +485,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_min_duration_sample_rate": 0.5, "log_statement_stats": false}'
+                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_statement_sample_rate": 0.5, "log_statement_stats": false}'
 
             - task: smoke-tests-mysql
               file: aws-broker-app/ci/run-smoke-tests.yml
@@ -1011,7 +1011,7 @@ jobs:
                 CF_SPACE: ((staging-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_min_duration_sample_rate": 0.5, "log_statement_stats": false}'
+                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_statement_sample_rate": 0.5, "log_statement_stats": false}'
 
             - task: smoke-tests-mysql
               file: aws-broker-app/ci/run-smoke-tests.yml
@@ -1704,7 +1704,7 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_min_duration_sample_rate": 0.5, "log_statement_stats": false}'
+                PG_QUERY_LOGGING: '{"log_connections": true, "log_disconnections": true, "log_checkpoints": true, "log_lock_waits": true, "log_min_duration_sample": 500, "log_min_duration_statement": 1000, "log_statement": "all", "log_statement_sample_rate": 0.5, "log_statement_stats": false}'
 
             - task: smoke-tests-mysql
               file: aws-broker-app/ci/run-smoke-tests.yml

--- a/services/rds/broker.go
+++ b/services/rds/broker.go
@@ -33,7 +33,7 @@ type PgQueryLoggingOptions struct {
 	LogMinDurationSample    *int64   `json:"log_min_duration_sample"`
 	LogMinDurationStatement *int64   `json:"log_min_duration_statement"`
 	LogStatement            *string  `json:"log_statement"`
-	LogStatementSampleRate  *float64 `json:"log_min_duration_sample_rate"`
+	LogStatementSampleRate  *float64 `json:"log_statement_sample_rate"`
 	LogStatementStats       *bool    `json:"log_statement_stats"`
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix typo of `LogStatementSampleRate` json field in `PgQueryLoggingOptions` struct
- Fix typo in smoke tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
