### PR TITLE
Add check for existing param group

### DIFF
--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -82,7 +82,8 @@ func (p *awsParameterGroupClient) ProvisionNewCustomParameterGroup(i *RDSInstanc
 // create a new parameter group or modify an existing one with the correct parameters for the
 // instance
 func (p *awsParameterGroupClient) ProvisionOrModifyCustomParameterGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error) {
-	if !p.needCustomParameters(i) {
+	hasExistingCustomParameterGroup := i.ParameterGroupName != "" && p.IsCustomParameterGroup(i.ParameterGroupName)
+	if !p.needCustomParameters(i) && !hasExistingCustomParameterGroup {
 		return false, nil
 	}
 

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -1934,6 +1934,57 @@ func TestProvisionOrModifyCustomParameterGroup(t *testing.T) {
 			},
 			expectedPGroupName: "prefix-database1-version-18-3",
 		},
+		"create new parameter group: update database major version, current group exists, needCustomParameters() returned false": {
+			dbInstance: &RDSInstance{
+				DbType:                   "mysql",
+				Database:                 "database1",
+				ParameterGroupName:       "prefix-database1-version-8-0",
+				AllowMajorVersionUpgrade: true,
+				DbVersion:                "8.4",
+			},
+			parameterGroupAdapter: &awsParameterGroupClient{
+				parameterGroupPrefix: "prefix-",
+				rds: &mockRDSClient{
+					describeDbParamsErrs: []error{nil, nil, &rdsTypes.DBParameterGroupNotFoundFault{}},
+					describeDbParamsResults: []*rds.DescribeDBParametersOutput{
+						{
+							Parameters: []rdsTypes.Parameter{
+								{
+									ParameterName:  aws.String("random-param"),
+									ParameterValue: aws.String("random-value"),
+								},
+							},
+						},
+						{
+							Parameters: []rdsTypes.Parameter{
+								{
+									ParameterName:  aws.String("random-param"),
+									ParameterValue: aws.String("random-value"),
+									ApplyMethod:    rdsTypes.ApplyMethodImmediate,
+								},
+							},
+						},
+					},
+					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
+						{
+							DBInstances: []rdsTypes.DBInstance{
+								{
+									EngineVersion: aws.String("8.4"),
+								},
+							},
+						},
+					},
+					dbEngineVersions: []rdsTypes.DBEngineVersion{
+						{
+							DBParameterGroupFamily: aws.String("mysql8.4"),
+						},
+					},
+					describeDbParamsNumPages: 1,
+				},
+			},
+			expectedPGroupName:          "prefix-database1-version-8-4",
+			expectParameterGroupCreated: true,
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Changes proposed in this pull request:

- In `ProvisionOrModifyCustomParameterGroup`, check if there is an existing custom param group to allow flow to execute
- Added unit test for this case

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
