### PR TITLE
Add missing flag for tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -682,6 +682,7 @@ jobs:
                 NEW_VERSION: 8.4.9
                 ENABLE_CLOUDWATCH_LOG_GROUP_EXPORTS_ON_CREATE: '["general"]'
                 DB_TYPE: mysql
+                ALLOW_MAJOR_VERSION_UPGRADE: true
     on_failure:
       put: slack
       params:
@@ -1223,6 +1224,7 @@ jobs:
                 NEW_VERSION: 8.4.9
                 ENABLE_CLOUDWATCH_LOG_GROUP_EXPORTS_ON_CREATE: '["general"]'
                 DB_TYPE: mysql
+                ALLOW_MAJOR_VERSION_UPGRADE: true
     on_failure:
       put: slack
       params:
@@ -2028,6 +2030,7 @@ jobs:
                 NEW_VERSION: 8.4.9
                 ENABLE_CLOUDWATCH_LOG_GROUP_EXPORTS_ON_CREATE: '["general"]'
                 DB_TYPE: mysql
+                ALLOW_MAJOR_VERSION_UPGRADE: true
     on_failure:
       put: slack
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- add ALLOW_MAJOR_VERSION_UPGRADE: true flag for CI acceptance tests upgrading major version of database with custom parameter group

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
