### PR TITLE
Fix: DescribeDBEngineVersions now returns version info regardless of status

### DIFF
--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -65,6 +65,7 @@ func (o *awsOptionsGroupClient) getMajorEngineVersion(i *RDSInstance) (string, e
 	dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{
 		Engine:        aws.String(i.DbType),
 		EngineVersion: aws.String(i.DbVersion),
+		IncludeAll:    aws.Bool(true), // Shows all engine versions (including deprecated ones)
 	}
 
 	defaultEngineInfo, err := o.rds.DescribeDBEngineVersions(o.ctx, dbEngineVersionsInput)

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -208,6 +208,7 @@ func (p *awsParameterGroupClient) getParameterGroupFamily(i *RDSInstance) error 
 	dbEngineVersionsInput := &rds.DescribeDBEngineVersionsInput{
 		Engine:        aws.String(i.DbType),
 		EngineVersion: aws.String(i.DbVersion),
+		IncludeAll:    aws.Bool(true), // Shows all engine versions (including deprecated ones)
 	}
 
 	// This call requires that the broker have permissions to make it.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets `IncludeAll` field in `DescribeDBEngineVersions` call to return version regardless of its status (i.e. deprecated). This fixes situations where the RDS instance is already on an deprecated version and needs to create parameter or option groups for that version. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
