### PR TITLE
Reconcile allocated storage on instance

### DIFF
--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -352,6 +352,11 @@ func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance
 		reconciledInstance.DbVersion = *dbInstanceState.EngineVersion
 	}
 
+	// reconcile storage with actual instance storage, if necessary
+	if reconciledInstance.AllocatedStorage != int64(*dbInstanceState.AllocatedStorage) {
+		reconciledInstance.AllocatedStorage = int64(*dbInstanceState.AllocatedStorage)
+	}
+
 	return &reconciledInstance, nil
 }
 

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -681,7 +681,8 @@ func TestReconcileDbState(t *testing.T) {
 						{
 							DBInstances: []rdsTypes.DBInstance{
 								{
-									EngineVersion: aws.String("15.14"),
+									EngineVersion:    aws.String("15.14"),
+									AllocatedStorage: aws.Int32(30),
 								},
 							},
 						},
@@ -690,10 +691,12 @@ func TestReconcileDbState(t *testing.T) {
 				&mockParameterGroupClient{},
 			),
 			dbInstance: RDSInstance{
-				DbVersion: "15",
+				DbVersion:        "15",
+				AllocatedStorage: 20,
 			},
 			expectedInstance: &RDSInstance{
-				DbVersion: "15.14",
+				DbVersion:        "15.14",
+				AllocatedStorage: 30,
 			},
 		},
 		"error describing database": {


### PR DESCRIPTION
## Changes proposed in this pull request:

- reconcile allocated storage on instance with actual value from RDS, if necessary
- update test for new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None