### PR TITLE
Migrate Option groups on RDS version upgrades

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,15 +79,16 @@ func run(ctx context.Context, out io.Writer) error {
 	// RDS workers
 	rdsClient := awsRds.NewFromConfig(cfg)
 	parameterGroupClient := rds.NewAwsParameterGroupClient(ctx, rdsClient, &settings, logger)
+	optionGroupClient := rds.NewAwsOptionGroupClient(ctx, rdsClient, &settings, logger)
 	credentialUtils := &rds.RDSCredentialUtils{}
 	river.AddWorker(workers, rds.NewCreateWorker(
-		db, &settings, rdsClient, logger, parameterGroupClient, credentialUtils,
+		db, &settings, rdsClient, logger, parameterGroupClient, optionGroupClient, credentialUtils,
 	))
 	river.AddWorker(workers, rds.NewModifyWorker(
-		db, &settings, rdsClient, logger, parameterGroupClient, credentialUtils,
+		db, &settings, rdsClient, logger, parameterGroupClient, optionGroupClient, credentialUtils,
 	))
 	river.AddWorker(workers, rds.NewDeleteWorker(
-		db, &settings, rdsClient, logger, parameterGroupClient, credentialUtils,
+		db, &settings, rdsClient, logger, parameterGroupClient, optionGroupClient, credentialUtils,
 	))
 
 	// ElastiCache workers

--- a/services/rds/create_worker.go
+++ b/services/rds/create_worker.go
@@ -37,6 +37,7 @@ type CreateWorker struct {
 	rds                  RDSClientInterface
 	logger               *slog.Logger
 	parameterGroupClient parameterGroupClient
+	optionGroupClient    optionGroupClient
 	credentialUtils      CredentialUtils
 }
 
@@ -46,6 +47,7 @@ func NewCreateWorker(
 	rds RDSClientInterface,
 	logger *slog.Logger,
 	parameterGroupClient parameterGroupClient,
+	optionGroupClient optionGroupClient,
 	credentialUtils CredentialUtils,
 ) *CreateWorker {
 	return &CreateWorker{
@@ -54,6 +56,7 @@ func NewCreateWorker(
 		rds:                  rds,
 		logger:               logger,
 		parameterGroupClient: parameterGroupClient,
+		optionGroupClient:    optionGroupClient,
 		credentialUtils:      credentialUtils,
 	}
 }

--- a/services/rds/create_worker_test.go
+++ b/services/rds/create_worker_test.go
@@ -82,6 +82,7 @@ func TestCreateWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -148,6 +149,7 @@ func TestCreateWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -169,6 +171,7 @@ func TestCreateWorkerWork(t *testing.T) {
 				&mockParameterGroupClient{
 					provisionOrModifyParamGroupErr: errors.New("failed"),
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -202,6 +205,7 @@ func TestCreateWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -235,6 +239,7 @@ func TestCreateWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -479,6 +484,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				&mockParameterGroupClient{
 					provisionNewParamGroupErr: errors.New("failed"),
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -512,6 +518,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -545,6 +552,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -595,6 +603,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -651,6 +660,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -703,6 +713,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -736,6 +747,7 @@ func TestAsyncCreateDb(t *testing.T) {
 				&mockRDSClient{},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockGetPassworrdErr: errors.New("error getting password"),
 				},
@@ -939,6 +951,7 @@ func TestWaitAndCreateDBReadReplica(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -978,6 +991,7 @@ func TestWaitAndCreateDBReadReplica(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -1018,6 +1032,7 @@ func TestWaitAndCreateDBReadReplica(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{},
@@ -1065,6 +1080,7 @@ func TestWaitAndCreateDBReadReplica(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{

--- a/services/rds/delete_worker.go
+++ b/services/rds/delete_worker.go
@@ -30,6 +30,7 @@ type DeleteWorker struct {
 	rds                  RDSClientInterface
 	logger               *slog.Logger
 	parameterGroupClient parameterGroupClient
+	optionGroupClient    optionGroupClient
 	credentialUtils      CredentialUtils
 }
 
@@ -39,6 +40,7 @@ func NewDeleteWorker(
 	rds RDSClientInterface,
 	logger *slog.Logger,
 	parameterGroupClient parameterGroupClient,
+	optionGroupClient optionGroupClient,
 	credentialUtils CredentialUtils,
 ) *DeleteWorker {
 	return &DeleteWorker{
@@ -47,6 +49,7 @@ func NewDeleteWorker(
 		rds:                  rds,
 		logger:               logger,
 		parameterGroupClient: parameterGroupClient,
+		optionGroupClient:    optionGroupClient,
 		credentialUtils:      credentialUtils,
 	}
 }
@@ -143,6 +146,22 @@ func (w *DeleteWorker) asyncDeleteDB(ctx context.Context, i *RDSInstance) error 
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to cleanup parameter groups: %s", err))
 		w.logger.Error("asyncDeleteDB: CleanupCustomParameterGroups error", "err", err)
 		return river.JobCancel(fmt.Errorf("asyncDeleteDB: error deleting parameter groups %w ", err))
+	}
+
+	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Deleting option group")
+	err = w.optionGroupClient.DeleteOptionGroup(i.OptionGroupName)
+	if err != nil {
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to delete option group: %s", err))
+		w.logger.Error("asyncDeleteDB: DeleteOptionGroup error", "err", err)
+		return river.JobCancel(fmt.Errorf("asyncDeleteDB: error deleting option group %w ", err))
+	}
+
+	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Cleaning up option groups")
+	err = w.optionGroupClient.CleanupCustomOptionGroups()
+	if err != nil {
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to cleanup option groups: %s", err))
+		w.logger.Error("asyncDeleteDB: CleanupCustomOptionGroups error", "err", err)
+		return river.JobCancel(fmt.Errorf("asyncDeleteDB: error deleting option groups %w ", err))
 	}
 
 	err = w.db.Unscoped().Delete(i).Error

--- a/services/rds/delete_worker.go
+++ b/services/rds/delete_worker.go
@@ -151,17 +151,16 @@ func (w *DeleteWorker) asyncDeleteDB(ctx context.Context, i *RDSInstance) error 
 	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Deleting option group")
 	err = w.optionGroupClient.DeleteOptionGroup(i.OptionGroupName)
 	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to delete option group: %s", err))
-		w.logger.Error("asyncDeleteDB: DeleteOptionGroup error", "err", err)
-		return river.JobCancel(fmt.Errorf("asyncDeleteDB: error deleting option group %w ", err))
+		// best effort deletion. Option group might still be attached to snapshots (preventing deletion), so leave it for later cleanup
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("asyncModifyDbInstance: deletion of old option group failed; leaving for later cleanup"))
+		w.logger.Warn("asyncDeleteDb: deletion of option group failed; leaving for later cleanup", "err", err)
 	}
 
 	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Cleaning up option groups")
 	err = w.optionGroupClient.CleanupCustomOptionGroups()
 	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to cleanup option groups: %s", err))
-		w.logger.Error("asyncDeleteDB: CleanupCustomOptionGroups error", "err", err)
-		return river.JobCancel(fmt.Errorf("asyncDeleteDB: error deleting option groups %w ", err))
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("Failed to cleanup option groups: %s", err))
+		w.logger.Warn("asyncDeleteDB: CleanupCustomOptionGroups error", "err", err)
 	}
 
 	err = w.db.Unscoped().Delete(i).Error

--- a/services/rds/delete_worker_test.go
+++ b/services/rds/delete_worker_test.go
@@ -63,6 +63,7 @@ func TestDeleteWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			expectedState: base.InstanceReady,
@@ -114,6 +115,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -140,6 +142,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -168,6 +171,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -196,6 +200,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -225,6 +230,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -253,6 +259,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -281,6 +288,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -307,6 +315,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -337,6 +346,7 @@ func TestAsyncDeleteDB(t *testing.T) {
 				&mockParameterGroupClient{
 					deleteParameterGroupErr: errors.New("error deleting parameter group"),
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -74,6 +74,53 @@ func (m *mockParameterGroupClient) ReconcileRDSInstanceParameterGroup(dbInstance
 	return &i, nil
 }
 
+type mockOptionGroupClient struct {
+	optionGroupName              string
+	provisionOrModifyCalled      bool
+	provisionOrModifyCreated     bool
+	provisionOrModifyOptGroupErr error
+	deleteOptionGroupErr         error
+	deletedOptionGroupName       string
+	isCustomOptionGroup          bool
+	isBrokerOptionGroup          bool
+	reconciledInstance           *RDSInstance
+}
+
+func (m *mockOptionGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error) {
+	m.provisionOrModifyCalled = true
+	if m.provisionOrModifyOptGroupErr != nil {
+		return false, m.provisionOrModifyOptGroupErr
+	}
+	if m.optionGroupName != "" {
+		i.OptionGroupName = m.optionGroupName
+	}
+	return m.provisionOrModifyCreated, nil
+}
+
+func (m *mockOptionGroupClient) CleanupCustomOptionGroups() error {
+	return nil
+}
+
+func (m *mockOptionGroupClient) DeleteOptionGroup(optionGroupName string) error {
+	m.deletedOptionGroupName = optionGroupName
+	return m.deleteOptionGroupErr
+}
+
+func (m *mockOptionGroupClient) IsCustomOptionGroup(optionGroupName string) bool {
+	return m.isCustomOptionGroup
+}
+
+func (m *mockOptionGroupClient) IsBrokerOptionGroup(optionGroupName string) bool {
+	return m.isBrokerOptionGroup
+}
+
+func (m *mockOptionGroupClient) ReconcileRDSInstanceOptionGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error) {
+	if m.reconciledInstance != nil {
+		return m.reconciledInstance, nil
+	}
+	return &i, nil
+}
+
 type mockCredentialUtils struct {
 	mockSalt              string
 	mockEncryptedPassword string
@@ -126,6 +173,53 @@ type mockRDSClient struct {
 	describeDBParameterGroupsCallNum    int
 	deleteDbParameterGroupErrs          []error
 	deleteDbParameterGroupCallNum       int
+	describeOptionGroupsResults         []*rds.DescribeOptionGroupsOutput
+	describeOptionGroupsErrs            []error
+	describeOptionGroupsCallNum         int
+	createOptionGroupInput              *rds.CreateOptionGroupInput
+	createOptionGroupErr                error
+	modifyOptionGroupInput              *rds.ModifyOptionGroupInput
+	modifyOptionGroupErr                error
+	deleteOptionGroupErrs               []error
+	deleteOptionGroupCallNum            int
+}
+
+func (m *mockRDSClient) CreateOptionGroup(ctx context.Context, params *rds.CreateOptionGroupInput, optFns ...func(*rds.Options)) (*rds.CreateOptionGroupOutput, error) {
+	m.createOptionGroupInput = params
+	if m.createOptionGroupErr != nil {
+		return nil, m.createOptionGroupErr
+	}
+	return nil, nil
+}
+
+func (m *mockRDSClient) ModifyOptionGroup(ctx context.Context, params *rds.ModifyOptionGroupInput, optFns ...func(*rds.Options)) (*rds.ModifyOptionGroupOutput, error) {
+	m.modifyOptionGroupInput = params
+	if m.modifyOptionGroupErr != nil {
+		return nil, m.modifyOptionGroupErr
+	}
+	return nil, nil
+}
+
+func (m *mockRDSClient) DeleteOptionGroup(ctx context.Context, params *rds.DeleteOptionGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteOptionGroupOutput, error) {
+	var err error
+	if len(m.deleteOptionGroupErrs) > m.deleteOptionGroupCallNum && m.deleteOptionGroupErrs[m.deleteOptionGroupCallNum] != nil {
+		err = m.deleteOptionGroupErrs[m.deleteOptionGroupCallNum]
+	}
+	m.deleteOptionGroupCallNum++
+	return nil, err
+}
+
+func (m *mockRDSClient) DescribeOptionGroups(ctx context.Context, params *rds.DescribeOptionGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeOptionGroupsOutput, error) {
+	var err error
+	if len(m.describeOptionGroupsErrs) > m.describeOptionGroupsCallNum && m.describeOptionGroupsErrs[m.describeOptionGroupsCallNum] != nil {
+		err = m.describeOptionGroupsErrs[m.describeOptionGroupsCallNum]
+	}
+	var result *rds.DescribeOptionGroupsOutput
+	if len(m.describeOptionGroupsResults) > m.describeOptionGroupsCallNum {
+		result = m.describeOptionGroupsResults[m.describeOptionGroupsCallNum]
+	}
+	m.describeOptionGroupsCallNum++
+	return result, err
 }
 
 func (m *mockRDSClient) AddTagsToResource(ctx context.Context, params *rds.AddTagsToResourceInput, optFns ...func(*rds.Options)) (*rds.AddTagsToResourceOutput, error) {

--- a/services/rds/modify_worker.go
+++ b/services/rds/modify_worker.go
@@ -35,6 +35,7 @@ type ModifyWorker struct {
 	rds                  RDSClientInterface
 	logger               *slog.Logger
 	parameterGroupClient parameterGroupClient
+	optionGroupClient    optionGroupClient
 	credentialUtils      CredentialUtils
 }
 
@@ -44,6 +45,7 @@ func NewModifyWorker(
 	rds RDSClientInterface,
 	logger *slog.Logger,
 	parameterGroupClient parameterGroupClient,
+	optionGroupClient optionGroupClient,
 	credentialUtils CredentialUtils,
 ) *ModifyWorker {
 	return &ModifyWorker{
@@ -52,6 +54,7 @@ func NewModifyWorker(
 		rds:                  rds,
 		logger:               logger,
 		parameterGroupClient: parameterGroupClient,
+		optionGroupClient:    optionGroupClient,
 		credentialUtils:      credentialUtils,
 	}
 }
@@ -100,6 +103,16 @@ func (w *ModifyWorker) prepareModifyDbInstanceInput(
 		params.DBParameterGroupName = &i.ParameterGroupName
 	}
 
+	// if the instance has a custom option group and there is a major version upgrade
+	// rebuild an equivalent group for new major version
+	_, err = w.optionGroupClient.ProvisionOrModifyCustomOptionGroup(i, rdsTags)
+	if err != nil {
+		return nil, err
+	}
+	if i.OptionGroupName != "" {
+		params.OptionGroupName = &i.OptionGroupName
+	}
+
 	if i.DbVersion != "" {
 		params.EngineVersion = aws.String(i.DbVersion)
 	}
@@ -126,6 +139,8 @@ func (w *ModifyWorker) prepareModifyDbInstanceInput(
 
 func (w *ModifyWorker) asyncModifyDbInstance(ctx context.Context, operation base.Operation, i *RDSInstance, plan *catalog.RDSPlan, database string, isReplica bool) error {
 	existingParameterGroupName := i.ParameterGroupName
+	existingOptionGroupName := i.OptionGroupName
+
 	modifyParams, err := w.prepareModifyDbInstanceInput(i, plan, database, isReplica)
 	if err != nil {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error preparing database modify parameters: %s", err))
@@ -164,6 +179,15 @@ func (w *ModifyWorker) asyncModifyDbInstance(ctx context.Context, operation base
 		if err != nil {
 			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting parameter group: %s", err))
 			return fmt.Errorf("asyncModifyDbInstance, error deleting parameter group: %w", err)
+		}
+	}
+
+	if existingOptionGroupName != "" && i.OptionGroupName != existingOptionGroupName {
+		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("Deleting old %s option group", databaseOperationTarget))
+		err = w.optionGroupClient.DeleteOptionGroup(existingOptionGroupName)
+		if err != nil {
+			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting option group: %s", err))
+			return fmt.Errorf("asyncModifyDb, error updating replica tags: %w", err)
 		}
 	}
 

--- a/services/rds/modify_worker.go
+++ b/services/rds/modify_worker.go
@@ -184,10 +184,11 @@ func (w *ModifyWorker) asyncModifyDbInstance(ctx context.Context, operation base
 
 	if existingOptionGroupName != "" && i.OptionGroupName != existingOptionGroupName {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("Deleting old %s option group", databaseOperationTarget))
+		// best effort deletion. Option group might still be attached to snapshots (preventing deletion), so leave it for later cleanup
 		err = w.optionGroupClient.DeleteOptionGroup(existingOptionGroupName)
 		if err != nil {
-			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotModified, fmt.Sprintf("Error deleting option group: %s", err))
-			return fmt.Errorf("asyncModifyDb, error updating replica tags: %w", err)
+			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, fmt.Sprintf("asyncModifyDbInstance: deletion of old option group failed; leaving for later cleanup"))
+			w.logger.Warn("asyncModifyDbInstance: deletion of old option group failed; leaving for later cleanup", "optionGroup", existingOptionGroupName, "err", err)
 		}
 	}
 

--- a/services/rds/modify_worker_test.go
+++ b/services/rds/modify_worker_test.go
@@ -82,6 +82,7 @@ func TestModifyWorkerWork(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			expectedState: base.InstanceReady,
@@ -133,6 +134,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				&mockParameterGroupClient{
 					provisionOrModifyParamGroupErr: errors.New("fail"),
 				},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -159,6 +161,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -185,6 +188,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -229,6 +233,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{},
@@ -296,6 +301,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -360,6 +366,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -413,6 +420,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -460,6 +468,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -516,6 +525,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			dbInstance: &RDSInstance{
@@ -561,6 +571,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				},
 				slog.New(&testutil.MockLogHandler{}),
 				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{},
@@ -630,6 +641,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				&mockParameterGroupClient{
 					customPgroupName: "new-group",
 				},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{},
@@ -676,6 +688,7 @@ func TestAsyncModifyDb(t *testing.T) {
 				&mockParameterGroupClient{
 					deleteParameterGroupErr: errors.New("failed to delete"),
 				},
+				&mockOptionGroupClient{},
 				&RDSCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{},
@@ -763,6 +776,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{
 					mockClearPassword: "fake-pw",
 				},
@@ -798,6 +812,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{
@@ -832,6 +847,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{
@@ -850,6 +866,46 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				EngineVersion:            aws.String("9.0"),
 			},
 		},
+		"sets option gruop for an instance with a custom option group": {
+			dbInstance: &RDSInstance{
+				DbType:                "mysql",
+				StorageType:           "gp3",
+				AllocatedStorage:      20,
+				Database:              "db-name",
+				BackupRetentionPeriod: 14,
+				DbVersion:             "8.4.9",
+				OptionGroupName:       "my-audit-group",
+			},
+			worker: NewModifyWorker(
+				brokerDB,
+				&config.Settings{},
+				&mockRDSClient{},
+				nil,
+				&mockParameterGroupClient{
+					rds: &mockRDSClient{},
+				},
+				&mockOptionGroupClient{
+					optionGroupName: "cg-aws-broker-db-name-option-8-4",
+				},
+				&mockCredentialUtils{},
+			),
+			plan: &catalog.RDSPlan{
+				InstanceClass: "class",
+				Redundant:     true,
+			},
+			expectedParams: &rds.ModifyDBInstanceInput{
+				AllocatedStorage:         aws.Int32(20),
+				ApplyImmediately:         aws.Bool(true),
+				DBInstanceClass:          aws.String("class"),
+				MultiAZ:                  aws.Bool(true),
+				DBInstanceIdentifier:     aws.String("db-name"),
+				AllowMajorVersionUpgrade: aws.Bool(false),
+				BackupRetentionPeriod:    aws.Int32(14),
+				StorageType:              aws.String("gp3"),
+				EngineVersion:            aws.String("8.4.9"),
+				OptionGroupName:          aws.String("cg-aws-broker-db-name-option-8-4"),
+			},
+		},
 		"does not update password for replica": {
 			dbInstance: &RDSInstance{
 				BinaryLogFormat:       "ROW",
@@ -866,6 +922,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{
@@ -899,6 +956,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{
@@ -936,6 +994,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 				&mockParameterGroupClient{
 					rds: &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{
@@ -973,6 +1032,7 @@ func TestPrepareModifyDbInstanceInput(t *testing.T) {
 					customPgroupName: "group1",
 					rds:              &mockRDSClient{},
 				},
+				&mockOptionGroupClient{},
 				&mockCredentialUtils{},
 			),
 			plan: &catalog.RDSPlan{

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -132,6 +132,9 @@ func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfig
 			if setting.Name == nil || setting.Value == nil {
 				continue
 			}
+			if setting.IsModifiable != nil && !*setting.IsModifiable {
+				continue
+			}
 			optionConfig.OptionSettings = append(optionConfig.OptionSettings, rdsTypes.OptionSetting{
 				Name:  setting.Name,
 				Value: setting.Value,

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -1,0 +1,301 @@
+package rds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/cloud-gov/aws-broker/config"
+)
+
+// Prefix for AWS managed default option groups
+const defaultOptionGroupPrefix = "default:"
+
+type optionGroupClient interface {
+	ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error)
+	CleanupCustomOptionGroups() error
+	DeleteOptionGroup(optionGroupName string) error
+	IsCustomOptionGroup(optionGroupName string) bool
+	IsBrokerOptionGroup(optionGroupName string) bool
+	ReconcileRDSInstanceOptionGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error)
+}
+
+type awsOptionsGroupClient struct {
+	ctx               context.Context
+	rds               RDSClientInterface
+	settings          *config.Settings
+	optionGroupPrefix string
+	logger            *slog.Logger
+}
+
+func NewAwsOptionGroupClient(ctx context.Context, rds RDSClientInterface, settings *config.Settings, logger *slog.Logger) *awsOptionsGroupClient {
+	return &awsOptionsGroupClient{
+		ctx:               ctx,
+		rds:               rds,
+		settings:          settings,
+		optionGroupPrefix: "cg-aws-broker-",
+		logger:            logger,
+	}
+}
+
+func (o *awsOptionsGroupClient) IsCustomOptionGroup(optionGroupName string) bool {
+	return optionGroupName != "" && !strings.HasPrefix(optionGroupName, defaultOptionGroupPrefix)
+}
+
+func (o *awsOptionsGroupClient) IsBrokerOptionGroup(optionGroupName string) bool {
+	return strings.HasPrefix(optionGroupName, o.optionGroupPrefix)
+}
+
+func (o *awsOptionsGroupClient) getOptionGroupName(i *RDSInstance, majorEngineVersion string) string {
+	return o.optionGroupPrefix + formatDBName(i.Database) + "-option-" + formatDBVersion(majorEngineVersion)
+}
+
+func (o *awsOptionsGroupClient) getMajorEngineVersion(i *RDSInstance) (string, error) {
+	if i.DbVersion == "" {
+		return "", errors.New("database version is required to determine major engine version")
+	}
+
+	dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{
+		Engine:        aws.String(i.DbType),
+		EngineVersion: aws.String(i.DbVersion),
+	}
+
+	defaultEngineInfo, err := o.rds.DescribeDBEngineVersions(o.ctx, dbEngineVersionsInput)
+	if err != nil {
+		return "", err
+	}
+	if len(defaultEngineInfo.DBEngineVersions) == 0 || defaultEngineInfo.DBEngineVersions[0].MajorEngineVersion == nil {
+		return "", fmt.Errorf("could not determine major engine version for $s, $s", i.DbType, i.DbVersion)
+	}
+
+	return *defaultEngineInfo.DBEngineVersions[0].MajorEngineVersion, nil
+}
+
+// Captures the instance's currently attached option group from live AWS state,
+// so the broker can recreate the group for the target version upon a major version upgrade.
+// Default groups are ignored
+func (o *awsOptionsGroupClient) ReconcileRDSInstanceOptionGroup(dbInstanceState *rdsTypes.DBInstance, i RDSInstance) (*RDSInstance, error) {
+	reconciledInstance := i
+
+	if len(*&dbInstanceState.OptionGroupMemberships) == 0 {
+		return &reconciledInstance, nil
+	}
+
+	optionGroupName := dbInstanceState.OptionGroupMemberships[0].OptionGroupName
+	if optionGroupName == nil || !o.IsCustomOptionGroup(*optionGroupName) {
+		return &reconciledInstance, nil
+	}
+
+	reconciledInstance.OptionGroupName = *optionGroupName
+	return &reconciledInstance, nil
+}
+
+// Returns the named option group
+func (o *awsOptionsGroupClient) describeOptionGroup(optionGroupName string) (*rdsTypes.OptionGroup, error) {
+	output, err := o.rds.DescribeOptionGroups(o.ctx, &rds.DescribeOptionGroupsInput{
+		OptionGroupName: aws.String(optionGroupName),
+	})
+	if err != nil {
+		var notFoundErr *rdsTypes.OptionGroupNotFoundFault
+		if errors.As(err, &notFoundErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("describeOptionGroup: error describing option group %s: %w", optionGroupName, err)
+	}
+	if len(output.OptionGroupsList) == 0 {
+		return nil, nil
+	}
+	return &output.OptionGroupsList[0], nil
+}
+
+// Converts the options configured on an existing option group into the configuration needed to
+// replicate them into a new group
+func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfiguration {
+	optionConfigs := []rdsTypes.OptionConfiguration{}
+	for _, option := range optionGroup.Options {
+		if option.OptionName == nil {
+			continue
+		}
+		optionConfig := rdsTypes.OptionConfiguration{
+			OptionName: option.OptionName,
+		}
+		// Coppy the setting name/value
+		for _, setting := range option.OptionSettings {
+			if setting.Name == nil || setting.Value == nil {
+				continue
+			}
+			optionConfig.OptionSettings = append(optionConfig.OptionSettings, rdsTypes.OptionSetting{
+				Name:  setting.Name,
+				Value: setting.Value,
+			})
+		}
+		optionConfigs = append(optionConfigs, optionConfig)
+	}
+	return optionConfigs
+}
+
+// Ensures that an instance with a custom option group keeps a valid one for its target database version.
+// On a major version upgrade, we create a new option group with the new target version carrying the same options.
+func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error) {
+	// For now, we only manage an option group for instances that
+	// already have a custom one attached (which is captured during the reconcile step)
+	if !o.IsCustomOptionGroup(i.OptionGroupName) {
+		return false, nil
+	}
+
+	existingOptionGroupName := i.OptionGroupName
+
+	existingOptionGroup, err := o.describeOptionGroup(existingOptionGroupName)
+	if err != nil {
+		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
+	}
+	if existingOptionGroup == nil {
+		return false, nil
+	}
+	existingMajorVersion := aws.ToString(existingOptionGroup.MajorEngineVersion)
+
+	targetMajorVersion, err := o.getMajorEngineVersion(i)
+	if err != nil {
+		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
+	}
+
+	// If major version is unchanged, the existing group is still valid
+	if existingMajorVersion == targetMajorVersion {
+		return false, nil
+	}
+
+	targetOptionGroupName := o.getOptionGroupName(i, targetMajorVersion)
+	if targetOptionGroupName == existingOptionGroupName {
+		return false, nil
+	}
+
+	targetOptionGroup, err := o.describeOptionGroup(targetOptionGroupName)
+	if err != nil {
+		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
+	}
+
+	createdOptionGroup := false
+	if targetOptionGroup == nil {
+		log.Printf("creating option group %s for %s %s", targetOptionGroupName, i.DbType, targetMajorVersion)
+		_, err = o.rds.CreateOptionGroup(o.ctx, &rds.CreateOptionGroupInput{
+			OptionGroupName:        aws.String(targetOptionGroupName),
+			EngineName:             aws.String(i.DbType),
+			MajorEngineVersion:     aws.String(targetMajorVersion),
+			OptionGroupDescription: aws.String("aws broker option group for " + formatDBName(i.Database)),
+			Tags:                   rdsTags,
+		})
+		if err != nil {
+			return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: error creating option group: %w", err)
+		}
+		createdOptionGroup = true
+	}
+
+	existingOptions := optionsFromGroup(existingOptionGroup)
+	if len(existingOptions) > 0 {
+		_, err = o.rds.ModifyOptionGroup(o.ctx, &rds.ModifyOptionGroupInput{
+			OptionGroupName:  aws.String(targetOptionGroupName),
+			OptionsToInclude: existingOptions,
+			ApplyImmediately: aws.Bool(true),
+		})
+		if err != nil {
+			return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: error adding options to option group: %w", err)
+		}
+	}
+
+	i.OptionGroupName = targetOptionGroupName
+	return createdOptionGroup, nil
+}
+
+// Deletes a broker-created option group. Retries deletion while it is still in use because
+// a recently detached group takes time to become deletable
+func (o *awsOptionsGroupClient) DeleteOptionGroup(optionGroupName string) error {
+	if optionGroupName == "" {
+		return nil
+	}
+
+	// Never delete a group the broker did not create.
+	if !o.IsBrokerOptionGroup(optionGroupName) {
+		o.logger.Info(fmt.Sprintf("skipping deletion of non-broker option group %s", optionGroupName))
+		return nil
+	}
+
+	existingOptionGroup, err := o.describeOptionGroup(optionGroupName)
+	if err != nil {
+		return err
+	}
+	if existingOptionGroup == nil {
+		return nil
+	}
+
+	attempts := 1
+	maxRetries := int(o.settings.PollAwsMaxRetries)
+
+	for attempts <= maxRetries {
+		_, err = o.rds.DeleteOptionGroup(o.ctx, &rds.DeleteOptionGroupInput{
+			OptionGroupName: &optionGroupName,
+		})
+		if err == nil {
+			return nil
+		}
+
+		var invalidStateErr *rdsTypes.InvalidOptionGroupStateFault
+		if errors.As(err, &invalidStateErr) {
+			attempts += 1
+			time.Sleep(o.settings.PollAwsMinDelay)
+			continue
+		}
+		var notFoundErr *rdsTypes.OptionGroupNotFoundFault
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
+		return err
+	}
+
+	return errors.New("could not verify deletion of option group")
+}
+
+// Deletes any broker-created option groups that are no longer in use. Groups still attached
+// to an instance fail to delete and are skipped.
+func (o *awsOptionsGroupClient) CleanupCustomOptionGroups() error {
+	input := &rds.DescribeOptionGroupsInput{}
+	paginator := rds.NewDescribeOptionGroupsPaginator(o.rds, input)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(o.ctx)
+		if err != nil {
+			return fmt.Errorf("CleanupCustomOptionGroups: error handling next page: %w", err)
+		}
+
+		for _, optionGroup := range output.OptionGroupsList {
+			if optionGroup.OptionGroupName == nil || !o.IsBrokerOptionGroup(*optionGroup.OptionGroupName) {
+				continue
+			}
+
+			_, err := o.rds.DeleteOptionGroup(o.ctx, &rds.DeleteOptionGroupInput{
+				OptionGroupName: optionGroup.OptionGroupName,
+			})
+			if err != nil {
+				var invalidStateErr *rdsTypes.InvalidOptionGroupStateFault
+				if errors.As(err, &invalidStateErr) {
+					o.logger.Debug(fmt.Sprintf("could not clean up option group %s: %s", *optionGroup.OptionGroupName, err))
+				}
+				var notFoundErr *rdsTypes.OptionGroupNotFoundFault
+				if errors.As(err, &notFoundErr) {
+					continue
+				}
+				return fmt.Errorf("CleanupCustomOptionGroups: DeleteOptionGroup err %w", err)
+			}
+
+			log.Printf("cleaned up %s option group", *optionGroup.OptionGroupName)
+		}
+	}
+
+	return nil
+}

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -135,6 +135,11 @@ func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfig
 			if setting.IsModifiable != nil && !*setting.IsModifiable {
 				continue
 			}
+			// Only copy options that aren't the default value
+			if aws.ToString(setting.Value) == aws.ToString(setting.DefaultValue) {
+				continue
+			}
+
 			optionConfig.OptionSettings = append(optionConfig.OptionSettings, rdsTypes.OptionSetting{
 				Name:  setting.Name,
 				Value: setting.Value,

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -275,6 +275,7 @@ func (o *awsOptionsGroupClient) CleanupCustomOptionGroups() error {
 				var invalidStateErr *rdsTypes.InvalidOptionGroupStateFault
 				if errors.As(err, &invalidStateErr) {
 					o.logger.Debug(fmt.Sprintf("could not clean up option group %s: %s", *optionGroup.OptionGroupName, err))
+					continue
 				}
 				var notFoundErr *rdsTypes.OptionGroupNotFoundFault
 				if errors.As(err, &notFoundErr) {

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -73,7 +73,7 @@ func (o *awsOptionsGroupClient) getMajorEngineVersion(i *RDSInstance) (string, e
 		return "", err
 	}
 	if len(defaultEngineInfo.DBEngineVersions) == 0 || defaultEngineInfo.DBEngineVersions[0].MajorEngineVersion == nil {
-		return "", fmt.Errorf("could not determine major engine version for $s, $s", i.DbType, i.DbVersion)
+		return "", fmt.Errorf("could not determine major engine version for %s, %s", i.DbType, i.DbVersion)
 	}
 
 	return *defaultEngineInfo.DBEngineVersions[0].MajorEngineVersion, nil

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
@@ -243,31 +242,14 @@ func (o *awsOptionsGroupClient) DeleteOptionGroup(optionGroupName string) error 
 		return nil
 	}
 
-	attempts := 1
-	maxRetries := int(o.settings.PollAwsMaxRetries)
-
-	for attempts <= maxRetries {
-		_, err = o.rds.DeleteOptionGroup(o.ctx, &rds.DeleteOptionGroupInput{
-			OptionGroupName: &optionGroupName,
-		})
-		if err == nil {
-			return nil
-		}
-
-		var invalidStateErr *rdsTypes.InvalidOptionGroupStateFault
-		if errors.As(err, &invalidStateErr) {
-			attempts += 1
-			time.Sleep(o.settings.PollAwsMinDelay)
-			continue
-		}
-		var notFoundErr *rdsTypes.OptionGroupNotFoundFault
-		if errors.As(err, &notFoundErr) {
-			return nil
-		}
-		return err
+	_, err = o.rds.DeleteOptionGroup(o.ctx, &rds.DeleteOptionGroupInput{
+		OptionGroupName: &optionGroupName,
+	})
+	if err == nil {
+		return nil
 	}
 
-	return errors.New("could not verify deletion of option group")
+	return err
 }
 
 // Deletes any broker-created option groups that are no longer in use. Groups still attached

--- a/services/rds/option_group_test.go
+++ b/services/rds/option_group_test.go
@@ -1,0 +1,261 @@
+package rds
+
+import (
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/cloud-gov/aws-broker/config"
+	"github.com/cloud-gov/aws-broker/testutil"
+)
+
+func newTestOptionGroupClient(rdsClient RDSClientInterface) *awsOptionsGroupClient {
+	return NewAwsOptionGroupClient(
+		nil,
+		rdsClient,
+		&config.Settings{
+			PollAwsMinDelay:   1 * time.Millisecond,
+			PollAwsMaxRetries: 1,
+		},
+		slog.New(&testutil.MockLogHandler{}),
+	)
+}
+
+func TestIsCustomOptionGroup(t *testing.T) {
+	o := newTestOptionGroupClient(&mockRDSClient{})
+	testCases := map[string]struct {
+		optionGroupName string
+		expected        bool
+	}{
+		"empty":         {"", false},
+		"default group": {"default:mysql-8-0", false},
+		"manual group":  {"my-audit-group", true},
+		"broker group":  {"cg-aws-broker-db1-version-8-4-9", true},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if got := o.IsCustomOptionGroup(tc.optionGroupName); got != tc.expected {
+				t.Errorf("IsCustomOptionGroup(%q) = %v, expected %v", tc.optionGroupName, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsBrokerOptionGroup(t *testing.T) {
+	o := newTestOptionGroupClient(&mockRDSClient{})
+	if o.IsBrokerOptionGroup("my-audit-group") {
+		t.Error("expected manual group to not be a broker group")
+	}
+	if !o.IsBrokerOptionGroup("cg-aws-broker-db1-version-8-4-9") {
+		t.Error("expected broker-prefixed group to be a broker group")
+	}
+}
+
+func TestReconcileRDSInstanceOptionGroup(t *testing.T) {
+	o := newTestOptionGroupClient(&mockRDSClient{})
+	testCases := map[string]struct {
+		dbInstanceState         *rdsTypes.DBInstance
+		instance                RDSInstance
+		expectedOptionGroupName string
+	}{
+		"no memberships leaves option group unset": {
+			dbInstanceState:         &rdsTypes.DBInstance{},
+			instance:                RDSInstance{},
+			expectedOptionGroupName: "",
+		},
+		"default option group is ignored": {
+			dbInstanceState: &rdsTypes.DBInstance{
+				OptionGroupMemberships: []rdsTypes.OptionGroupMembership{
+					{OptionGroupName: aws.String("default:mysql-8-0")},
+				},
+			},
+		},
+		"custom option group is captured": {
+			dbInstanceState: &rdsTypes.DBInstance{
+				OptionGroupMemberships: []rdsTypes.OptionGroupMembership{
+					{OptionGroupName: aws.String("my-audit-group")},
+				},
+			},
+			instance:                RDSInstance{},
+			expectedOptionGroupName: "my-audit-group",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			reconciled, err := o.ReconcileRDSInstanceOptionGroup(tc.dbInstanceState, tc.instance)
+			if err != nil {
+				t.Fatalf("unexpected err: %s", err)
+			}
+			if reconciled.OptionGroupName != tc.expectedOptionGroupName {
+				t.Errorf("expected OptiongroupName %q, got %q", tc.expectedOptionGroupName, reconciled.OptionGroupName)
+			}
+		})
+	}
+}
+
+func TestProvisionOrModifyCustomOptionGroup_MajorUpgrade(t *testing.T) {
+	optionGroupNotFound := &rdsTypes.OptionGroupNotFoundFault{}
+	mockRDS := &mockRDSClient{
+		describeOptionGroupsErrs: []error{nil, optionGroupNotFound},
+		describeOptionGroupsResults: []*rds.DescribeOptionGroupsOutput{
+			{
+				OptionGroupsList: []rdsTypes.OptionGroup{
+					{
+						OptionGroupName:    aws.String("my-audit-group"),
+						MajorEngineVersion: aws.String("8.0"),
+						Options: []rdsTypes.Option{
+							{
+								OptionName: aws.String("MARIADB_AUDIT_PLUGIN"),
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		dbEngineVersions: []rdsTypes.DBEngineVersion{
+			{MajorEngineVersion: aws.String("8.4")},
+		},
+	}
+
+	o := newTestOptionGroupClient(mockRDS)
+
+	i := &RDSInstance{
+		Database:        "db1",
+		DbType:          "mysql",
+		DbVersion:       "8.4.9",
+		OptionGroupName: "my-audit-group",
+	}
+
+	created, err := o.ProvisionOrModifyCustomOptionGroup(i, nil)
+	if err != nil {
+		t.Fatalf("unexepcted error: %s", err)
+	}
+	if !created {
+		t.Errorf("expected a new option group to be created")
+	}
+
+	expectedName := "cg-aws-broker-db1-option-8-4"
+	if i.OptionGroupName != expectedName {
+		t.Errorf("expected OptionGroupName %q, got %q", expectedName, i.OptionGroupName)
+	}
+	if mockRDS.createOptionGroupInput == nil {
+		t.Fatalf("expected CreateOptionGroup to be called")
+	}
+	if got := aws.ToString(mockRDS.createOptionGroupInput.EngineName); got != "mysql" {
+		t.Errorf("expected EngineName mysql, got %q", got)
+	}
+	if got := aws.ToString(mockRDS.createOptionGroupInput.OptionGroupName); got != expectedName {
+		t.Errorf("expected created group name %q, got %q", expectedName, got)
+	}
+	if mockRDS.modifyOptionGroupInput == nil {
+		t.Fatal("expected ModifyOptionGroup to be called to copy options")
+	}
+	optionNames := []string{}
+	for _, opt := range mockRDS.modifyOptionGroupInput.OptionsToInclude {
+		optionNames = append(optionNames, aws.ToString(opt.OptionName))
+	}
+	if !slices.Contains(optionNames, "MARIADB_AUDIT_PLUGIN") {
+		t.Errorf("expected MARIADB_AUDIT_PLUGIN to be carried forward, got %v", optionNames)
+	}
+}
+
+func TestProvisionOrModifyCustomOptionGroup_NoOp(t *testing.T) {
+	testCases := map[string]struct {
+		instance                *RDSInstance
+		describeResults         []*rds.DescribeOptionGroupsOutput
+		dbEngineVersions        []rdsTypes.DBEngineVersion
+		expectedOptionGroupName string
+	}{
+		"no option group": {
+			instance:                &RDSInstance{Database: "db1", DbType: "mysql", DbVersion: "8.4.9"},
+			expectedOptionGroupName: "",
+		},
+		"default option group": {
+			instance:                &RDSInstance{Database: "db1", DbType: "mysql", DbVersion: "8.4.9", OptionGroupName: "default:mysql-8-4"},
+			expectedOptionGroupName: "default:mysql-8-4",
+		},
+		"same major version": {
+			instance: &RDSInstance{Database: "db1", DbType: "mysql", DbVersion: "8.0.46", OptionGroupName: "my-audit-group"},
+			describeResults: []*rds.DescribeOptionGroupsOutput{
+				{
+					OptionGroupsList: []rdsTypes.OptionGroup{
+						{
+							OptionGroupName:    aws.String("my-audit-group"),
+							MajorEngineVersion: aws.String("8.0"),
+							Options: []rdsTypes.Option{
+								{OptionName: aws.String("MARIADB_AUDIT_PLUGIN")},
+							},
+						},
+					},
+				},
+			},
+			dbEngineVersions:        []rdsTypes.DBEngineVersion{{MajorEngineVersion: aws.String("8.0")}},
+			expectedOptionGroupName: "my-audit-group",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockRDS := &mockRDSClient{
+				describeOptionGroupsResults: tc.describeResults,
+				dbEngineVersions:            tc.dbEngineVersions,
+			}
+			o := newTestOptionGroupClient(mockRDS)
+
+			created, err := o.ProvisionOrModifyCustomOptionGroup(tc.instance, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if created {
+				t.Error("expected no option group to be created")
+			}
+			if mockRDS.createOptionGroupInput != nil {
+				t.Error("expected CreateOptionGroup not to be called")
+			}
+			if tc.instance.OptionGroupName != tc.expectedOptionGroupName {
+				t.Errorf("expected option group %q, got %q", tc.expectedOptionGroupName, tc.instance.OptionGroupName)
+			}
+		})
+	}
+}
+
+func TestDeleteOptionGroup(t *testing.T) {
+	testCases := map[string]struct {
+		optionGroupName     string
+		describeResults     []*rds.DescribeOptionGroupsOutput
+		expectedDeleteCalls int
+	}{
+		"manually-created group is never deleted": {
+			optionGroupName:     "my-audit-group",
+			expectedDeleteCalls: 0,
+		},
+		"broker group is deleted": {
+			optionGroupName: "cg-aws-broker-db1-option-8-0",
+			describeResults: []*rds.DescribeOptionGroupsOutput{
+				{
+					OptionGroupsList: []rdsTypes.OptionGroup{
+						{OptionGroupName: aws.String("cg-aws-broker-db1-option-8-0")},
+					},
+				},
+			},
+			expectedDeleteCalls: 1,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockRDS := &mockRDSClient{describeOptionGroupsResults: tc.describeResults}
+			o := newTestOptionGroupClient(mockRDS)
+
+			if err := o.DeleteOptionGroup(tc.optionGroupName); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if mockRDS.deleteOptionGroupCallNum != tc.expectedDeleteCalls {
+				t.Errorf("expected DeleteOptionGroup to be called %d times(s), got %d", tc.expectedDeleteCalls, mockRDS.deleteDBInstancesCallNum)
+			}
+		})
+	}
+}

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -61,8 +61,9 @@ func initializeAdapter(
 	rdsClient := rds.NewFromConfig(cfg)
 
 	parameterGroupClient := NewAwsParameterGroupClient(ctx, rdsClient, s, logger)
+	optionGroupClient := NewAwsOptionGroupClient(ctx, rdsClient, s, logger)
 
-	dbAdapter := NewRdsDedicatedDBAdapter(ctx, s, db, rdsClient, parameterGroupClient, logger, riverClient)
+	dbAdapter := NewRdsDedicatedDBAdapter(ctx, s, db, rdsClient, parameterGroupClient, optionGroupClient, logger, riverClient)
 	return dbAdapter, nil
 }
 
@@ -72,6 +73,7 @@ func NewRdsDedicatedDBAdapter(
 	db *gorm.DB,
 	rdsClient RDSClientInterface,
 	parameterGroupClient parameterGroupClient,
+	optionGroupClient optionGroupClient,
 	logger *slog.Logger,
 	riverClient *river.Client[*sql.Tx],
 ) *dedicatedDBAdapter {
@@ -80,6 +82,7 @@ func NewRdsDedicatedDBAdapter(
 		settings:             *s,
 		rds:                  rdsClient,
 		parameterGroupClient: parameterGroupClient,
+		optionGroupClient:    optionGroupClient,
 		db:                   db,
 		logger:               logger,
 		riverClient:          riverClient,
@@ -146,6 +149,7 @@ type dedicatedDBAdapter struct {
 	settings             config.Settings
 	rds                  RDSClientInterface
 	parameterGroupClient parameterGroupClient
+	optionGroupClient    optionGroupClient
 	db                   *gorm.DB
 	logger               *slog.Logger
 	riverClient          *river.Client[*sql.Tx]
@@ -355,6 +359,14 @@ func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance
 	// Capture any parameter groups created manually
 	reconciledInstanceWithParameters, err := d.parameterGroupClient.ReconcileRDSInstanceParameterGroup(dbInstanceState, reconciledInstance)
 	reconciledInstance = *reconciledInstanceWithParameters
+	if err != nil {
+		return &reconciledInstance, err
+	}
+
+	// Capture any custom option groups (e.g. a manually attached MariaDB audit plugin)
+	// so it can be rebuilt for the target version on a major version upgrade
+	reconciledInstanceWithOptions, err := d.optionGroupClient.ReconcileRDSInstanceOptionGroup(dbInstanceState, reconciledInstance)
+	reconciledInstance = *reconciledInstanceWithOptions
 	if err != nil {
 		return &reconciledInstance, err
 	}

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -30,13 +30,18 @@ import (
 	"github.com/cloud-gov/aws-broker/testutil"
 )
 
-func NewTestDedicatedDBAdapter(ctx context.Context, brokerDB *gorm.DB, s *config.Settings, rdsClient RDSClientInterface, parameterGroupClient parameterGroupClient) *dedicatedDBAdapter {
+func NewTestDedicatedDBAdapter(ctx context.Context, brokerDB *gorm.DB, s *config.Settings, rdsClient RDSClientInterface, parameterGroupClient parameterGroupClient, optionGroupClients ...optionGroupClient) *dedicatedDBAdapter {
 	logger := slog.New(&testutil.MockLogHandler{})
 
+	var optionGroupClient optionGroupClient = &mockOptionGroupClient{}
+	if len(optionGroupClients) > 0 {
+		optionGroupClient = optionGroupClients[0]
+	}
+
 	workers := river.NewWorkers()
-	river.AddWorker(workers, NewCreateWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, &mockCredentialUtils{}))
-	river.AddWorker(workers, NewModifyWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, &mockCredentialUtils{}))
-	river.AddWorker(workers, NewDeleteWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, &mockCredentialUtils{}))
+	river.AddWorker(workers, NewCreateWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, optionGroupClient, &mockCredentialUtils{}))
+	river.AddWorker(workers, NewModifyWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, optionGroupClient, &mockCredentialUtils{}))
+	river.AddWorker(workers, NewDeleteWorker(brokerDB, s, rdsClient, logger, parameterGroupClient, optionGroupClient, &mockCredentialUtils{}))
 
 	if s.DbConfig == nil {
 		s.DbConfig = &db.DBConfig{
@@ -49,7 +54,7 @@ func NewTestDedicatedDBAdapter(ctx context.Context, brokerDB *gorm.DB, s *config
 		log.Fatal(fmt.Errorf("error creating river client: %w", err))
 	}
 
-	return NewRdsDedicatedDBAdapter(ctx, s, brokerDB, rdsClient, parameterGroupClient, logger, riverClient)
+	return NewRdsDedicatedDBAdapter(ctx, s, brokerDB, rdsClient, parameterGroupClient, optionGroupClient, logger, riverClient)
 }
 
 func TestCreateDb(t *testing.T) {
@@ -734,6 +739,43 @@ func TestReconcileDbState(t *testing.T) {
 			expectedInstance: &RDSInstance{
 				DbVersion:          "15",
 				ParameterGroupName: "custom-group",
+			},
+		},
+		"reconcile custom option group": {
+			ctx: t.Context(),
+			dbAdapter: NewTestDedicatedDBAdapter(
+				t.Context(),
+				brokerDB,
+				&config.Settings{},
+				&mockRDSClient{
+					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
+						{
+							DBInstances: []rdsTypes.DBInstance{
+								{
+									OptionGroupMemberships: []rdsTypes.OptionGroupMembership{
+										{
+											OptionGroupName: aws.String("my-audit-group"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&mockParameterGroupClient{},
+				&mockOptionGroupClient{
+					reconciledInstance: &RDSInstance{
+						DbVersion:       "8.0",
+						OptionGroupName: "my-audit-group",
+					},
+				},
+			),
+			dbInstance: RDSInstance{
+				DbVersion: "8.0",
+			},
+			expectedInstance: &RDSInstance{
+				DbVersion:       "8.0",
+				OptionGroupName: "my-audit-group",
 			},
 		},
 		"error describing database": {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -48,6 +48,7 @@ type RDSInstance struct {
 	PgQueryLogging       *PgQueryLoggingOptions `gorm:"serializer:json"`
 	ParameterGroupFamily string                 `gorm:"-"`
 	ParameterGroupName   string                 `sql:"size(255)"`
+	OptionGroupName      string                 `sql:"size(255)"`
 
 	EnabledCloudwatchLogGroupExports pq.StringArray `gorm:"type:text[]"`
 

--- a/services/rds/types.go
+++ b/services/rds/types.go
@@ -13,15 +13,19 @@ type RDSClientInterface interface {
 	CreateDBInstance(ctx context.Context, params *rds.CreateDBInstanceInput, optFns ...func(*rds.Options)) (*rds.CreateDBInstanceOutput, error)
 	CreateDBInstanceReadReplica(ctx context.Context, params *rds.CreateDBInstanceReadReplicaInput, optFns ...func(*rds.Options)) (*rds.CreateDBInstanceReadReplicaOutput, error)
 	CreateDBParameterGroup(ctx context.Context, params *rds.CreateDBParameterGroupInput, optFns ...func(*rds.Options)) (*rds.CreateDBParameterGroupOutput, error)
+	CreateOptionGroup(ctx context.Context, params *rds.CreateOptionGroupInput, optFns ...func(*rds.Options)) (*rds.CreateOptionGroupOutput, error)
 	DeleteDBInstance(ctx context.Context, params *rds.DeleteDBInstanceInput, optFns ...func(*rds.Options)) (*rds.DeleteDBInstanceOutput, error)
 	DeleteDBParameterGroup(ctx context.Context, params *rds.DeleteDBParameterGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteDBParameterGroupOutput, error)
+	DeleteOptionGroup(ctx context.Context, params *rds.DeleteOptionGroupInput, optFns ...func(*rds.Options)) (*rds.DeleteOptionGroupOutput, error)
 	DescribeDBEngineVersions(ctx context.Context, params *rds.DescribeDBEngineVersionsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBEngineVersionsOutput, error)
 	DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
 	DescribeDBParameterGroups(ctx context.Context, params *rds.DescribeDBParameterGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBParameterGroupsOutput, error)
 	DescribeDBParameters(ctx context.Context, params *rds.DescribeDBParametersInput, optFns ...func(*rds.Options)) (*rds.DescribeDBParametersOutput, error)
 	DescribeEngineDefaultParameters(ctx context.Context, params *rds.DescribeEngineDefaultParametersInput, optFns ...func(*rds.Options)) (*rds.DescribeEngineDefaultParametersOutput, error)
+	DescribeOptionGroups(ctx context.Context, params *rds.DescribeOptionGroupsInput, optFns ...func(*rds.Options)) (*rds.DescribeOptionGroupsOutput, error)
 	ModifyDBInstance(ctx context.Context, params *rds.ModifyDBInstanceInput, optFns ...func(*rds.Options)) (*rds.ModifyDBInstanceOutput, error)
 	ModifyDBParameterGroup(ctx context.Context, params *rds.ModifyDBParameterGroupInput, optFns ...func(*rds.Options)) (*rds.ModifyDBParameterGroupOutput, error)
+	ModifyOptionGroup(ctx context.Context, params *rds.ModifyOptionGroupInput, optFns ...func(*rds.Options)) (*rds.ModifyOptionGroupOutput, error)
 }
 
 var rdsApplyMethodMap = map[string]rdsTypes.ApplyMethod{


### PR DESCRIPTION
## Changes proposed in this pull request:

- This change is to fix blocked RDS major version upgrades due to custom option groups (all of which are to attach `MARIADB_AUDIT_PLUGIN`). The main functionality implemented here is the migration of existing option groups when major version upgrades are initiated. 
  - End-to-end flow: 
    1. user performs an `update-service` command 
    2. the broker reconciles with the live instance to see if there is an existing custom option group
    3. `ModifyWorker` provisions a new option group if there is a major version upgrade. All options from the existing group are replicated on the new group.
    4. The modify db params takes the new option group name so AWS can attach the new group.
    5. Post modify: broker attempts cleanup of old option group, but will silently fail and proceed if the group is still in use by snapshots
- The delete service path was updated to perform a cleanup of old orphaned broker-managed option groups if they weren't deleted in the past (e.g. due to still being attached to a snapshot) 

### Test verification 
￼
Initial db instance (v8.0) with an attached custom option group
<img width="676" height="708" alt="Instance" src="https://github.com/user-attachments/assets/ffe5921e-cc8f-47c6-8588-7b4a3d8b493c" />
The initial custom option group (v8.0)
<img width="976" height="762" alt="cg-aws-broker-option-test" src="https://github.com/user-attachments/assets/bb387e82-221d-4e7b-8262-3d1bdb7d4ed4" />

After the update-service call to upgrade from v8.0 to v8.4

cf success message
<img width="1928" height="1056" alt="some service leftance is not currently being eared" src="https://github.com/user-attachments/assets/190dfad6-ed32-4ffe-a88a-35ff9d64871c" />

DB instance now attached to the new option group created by broker
<img width="582" height="694" alt="Instance" src="https://github.com/user-attachments/assets/19e6e72c-58a3-4f24-8ffd-623eb1ba7b60" />

The new option group with the matching options
<img width="2270" height="1450" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/bb604c51-469f-4393-8409-a4a63b2a2f0c" />





￼

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
