### PR TITLE
test(rds): guard Oracle log-export allowlist == baseline supported set (#546)

### DIFF
--- a/services/rds/validate_test.go
+++ b/services/rds/validate_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -261,5 +262,48 @@ func TestValidateOracleOptions(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 		})
+	}
+}
+
+// TestOracleLogExportAllowlistMatchesBaseline is the #546 drift guard. The
+// customer-facing log-export allowlist enforced by validateOracleOptions
+// (validOracleLogExports) MUST be exactly the embedded baseline's `supported`
+// set, and the baseline's `default_exports` (what the create path enables when
+// the customer supplies none) MUST be a subset of that supported set. If a future
+// refactor reintroduces a hand-maintained Go literal, or edits log_exports.yml
+// inconsistently, this test fails instead of silently drifting.
+func TestOracleLogExportAllowlistMatchesBaseline(t *testing.T) {
+	baseline, err := loadOracleLogExports()
+	if err != nil {
+		t.Fatalf("loadOracleLogExports: %v", err)
+	}
+
+	// 1. The enforced allowlist is derived from — and equal to — the baseline
+	//    `supported` set (single source of truth; no duplication).
+	allow, err := validOracleLogExports()
+	if err != nil {
+		t.Fatalf("validOracleLogExports: %v", err)
+	}
+	if !slices.Equal(allow, baseline.Supported) {
+		t.Errorf("validOracleLogExports() = %v, want baseline supported set %v (they must not drift)",
+			allow, baseline.Supported)
+	}
+
+	// 2. default_exports ⊆ supported — you cannot default-enable an export the
+	//    engine does not support (create path would advertise an invalid request).
+	for _, d := range baseline.DefaultExports {
+		if !slices.Contains(baseline.Supported, d) {
+			t.Errorf("default export %q is not in the supported set %v", d, baseline.Supported)
+		}
+	}
+
+	// 3. Every default export the create path enables must pass the same allowlist
+	//    a customer request is validated against (i.e. the born-hardened default
+	//    posture can never be self-rejected by validateOracleOptions).
+	if err := validateOracleOptions(Options{
+		EnableCloudWatchLogGroupExports: baseline.DefaultExports,
+	}); err != nil {
+		t.Errorf("default log exports %v rejected by validateOracleOptions: %v",
+			baseline.DefaultExports, err)
 	}
 }

--- a/services/rds/validate_test.go
+++ b/services/rds/validate_test.go
@@ -265,7 +265,7 @@ func TestValidateOracleOptions(t *testing.T) {
 	}
 }
 
-// TestOracleLogExportAllowlistMatchesBaseline is the #546 drift guard. The
+// TestOracleLogExportAllowlistMatchesBaseline is a drift guard. The
 // customer-facing log-export allowlist enforced by validateOracleOptions
 // (validOracleLogExports) MUST be exactly the embedded baseline's `supported`
 // set, and the baseline's `default_exports` (what the create path enables when
@@ -289,8 +289,9 @@ func TestOracleLogExportAllowlistMatchesBaseline(t *testing.T) {
 			allow, baseline.Supported)
 	}
 
-	// 2. default_exports ⊆ supported — you cannot default-enable an export the
-	//    engine does not support (create path would advertise an invalid request).
+	// 2. default_exports is a subset of supported — you cannot default-enable an
+	//    export the engine does not support (create path would advertise an
+	//    invalid request).
 	for _, d := range baseline.DefaultExports {
 		if !slices.Contains(baseline.Supported, d) {
 			t.Errorf("default export %q is not in the supported set %v", d, baseline.Supported)


### PR DESCRIPTION
## What
Adds a regression guard (`TestOracleLogExportAllowlistMatchesBaseline`) for the invariant #537 established when it replaced the hand-maintained Go literal with a baseline-derived allowlist.

Asserts:
1. `validOracleLogExports()` (the enforced customer allowlist) **equals** the embedded baseline `log_exports.yml` `supported` set — a future refactor reintroducing a hardcoded list can't silently drift.
2. `default_exports` ⊆ `supported` — can't default-enable an unsupported export.
3. The born-hardened default export set **passes** `validateOracleOptions` — the create path's default posture can never be self-rejected by the allowlist.

## Why
A hostile self-review of #537 flagged the original duplicated log-export literal as a drift risk. #537 fixed the duplication by deriving from the baseline; this locks the invariant with an explicit test.

## Testing
- `go test ./services/rds/` green; verified the guard **fails** when a bogus `default_export` not in `supported` is introduced, then restored.
- Build / vet / gofmt / golangci-lint (fresh cache + fresh pre-commit env) all clean.

No behavior change; test-only.

Base is the Oracle integration branch `feat/oracle-19c-stig-brokered-rds` (per the branching strategy — not `main`).

Closes #546.