### PR TITLE
Reconcile DB parameter group and values

### DIFF
--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -66,7 +66,7 @@ func (m *mockParameterGroupClient) IsCustomParameterGroup(parameterGroupName str
 	return m.isCustomParameterGroup
 }
 
-func (m *mockParameterGroupClient) ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error) {
+func (m *mockParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error) {
 	return nil, nil
 }
 

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -66,6 +66,10 @@ func (m *mockParameterGroupClient) IsCustomParameterGroup(parameterGroupName str
 	return m.isCustomParameterGroup
 }
 
+func (m *mockParameterGroupClient) ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error) {
+	return nil, nil
+}
+
 type mockCredentialUtils struct {
 	mockSalt              string
 	mockEncryptedPassword string

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -36,6 +36,7 @@ type mockParameterGroupClient struct {
 	provisionOrModifyParamGroupErr error
 	deleteParameterGroupErr        error
 	isCustomParameterGroup         bool
+	reconciledInstance             *RDSInstance
 }
 
 func (m *mockParameterGroupClient) ProvisionNewCustomParameterGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error {
@@ -67,7 +68,10 @@ func (m *mockParameterGroupClient) IsCustomParameterGroup(parameterGroupName str
 }
 
 func (m *mockParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error) {
-	return nil, nil
+	if m.reconciledInstance != nil {
+		return m.reconciledInstance, nil
+	}
+	return &i, nil
 }
 
 type mockCredentialUtils struct {

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -725,7 +725,7 @@ func (p *awsParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceS
 
 	dbParameters, ok := existingParameters[reconciledInstance.DbType]
 	if !ok {
-		return &i, nil
+		return &reconciledInstance, nil
 	}
 
 	addReconciledCloudwatchLogGroupExport := func(instance RDSInstance, enabledLogGroupName string) RDSInstance {

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -712,9 +712,11 @@ func (p *awsParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceS
 
 	reconciledInstance := i
 	parameterGroupName := *dbInstanceState.DBParameterGroups[0].DBParameterGroupName
-	if p.IsCustomParameterGroup(parameterGroupName) {
-		reconciledInstance.ParameterGroupName = parameterGroupName
+	if !p.IsCustomParameterGroup(parameterGroupName) {
+		return &reconciledInstance, nil
 	}
+
+	reconciledInstance.ParameterGroupName = parameterGroupName
 
 	existingParameters, err := p.getExistingParameters(&reconciledInstance)
 	if err != nil {
@@ -730,7 +732,9 @@ func (p *awsParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceS
 		if instance.EnabledCloudwatchLogGroupExports == nil {
 			instance.EnabledCloudwatchLogGroupExports = make(pq.StringArray, 0)
 		}
-		instance.EnabledCloudwatchLogGroupExports = append(instance.EnabledCloudwatchLogGroupExports, enabledLogGroupName)
+
+		idx, _ := slices.BinarySearch(instance.EnabledCloudwatchLogGroupExports, enabledLogGroupName)
+		instance.EnabledCloudwatchLogGroupExports = slices.Insert(instance.EnabledCloudwatchLogGroupExports, idx, enabledLogGroupName)
 		return instance
 	}
 

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -29,7 +29,7 @@ type parameterGroupClient interface {
 	CleanupCustomParameterGroups() error
 	DeleteParameterGroup(parameterGroupName string) error
 	IsCustomParameterGroup(parameterGroupName string) bool
-	ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error)
+	ReconcileRDSInstanceParameterGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error)
 }
 
 // awsParameterGroupClient provides abstractions for calls to the AWS RDS API for parameter groups
@@ -705,13 +705,26 @@ func removeLibraryFromSharedPreloadLibraries(
 	return customSharePreloadLibrariesParam
 }
 
-func (p *awsParameterGroupClient) ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error) {
-	dbParameters, ok := parameters[i.DbType]
-	if !ok {
+func (p *awsParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error) {
+	if len(dbInstanceState.DBParameterGroups) == 0 {
 		return &i, nil
 	}
 
 	reconciledInstance := i
+	parameterGroupName := *dbInstanceState.DBParameterGroups[0].DBParameterGroupName
+	if p.IsCustomParameterGroup(parameterGroupName) {
+		reconciledInstance.ParameterGroupName = parameterGroupName
+	}
+
+	existingParameters, err := p.getExistingParameters(&reconciledInstance)
+	if err != nil {
+		return &reconciledInstance, nil
+	}
+
+	dbParameters, ok := existingParameters[reconciledInstance.DbType]
+	if !ok {
+		return &i, nil
+	}
 
 	addReconciledCloudwatchLogGroupExport := func(instance RDSInstance, enabledLogGroupName string) RDSInstance {
 		if instance.EnabledCloudwatchLogGroupExports == nil {

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/lib/pq"
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
@@ -28,6 +29,7 @@ type parameterGroupClient interface {
 	CleanupCustomParameterGroups() error
 	DeleteParameterGroup(parameterGroupName string) error
 	IsCustomParameterGroup(parameterGroupName string) bool
+	ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error)
 }
 
 // awsParameterGroupClient provides abstractions for calls to the AWS RDS API for parameter groups
@@ -701,4 +703,105 @@ func removeLibraryFromSharedPreloadLibraries(
 	customSharePreloadLibrariesParam := strings.Join(libraries, ",")
 	log.Printf("generated custom %s param: %s", sharedPreloadLibrariesParameterName, customSharePreloadLibrariesParam)
 	return customSharePreloadLibrariesParam
+}
+
+func (p *awsParameterGroupClient) ReconcileRDSInstanceParameters(parameters map[string]map[string]paramDetails, i RDSInstance) (*RDSInstance, error) {
+	dbParameters, ok := parameters[i.DbType]
+	if !ok {
+		return &i, nil
+	}
+
+	reconciledInstance := i
+
+	addReconciledCloudwatchLogGroupExport := func(instance RDSInstance, enabledLogGroupName string) RDSInstance {
+		if instance.EnabledCloudwatchLogGroupExports == nil {
+			instance.EnabledCloudwatchLogGroupExports = make(pq.StringArray, 0)
+		}
+		instance.EnabledCloudwatchLogGroupExports = append(instance.EnabledCloudwatchLogGroupExports, enabledLogGroupName)
+		return instance
+	}
+
+	initPgQueryLogging := func(instance RDSInstance) RDSInstance {
+		if instance.PgQueryLogging == nil {
+			instance.PgQueryLogging = &PgQueryLoggingOptions{}
+		}
+		return instance
+	}
+
+	for key, paramDetails := range dbParameters {
+		if key == "log_bin_trust_function_creators" {
+			reconciledInstance.EnableFunctions = (paramDetails.value == "1")
+		}
+		if key == "binlog_format" {
+			reconciledInstance.BinaryLogFormat = paramDetails.value
+		}
+		if key == "general_log" && paramDetails.value == "1" {
+			reconciledInstance = addReconciledCloudwatchLogGroupExport(reconciledInstance, "general")
+		}
+		if key == "slow_query_log" && paramDetails.value == "1" {
+			reconciledInstance = addReconciledCloudwatchLogGroupExport(reconciledInstance, "slowquery")
+		}
+		if key == "long_query_time" {
+			longQueryTime, err := strconv.ParseFloat(paramDetails.value, 64)
+			if err != nil {
+				return &reconciledInstance, err
+			}
+			reconciledInstance.LongQueryTime = &longQueryTime
+		}
+		if key == sharedPreloadLibrariesParameterName {
+			if strings.Contains(paramDetails.value, pgCronLibraryName) {
+				reconciledInstance.EnablePgCron = aws.Bool(true)
+			}
+		}
+		if key == "log_connections" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogConnections = &paramDetails.value
+		}
+		if key == "log_disconnections" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogDisconnections = aws.Bool(paramDetails.value == "1")
+		}
+		if key == "log_checkpoints" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogCheckpoints = aws.Bool(paramDetails.value == "1")
+		}
+		if key == "log_lock_waits" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogLockWaits = aws.Bool(paramDetails.value == "1")
+		}
+		if key == "log_min_duration_sample" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			logMinDurationSample, err := strconv.Atoi(paramDetails.value)
+			if err != nil {
+				return &reconciledInstance, err
+			}
+			reconciledInstance.PgQueryLogging.LogMinDurationSample = aws.Int64(int64(logMinDurationSample))
+		}
+		if key == "log_min_duration_statement" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			logMinDurationStatement, err := strconv.Atoi(paramDetails.value)
+			if err != nil {
+				return &reconciledInstance, err
+			}
+			reconciledInstance.PgQueryLogging.LogMinDurationStatement = aws.Int64(int64(logMinDurationStatement))
+		}
+		if key == "log_statement" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogStatement = &paramDetails.value
+		}
+		if key == "log_statement_sample_rate" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			logStatementSampleRate, err := strconv.ParseFloat(paramDetails.value, 64)
+			if err != nil {
+				return &reconciledInstance, err
+			}
+			reconciledInstance.PgQueryLogging.LogStatementSampleRate = aws.Float64(logStatementSampleRate)
+		}
+		if key == "log_statement_stats" {
+			reconciledInstance = initPgQueryLogging(reconciledInstance)
+			reconciledInstance.PgQueryLogging.LogStatementStats = aws.Bool(paramDetails.value == "1")
+		}
+	}
+
+	return &reconciledInstance, nil
 }

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -2256,6 +2256,35 @@ func TestIsCustomParameterGroup(t *testing.T) {
 }
 
 func TestReconcileRDSInstanceParameters(t *testing.T) {
+	t.Run("ignore non-custom parameter group", func(t *testing.T) {
+		parameterGroupClient := &awsParameterGroupClient{
+			parameterGroupPrefix: "prefix-",
+		}
+		dbInstanceState := &rdsTypes.DBInstance{
+			DBParameterGroups: []rdsTypes.DBParameterGroupStatus{
+				{
+					DBParameterGroupName: aws.String("not-custom-group"),
+				},
+			},
+		}
+		i := RDSInstance{
+			DbType: "mysql",
+		}
+		expectedInstance := &RDSInstance{
+			DbType: "mysql",
+		}
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, i)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if diff := deep.Equal(i, expectedInstance); diff == nil {
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameterGroup should not have been mutated")
+		}
+		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
+			t.Error(diff)
+		}
+	})
+
 	t.Run("reconcile MySQL parameters", func(t *testing.T) {
 		parameterGroupClient := &awsParameterGroupClient{
 			parameterGroupPrefix: "prefix-",

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/go-test/deep"
+	"github.com/lib/pq"
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
@@ -2249,6 +2251,151 @@ func TestIsCustomParameterGroup(t *testing.T) {
 		}
 		if parameterGroupClient.IsCustomParameterGroup("1234") != false {
 			t.Fatal("IsCustomParameterGroup should return false")
+		}
+	})
+}
+
+func TestReconcileRDSInstanceParameters(t *testing.T) {
+	t.Run("reconcile MySQL parameters", func(t *testing.T) {
+		parameterGroupClient := &awsParameterGroupClient{
+			parameterGroupPrefix: "prefix-",
+		}
+		parameters := map[string]map[string]paramDetails{
+			"mysql": {
+				"log_bin_trust_function_creators": paramDetails{
+					value: "1",
+				},
+				"binlog_format": paramDetails{
+					value: "format",
+				},
+				"general_log": paramDetails{
+					value: "1",
+				},
+				"slow_query_log": paramDetails{
+					value: "1",
+				},
+				"long_query_time": paramDetails{
+					value: "0.5",
+				},
+			},
+		}
+		i := RDSInstance{
+			DbType: "mysql",
+		}
+		expectedInstance := &RDSInstance{
+			DbType:                           "mysql",
+			EnableFunctions:                  true,
+			BinaryLogFormat:                  "format",
+			EnabledCloudwatchLogGroupExports: pq.StringArray{"general", "slowquery"},
+			LongQueryTime:                    aws.Float64(0.5),
+		}
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if diff := deep.Equal(i, expectedInstance); diff == nil {
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+		}
+		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("reconcile MySQL general log group", func(t *testing.T) {
+		parameterGroupClient := &awsParameterGroupClient{
+			parameterGroupPrefix: "prefix-",
+		}
+		parameters := map[string]map[string]paramDetails{
+			"mysql": {
+				"general_log": paramDetails{
+					value: "1",
+				},
+			},
+		}
+		i := RDSInstance{
+			DbType: "mysql",
+		}
+		expectedInstance := &RDSInstance{
+			DbType:                           "mysql",
+			EnabledCloudwatchLogGroupExports: pq.StringArray{"general"},
+		}
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if diff := deep.Equal(i, expectedInstance); diff == nil {
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+		}
+		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("reconcile PostgreSQL parameters", func(t *testing.T) {
+		parameterGroupClient := &awsParameterGroupClient{
+			parameterGroupPrefix: "prefix-",
+		}
+		parameters := map[string]map[string]paramDetails{
+			"postgres": {
+				"shared_preload_libraries": paramDetails{
+					value: "foobar,pg_cron",
+				},
+				"log_connections": paramDetails{
+					value: "1",
+				},
+				"log_disconnections": paramDetails{
+					value: "1",
+				},
+				"log_min_duration_sample": paramDetails{
+					value: "500",
+				},
+				"log_min_duration_statement": paramDetails{
+					value: "700",
+				},
+				"log_checkpoints": paramDetails{
+					value: "1",
+				},
+				"log_lock_waits": paramDetails{
+					value: "1",
+				},
+				"log_statement": paramDetails{
+					value: "ddl",
+				},
+				"log_statement_sample_rate": paramDetails{
+					value: "0.7",
+				},
+				"log_statement_stats": paramDetails{
+					value: "1",
+				},
+			},
+		}
+		i := RDSInstance{
+			DbType: "postgres",
+		}
+		expectedInstance := &RDSInstance{
+			DbType:       "postgres",
+			EnablePgCron: aws.Bool(true),
+			PgQueryLogging: &PgQueryLoggingOptions{
+				LogConnections:          aws.String("1"),
+				LogDisconnections:       aws.Bool(true),
+				LogMinDurationSample:    aws.Int64(500),
+				LogMinDurationStatement: aws.Int64(700),
+				LogCheckpoints:          aws.Bool(true),
+				LogLockWaits:            aws.Bool(true),
+				LogStatement:            aws.String("ddl"),
+				LogStatementSampleRate:  aws.Float64(0.7),
+				LogStatementStats:       aws.Bool(true),
+			},
+		}
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if diff := deep.Equal(i, expectedInstance); diff == nil {
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+		}
+		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
+			t.Error(diff)
 		}
 	})
 }

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -2259,23 +2259,39 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 	t.Run("reconcile MySQL parameters", func(t *testing.T) {
 		parameterGroupClient := &awsParameterGroupClient{
 			parameterGroupPrefix: "prefix-",
+			rds: &mockRDSClient{
+				describeDbParamsResults: []*rds.DescribeDBParametersOutput{
+					{
+						Parameters: []rdsTypes.Parameter{
+							{
+								ParameterName:  aws.String("log_bin_trust_function_creators"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("binlog_format"),
+								ParameterValue: aws.String("format"),
+							},
+							{
+								ParameterName:  aws.String("general_log"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("slow_query_log"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("long_query_time"),
+								ParameterValue: aws.String("0.5"),
+							},
+						},
+					},
+				},
+			},
 		}
-		parameters := map[string]map[string]paramDetails{
-			"mysql": {
-				"log_bin_trust_function_creators": paramDetails{
-					value: "1",
-				},
-				"binlog_format": paramDetails{
-					value: "format",
-				},
-				"general_log": paramDetails{
-					value: "1",
-				},
-				"slow_query_log": paramDetails{
-					value: "1",
-				},
-				"long_query_time": paramDetails{
-					value: "0.5",
+		dbInstanceState := &rdsTypes.DBInstance{
+			DBParameterGroups: []rdsTypes.DBParameterGroupStatus{
+				{
+					DBParameterGroupName: aws.String("prefix-group1"),
 				},
 			},
 		}
@@ -2284,17 +2300,18 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 		}
 		expectedInstance := &RDSInstance{
 			DbType:                           "mysql",
+			ParameterGroupName:               "prefix-group1",
 			EnableFunctions:                  true,
 			BinaryLogFormat:                  "format",
 			EnabledCloudwatchLogGroupExports: pq.StringArray{"general", "slowquery"},
 			LongQueryTime:                    aws.Float64(0.5),
 		}
-		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, i)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
 		if diff := deep.Equal(i, expectedInstance); diff == nil {
-			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameterGroup should not have been mutated")
 		}
 		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
 			t.Error(diff)
@@ -2304,11 +2321,23 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 	t.Run("reconcile MySQL general log group", func(t *testing.T) {
 		parameterGroupClient := &awsParameterGroupClient{
 			parameterGroupPrefix: "prefix-",
+			rds: &mockRDSClient{
+				describeDbParamsResults: []*rds.DescribeDBParametersOutput{
+					{
+						Parameters: []rdsTypes.Parameter{
+							{
+								ParameterName:  aws.String("general_log"),
+								ParameterValue: aws.String("1"),
+							},
+						},
+					},
+				},
+			},
 		}
-		parameters := map[string]map[string]paramDetails{
-			"mysql": {
-				"general_log": paramDetails{
-					value: "1",
+		dbInstanceState := &rdsTypes.DBInstance{
+			DBParameterGroups: []rdsTypes.DBParameterGroupStatus{
+				{
+					DBParameterGroupName: aws.String("prefix-group1"),
 				},
 			},
 		}
@@ -2317,14 +2346,15 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 		}
 		expectedInstance := &RDSInstance{
 			DbType:                           "mysql",
+			ParameterGroupName:               "prefix-group1",
 			EnabledCloudwatchLogGroupExports: pq.StringArray{"general"},
 		}
-		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, i)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
 		if diff := deep.Equal(i, expectedInstance); diff == nil {
-			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameterGroup should not have been mutated")
 		}
 		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
 			t.Error(diff)
@@ -2334,38 +2364,59 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 	t.Run("reconcile PostgreSQL parameters", func(t *testing.T) {
 		parameterGroupClient := &awsParameterGroupClient{
 			parameterGroupPrefix: "prefix-",
+			rds: &mockRDSClient{
+				describeDbParamsResults: []*rds.DescribeDBParametersOutput{
+					{
+						Parameters: []rdsTypes.Parameter{
+							{
+								ParameterName:  aws.String("shared_preload_libraries"),
+								ParameterValue: aws.String("foobar,pg_cron"),
+							},
+							{
+								ParameterName:  aws.String("log_connections"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("log_disconnections"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("log_min_duration_sample"),
+								ParameterValue: aws.String("500"),
+							},
+							{
+								ParameterName:  aws.String("log_min_duration_statement"),
+								ParameterValue: aws.String("700"),
+							},
+							{
+								ParameterName:  aws.String("log_checkpoints"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("log_lock_waits"),
+								ParameterValue: aws.String("1"),
+							},
+							{
+								ParameterName:  aws.String("log_statement"),
+								ParameterValue: aws.String("ddl"),
+							},
+							{
+								ParameterName:  aws.String("log_statement_sample_rate"),
+								ParameterValue: aws.String("0.7"),
+							},
+							{
+								ParameterName:  aws.String("log_statement_stats"),
+								ParameterValue: aws.String("1"),
+							},
+						},
+					},
+				},
+			},
 		}
-		parameters := map[string]map[string]paramDetails{
-			"postgres": {
-				"shared_preload_libraries": paramDetails{
-					value: "foobar,pg_cron",
-				},
-				"log_connections": paramDetails{
-					value: "1",
-				},
-				"log_disconnections": paramDetails{
-					value: "1",
-				},
-				"log_min_duration_sample": paramDetails{
-					value: "500",
-				},
-				"log_min_duration_statement": paramDetails{
-					value: "700",
-				},
-				"log_checkpoints": paramDetails{
-					value: "1",
-				},
-				"log_lock_waits": paramDetails{
-					value: "1",
-				},
-				"log_statement": paramDetails{
-					value: "ddl",
-				},
-				"log_statement_sample_rate": paramDetails{
-					value: "0.7",
-				},
-				"log_statement_stats": paramDetails{
-					value: "1",
+		dbInstanceState := &rdsTypes.DBInstance{
+			DBParameterGroups: []rdsTypes.DBParameterGroupStatus{
+				{
+					DBParameterGroupName: aws.String("prefix-group1"),
 				},
 			},
 		}
@@ -2373,8 +2424,9 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 			DbType: "postgres",
 		}
 		expectedInstance := &RDSInstance{
-			DbType:       "postgres",
-			EnablePgCron: aws.Bool(true),
+			DbType:             "postgres",
+			EnablePgCron:       aws.Bool(true),
+			ParameterGroupName: "prefix-group1",
 			PgQueryLogging: &PgQueryLoggingOptions{
 				LogConnections:          aws.String("1"),
 				LogDisconnections:       aws.Bool(true),
@@ -2387,12 +2439,12 @@ func TestReconcileRDSInstanceParameters(t *testing.T) {
 				LogStatementStats:       aws.Bool(true),
 			},
 		}
-		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameters(parameters, i)
+		reconciledInstance, err := parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, i)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
 		if diff := deep.Equal(i, expectedInstance); diff == nil {
-			t.Error("RDSInstance argument to ReconcileRDSInstanceParameters should not have been mutated")
+			t.Error("RDSInstance argument to ReconcileRDSInstanceParameterGroup should not have been mutated")
 		}
 		if diff := deep.Equal(reconciledInstance, expectedInstance); diff != nil {
 			t.Error(diff)

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -357,6 +357,7 @@ func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance
 		parameterGroupName := *dbInstanceState.DBParameterGroups[0].DBParameterGroupName
 		if d.parameterGroupClient.IsCustomParameterGroup(parameterGroupName) {
 			reconciledInstance.ParameterGroupName = parameterGroupName
+			// reconciledInstance = d.parameterGroupClient.ReconcileRDSInstanceParameters()
 		}
 	}
 

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -353,12 +353,10 @@ func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance
 	}
 
 	// Capture any parameter groups created manually
-	if len(dbInstanceState.DBParameterGroups) > 0 {
-		parameterGroupName := *dbInstanceState.DBParameterGroups[0].DBParameterGroupName
-		if d.parameterGroupClient.IsCustomParameterGroup(parameterGroupName) {
-			reconciledInstance.ParameterGroupName = parameterGroupName
-			// reconciledInstance = d.parameterGroupClient.ReconcileRDSInstanceParameters()
-		}
+	reconciledInstanceWithParameters, err := d.parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, reconciledInstance)
+	reconciledInstance = *reconciledInstanceWithParameters
+	if err != nil {
+		return &reconciledInstance, err
 	}
 
 	// reconcile storage with actual instance storage, if necessary

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -722,6 +722,10 @@ func TestReconcileDbState(t *testing.T) {
 				},
 				&mockParameterGroupClient{
 					isCustomParameterGroup: true,
+					reconciledInstance: &RDSInstance{
+						DbVersion:          "15",
+						ParameterGroupName: "custom-group",
+					},
 				},
 			),
 			dbInstance: RDSInstance{
@@ -730,36 +734,6 @@ func TestReconcileDbState(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				DbVersion:          "15",
 				ParameterGroupName: "custom-group",
-			},
-		},
-		"ignore not custom parameter group": {
-			ctx: t.Context(),
-			dbAdapter: NewTestDedicatedDBAdapter(
-				t.Context(),
-				brokerDB,
-				&config.Settings{},
-				&mockRDSClient{
-					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
-						{
-							DBInstances: []rdsTypes.DBInstance{
-								{
-									DBParameterGroups: []rdsTypes.DBParameterGroupStatus{
-										{
-											DBParameterGroupName: aws.String("not-custom-group"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				&mockParameterGroupClient{},
-			),
-			dbInstance: RDSInstance{
-				DbVersion: "15",
-			},
-			expectedInstance: &RDSInstance{
-				DbVersion: "15",
 			},
 		},
 		"error describing database": {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Reconcile DB parameter group and values when modifying database

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
