### PR TITLE
improve error handling when getting parameter group family

### DIFF
--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -216,6 +216,10 @@ func (p *awsParameterGroupClient) getParameterGroupFamily(i *RDSInstance) error 
 		return err
 	}
 
+	if len(defaultEngineInfo.DBEngineVersions) == 0 {
+		return fmt.Errorf("no engine versions were returned for version %s", i.DbVersion)
+	}
+
 	// The value from the engine info is a string pointer, so we must
 	// retrieve its actual value.
 	parameterGroupFamily = *defaultEngineInfo.DBEngineVersions[0].DBParameterGroupFamily

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -1342,6 +1342,17 @@ func TestGetParameterGroupFamily(t *testing.T) {
 				rds: &mockRDSClient{},
 			},
 		},
+		"no engine versions are returned": {
+			dbInstance: &RDSInstance{
+				DbVersion: "15.12",
+			},
+			expectedErr: "no engine versions were returned for version 15.12",
+			parameterGroupAdapter: &awsParameterGroupClient{
+				rds: &mockRDSClient{
+					dbEngineVersions: []rdsTypes.DBEngineVersion{},
+				},
+			},
+		},
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Changes proposed in this pull request:

- improve error handling when no DB engine versions are returned in awsParameterGroupClient.getParameterGroupFamily() so that code will return an error instead of panicking

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
