### PR TITLE
updating the RDS catalog and catalog test with pSQL and MySQL offering changes

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -21,7 +21,7 @@ rds:
       metadata:
         bullets:
           - &single-az-rds "Single-AZ RDS instance"
-          - &default-postgresql-v15 "Default PostgreSQL v15"
+          - &default-postgresql-v18 "Default PostgreSQL v18"
           - &minimum-1-core "minimum 1 core"
           - &minimum-1-gib-memory "minimum 1 GiB memory"
           - &default-10-gb-storage "Default 10 GB storage"
@@ -35,10 +35,11 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 20
       approvedMajorVersions: &approved_rds_pg_versions
-        - "14"
         - "15"
         - "16"
-      dbVersion: &default-pg-version "16.13"
+        - "17"
+        - "18"
+      dbVersion: &default-pg-version "18.3"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -57,7 +58,7 @@ rds:
       metadata:
         bullets:
           - &multi-az-rds "Multi-AZ RDS instance"
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -90,7 +91,7 @@ rds:
         bullets:
           - &read-replica "includes 1 read replica"
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -124,7 +125,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-2-gib-memory "minimum 2 GiB memory"
           - *default-10-gb-storage
@@ -157,7 +158,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -191,7 +192,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -225,7 +226,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-4-gib-memory "minimum 4 GiB memory"
           - *default-10-gb-storage
@@ -258,7 +259,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -292,7 +293,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -326,7 +327,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-8-gib-memory "minimum 8 GiB memory"
           - *default-10-gb-storage
@@ -359,7 +360,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -393,7 +394,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -427,7 +428,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -460,7 +461,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -493,7 +494,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -527,7 +528,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - &minimum-2-cores "minimum 2 cores"
           - &minimum-16-gib-memory "minimum 16 GiB memory"
           - *default-10-gb-storage
@@ -561,7 +562,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -595,7 +596,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -630,7 +631,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - &minimum-4-cores "minimum 4 cores"
           - &minimum-32-gib-memory "minimum 32 GiB memory"
           - *default-10-gb-storage
@@ -664,7 +665,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-32-gib-memory
           - *default-10-gb-storage
@@ -698,7 +699,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-32-gib-memory
           - *default-10-gb-storage
@@ -733,7 +734,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - &minimum-4-cores "minimum 4 graviton cores"
           - &minimum-16-gib-memory "minimum 16 GiB memory"
           - *default-10-gb-storage
@@ -767,7 +768,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -801,7 +802,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-postgresql-v15
+          - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -836,7 +837,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - &default-mysql-v8 "Default MySQL v8"
+          - &default-mysql-v8.4.8 "Default MySQL v8.4.8"
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -851,7 +852,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: &default-mysql-version "8.4.4"
+      dbVersion: &default-mysql-version "8.4.8"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -871,7 +872,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -906,7 +907,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -940,7 +941,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -974,7 +975,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -1009,7 +1010,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -1044,7 +1045,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1078,7 +1079,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1113,7 +1114,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1148,7 +1149,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1182,7 +1183,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1217,7 +1218,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1252,7 +1253,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1286,7 +1287,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1321,7 +1322,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1356,7 +1357,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -1390,7 +1391,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -1425,7 +1426,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8
+          - *default-mysql-v8.4.8
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -837,7 +837,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - &default-mysql-v8.4.8 "Default MySQL v8.4.8"
+          - &default-mysql-v8.4.9 "Default MySQL v8.4.9"
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -852,7 +852,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions:
         - "8.4"
-      dbVersion: &default-mysql-version "8.4.8"
+      dbVersion: &default-mysql-version "8.4.9"
       dbType: mysql
       plan_updateable: true
       redundant: false
@@ -872,7 +872,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -907,7 +907,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-1-gib-memory
           - *default-10-gb-storage
@@ -941,7 +941,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -975,7 +975,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -1010,7 +1010,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-2-gib-memory
           - *default-10-gb-storage
@@ -1045,7 +1045,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1079,7 +1079,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1114,7 +1114,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-4-gib-memory
           - *default-10-gb-storage
@@ -1149,7 +1149,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1183,7 +1183,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1218,7 +1218,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1253,7 +1253,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1287,7 +1287,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1322,7 +1322,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-1-core
           - *minimum-8-gib-memory
           - *default-10-gb-storage
@@ -1357,7 +1357,7 @@ rds:
       metadata:
         bullets:
           - *single-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -1391,7 +1391,7 @@ rds:
       metadata:
         bullets:
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage
@@ -1426,7 +1426,7 @@ rds:
         bullets:
           - *read-replica
           - *multi-az-rds
-          - *default-mysql-v8.4.8
+          - *default-mysql-v8.4.9
           - *minimum-2-cores
           - *minimum-16-gib-memory
           - *default-10-gb-storage

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -282,7 +282,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.small
       dbType: mysql
-      dbVersion: "8.4.8"
+      dbVersion: "8.4.9"
       allocatedStorage: 20
       approvedMajorVersions: &rds-mysql-approved-major-versions
         - "8.4"
@@ -311,7 +311,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.medium
       dbType: mysql
-      dbVersion: "8.4.8"
+      dbVersion: "8.4.9"
       allocatedStorage: 20
       approvedMajorVersions: *rds-mysql-approved-major-versions
       plan_updateable: true

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -190,10 +190,11 @@ rds:
       instanceClass: db.t3.micro
       allocatedStorage: 20
       approvedMajorVersions: &rds-postgres-approved-major-versions
-        - "14"
         - "15"
         - "16"
-      dbVersion: "16"
+        - "17"
+        - "18"
+      dbVersion: "18.3"
       dbType: postgres
       plan_updateable: true
       redundant: false
@@ -224,7 +225,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions: *rds-postgres-approved-major-versions
       dbType: postgres
-      dbVersion: "16"
+      dbVersion: "18.3"
       plan_updateable: true
       redundant: false
       encrypted: true
@@ -254,7 +255,7 @@ rds:
       allocatedStorage: 20
       approvedMajorVersions: *rds-postgres-approved-major-versions
       dbType: postgres
-      dbVersion: "16"
+      dbVersion: "18.3"
       redundant: true
       encrypted: true
       storage_type: gp3
@@ -281,7 +282,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.small
       dbType: mysql
-      dbVersion: "8.4"
+      dbVersion: "8.4.8"
       allocatedStorage: 20
       approvedMajorVersions: &rds-mysql-approved-major-versions
         - "8.4"
@@ -310,7 +311,7 @@ rds:
       adapter: dedicated
       instanceClass: db.t3.medium
       dbType: mysql
-      dbVersion: "8.4"
+      dbVersion: "8.4.8"
       allocatedStorage: 20
       approvedMajorVersions: *rds-mysql-approved-major-versions
       plan_updateable: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1774,7 +1774,7 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4.9"
+                DB_VERSION: "8.4.4"
 
             - task: smoke-tests-mysql-update-small-to-medium
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -443,7 +443,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                DB_VERSION: 18.3
+                DB_VERSION: 17.3
 
             - task: smoke-tests-postgres-update-storage
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -526,7 +526,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4.9"
+                DB_VERSION: "8.4.4"
 
             - task: smoke-tests-mysql-update-storage
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -443,7 +443,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                DB_VERSION: 15
+                DB_VERSION: 18.3
 
             - task: smoke-tests-postgres-update-storage
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -526,7 +526,7 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4"
+                DB_VERSION: "8.4.9"
 
             - task: smoke-tests-mysql-update-storage
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -636,8 +636,8 @@ jobs:
                 CF_SPACE: ((development-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                OLD_VERSION: 14
-                NEW_VERSION: 16
+                OLD_VERSION: 15.1
+                NEW_VERSION: 18.3
                 ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-rotate-creds-replica
@@ -1081,7 +1081,7 @@ jobs:
                 CF_SPACE: ((staging-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4"
+                DB_VERSION: "8.4.9"
 
             - task: smoke-tests-mysql-update-small-to-medium
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -1135,8 +1135,8 @@ jobs:
                 CF_SPACE: ((staging-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                OLD_VERSION: 14
-                NEW_VERSION: 16
+                OLD_VERSION: 15.1
+                NEW_VERSION: 18.3
                 ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-replica
@@ -1774,7 +1774,7 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4"
+                DB_VERSION: "8.4.9"
 
             - task: smoke-tests-mysql-update-small-to-medium
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml
@@ -1927,8 +1927,8 @@ jobs:
                 CF_SPACE: ((prod-tests-cf-space))
                 SERVICE_PLAN: micro-psql
                 DB_TYPE: postgres
-                OLD_VERSION: 14
-                NEW_VERSION: 16
+                OLD_VERSION: 15.1
+                NEW_VERSION: 18.3
                 ALLOW_MAJOR_VERSION_UPGRADE: true
 
             - task: smoke-tests-postgres-replica

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1081,7 +1081,7 @@ jobs:
                 CF_SPACE: ((staging-tests-cf-space))
                 SERVICE_PLAN: small-mysql
                 DB_TYPE: mysql
-                DB_VERSION: "8.4.9"
+                DB_VERSION: "8.4.4"
 
             - task: smoke-tests-mysql-update-small-to-medium
               file: aws-broker-app/ci/run-smoke-tests-db-updates.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

-Just updating the broker to support pSQL version 15-18 with 18.3 being the new default version. Support for pSQL version 14 for new RDS instances was dropped from the broker. Also updating the broker to change the default MySQL version to 8.4.8.
-Updated the catalog test to reflect these changes.
-

## Things to check
- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None, just updating the catalog and catalog test.
