### PR TITLE
feat(rds): minimal Oracle SE2 with TLS (TCPS) only

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When an authenticated, authorized CloudFoundry user runs `cf create-service aws-
 curl -X PUT https://username:password@aws-broker..../v2/service_instances/:instance_id
 ```
 
-The broker expects the `AUTH_PASS`and `AUTH_USER` as specified in the environment, which the Platform has provided (see above)
+The broker expects the `AUTH_PASS`and `AUTH_USER` as specified in the environment, which the Platform has provided (see above).
 
 The response indicates if the provisioning request has been accepted.
 

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1289,6 +1289,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       dbType: oracle-se2
+      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
       licenseModel: license-included
       redundant: false
       encrypted: true

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1268,6 +1268,39 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         broker: "AWS broker"
+    - id: "e7d65895-4fc3-4a66-8c61-68da4944c69c"
+      name: &medium-oracle-se2-name "medium-oracle-se2"
+      description: "Single-AZ RDS instance of Oracle SE2, minimum 2 core, minimum 4 GiB memory"
+      metadata:
+        bullets:
+          - *single-az-rds
+          - &oracle-se2 "Oracle Standard Edition 2"
+          - *minimum-2-cores
+          - *minimum-4-gib-memory
+          - &default-20-gb-storage "Default 20 GB storage"
+          - &license-included "License Included"
+        costs:
+          - amount:
+              usd: 118
+            unit: "MONTHLY"
+        displayName: *medium-oracle-se2-name
+      free: false
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      allocatedStorage: 20
+      dbType: oracle-se2
+      licenseModel: license-included
+      redundant: false
+      encrypted: true
+      storage_type: gp3
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.oracle_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        broker: "AWS broker"
+
 redis:
   id: "cda65825-e357-4a93-a24b-9ab138d97815"
   name: "aws-elasticache-redis"

--- a/ci/build-manifest.sh
+++ b/ci/build-manifest.sh
@@ -26,6 +26,7 @@ meta:
     subnet_group: `${TERRAFORM} output -raw -state stack.tfstate rds_subnet_group`
     postgres_security_group: `${TERRAFORM} output -raw -state=stack.tfstate rds_postgres_security_group`
     mysql_security_group: `${TERRAFORM} output -raw -state=stack.tfstate rds_mysql_security_group`
+    oracle_security_group: `${TERRAFORM} output -raw -state=stack.tfstate rds_oracle_security_group`
   redis:
     subnet_group: `${TERRAFORM} output -raw -state stack.tfstate elasticache_subnet_group`
     security_group: `${TERRAFORM} output -raw -state stack.tfstate elasticache_redis_security_group`

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -189,6 +189,7 @@ jobs:
             aws-rds:small-mysql-redundant
             aws-rds:small-psql
             aws-rds:small-psql-redundant
+            aws-rds:medium-oracle-se2
             aws-elasticache-redis:redis-dev
             aws-elasticache-redis:redis-3node
             aws-elasticache-redis:redis-5node
@@ -699,6 +700,20 @@ jobs:
                 ENABLE_CLOUDWATCH_LOG_GROUP_EXPORTS_ON_CREATE: '["general"]'
                 DB_TYPE: mysql
                 ALLOW_MAJOR_VERSION_UPGRADE: true
+
+            - task: smoke-tests-oracle
+              file: aws-broker-app/ci/run-smoke-tests.yml
+              image: general-task
+              params:
+                BROKER_NAME: ((development-broker-name))
+                CF_API_URL: ((development-cf-api-url))
+                CF_USERNAME: ((development-cf-deploy-username))
+                CF_PASSWORD: ((development-cf-deploy-password))
+                CF_ORGANIZATION: ((development-tests-cf-organization))
+                CF_SPACE: ((development-tests-cf-space))
+                SERVICE_PLAN: medium-oracle-se2
+                DB_TYPE: oracle-se2
+
     on_failure:
       put: slack
       params:

--- a/ci/terraform/rds_module/variables.tf
+++ b/ci/terraform/rds_module/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "16.8"
+  default = "16.13"
 }
 
 variable "rds_username" {

--- a/services/rds/create_worker.go
+++ b/services/rds/create_worker.go
@@ -89,7 +89,7 @@ func (w *CreateWorker) prepareCreateDbInput(
 		// Instance class is defined by the plan
 		DBInstanceClass:         &plan.InstanceClass,
 		DBInstanceIdentifier:    &i.Database,
-		DBName:                  aws.String(formatDBName(i.Database)),
+		DBName:                  aws.String(formatDBName(i.Database, i.DbType)),
 		Engine:                  aws.String(i.DbType),
 		MasterUserPassword:      &password,
 		MasterUsername:          &i.Username,

--- a/services/rds/create_worker.go
+++ b/services/rds/create_worker.go
@@ -127,6 +127,16 @@ func (w *CreateWorker) prepareCreateDbInput(
 		params.DBParameterGroupName = aws.String(i.ParameterGroupName)
 	}
 
+	// Provision + attach the engine's baseline option group at create time
+	// (Oracle SE2: the SSL/TCPS option that opens the TLS listener on port 2484).
+	// No-op for engines with no baseline options (postgres/mysql). Fails closed.
+	if err = w.optionGroupClient.ProvisionBaselineOptionGroup(i, rdsTags); err != nil {
+		return nil, err
+	}
+	if i.OptionGroupName != "" {
+		params.OptionGroupName = aws.String(i.OptionGroupName)
+	}
+
 	return params, nil
 }
 

--- a/services/rds/create_worker.go
+++ b/services/rds/create_worker.go
@@ -127,9 +127,8 @@ func (w *CreateWorker) prepareCreateDbInput(
 		params.DBParameterGroupName = aws.String(i.ParameterGroupName)
 	}
 
-	// Provision + attach the engine's baseline option group at create time
-	// (Oracle SE2: the SSL/TCPS option that opens the TLS listener on port 2484).
-	// No-op for engines with no baseline options (postgres/mysql). Fails closed.
+	// Attach the engine's baseline option group (Oracle SE2: SSL/TCPS). No-op
+	// for postgres/mysql. Fails closed.
 	if err = w.optionGroupClient.ProvisionBaselineOptionGroup(i, rdsTags); err != nil {
 		return nil, err
 	}

--- a/services/rds/create_worker_test.go
+++ b/services/rds/create_worker_test.go
@@ -296,8 +296,9 @@ func TestPrepareCreateDbInstanceInput(t *testing.T) {
 				credentialUtils: &RDSCredentialUtils{},
 			},
 			worker: &CreateWorker{
-				settings: &config.Settings{},
-				rds:      &mockRDSClient{},
+				settings:          &config.Settings{},
+				rds:               &mockRDSClient{},
+				optionGroupClient: &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{
 					provisionNewParamGroupErr: testErr,
 					rds:                       &mockRDSClient{},
@@ -327,7 +328,8 @@ func TestPrepareCreateDbInstanceInput(t *testing.T) {
 				settings: &config.Settings{
 					PubliclyAccessibleFeature: true,
 				},
-				rds: &mockRDSClient{},
+				rds:               &mockRDSClient{},
+				optionGroupClient: &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{
 					rds:              &mockRDSClient{},
 					customPgroupName: "parameter-group-1",
@@ -390,7 +392,8 @@ func TestPrepareCreateDbInstanceInput(t *testing.T) {
 				settings: &config.Settings{
 					PubliclyAccessibleFeature: true,
 				},
-				rds: &mockRDSClient{},
+				rds:               &mockRDSClient{},
+				optionGroupClient: &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{
 					rds:              &mockRDSClient{},
 					customPgroupName: "parameter-group-1",
@@ -817,6 +820,7 @@ func TestCreateDBReadReplica(t *testing.T) {
 					PollAwsMaxDuration: 10 * time.Millisecond,
 				},
 				rds:                  &mockRDSClient{},
+				optionGroupClient:    &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{},
 				logger:               slog.New(&testutil.MockLogHandler{}),
 			},
@@ -843,6 +847,7 @@ func TestCreateDBReadReplica(t *testing.T) {
 					PollAwsMaxDuration: 10 * time.Millisecond,
 				},
 				rds:                  &mockRDSClient{},
+				optionGroupClient:    &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{},
 				logger:               slog.New(&testutil.MockLogHandler{}),
 			},
@@ -876,6 +881,7 @@ func TestCreateDBReadReplica(t *testing.T) {
 						&rdsTypes.InvalidDBInstanceStateFault{},
 					},
 				},
+				optionGroupClient:    &mockOptionGroupClient{},
 				parameterGroupClient: &mockParameterGroupClient{},
 				logger:               slog.New(&testutil.MockLogHandler{}),
 			},

--- a/services/rds/credentials.go
+++ b/services/rds/credentials.go
@@ -19,9 +19,14 @@ type CredentialUtils interface {
 	generateCredentials(settings *config.Settings) (string, string, error)
 }
 
-func formatDBName(database string) string {
-	re, _ := regexp.Compile("(i?)[^a-z0-9]")
-	return re.ReplaceAllString(database, "")
+func formatDBName(database string, dbType string) string {
+	switch dbType {
+	case "oracle-se1", "oracle-se2":
+		return "ORCL"
+	default:
+		re, _ := regexp.Compile("(i?)[^a-z0-9]")
+		return re.ReplaceAllString(database, "")
+	}
 }
 
 type RDSCredentialUtils struct {
@@ -68,7 +73,7 @@ func (u *RDSCredentialUtils) getCredentials(i *RDSInstance, password string) (ma
 		return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
 	}
 
-	dbName := formatDBName(i.Database)
+	dbName := formatDBName(i.Database, i.DbType)
 	uri := fmt.Sprintf(
 		"%s://%s:%s@%s:%d/%s",
 		dbScheme,

--- a/services/rds/credentials.go
+++ b/services/rds/credentials.go
@@ -141,7 +141,8 @@ func oracleCredentials(i *RDSInstance, password, scheme, serviceName string) (ma
 		"name":                serviceName,
 		"ssl_required":        "true",
 		"ssl_server_dn_match": "true",
-		"ca_cert_bundle_url":  "https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem",
+		// No ca_cert_bundle_url: the RDS GovCloud truststore host is not on the
+		// platform egress allowlist, so apps must vendor the CA bundle offline.
 	}, nil
 }
 

--- a/services/rds/credentials.go
+++ b/services/rds/credentials.go
@@ -76,6 +76,10 @@ func (u *RDSCredentialUtils) getCredentials(i *RDSInstance, password string) (ma
 	}
 
 	dbName := formatDBName(i.Database, i.DbType)
+	if i.DbType == "oracle-se1" || i.DbType == "oracle-se2" {
+		return oracleCredentials(i, password, dbScheme, dbName)
+	}
+
 	uri := fmt.Sprintf(
 		"%s://%s:%s@%s:%d/%s",
 		dbScheme,
@@ -110,6 +114,35 @@ func (u *RDSCredentialUtils) getCredentials(i *RDSInstance, password string) (ma
 	}
 
 	return credentials, nil
+}
+
+func oracleCredentials(i *RDSInstance, password, scheme, serviceName string) (map[string]string, error) {
+	const sslPort int64 = 2484
+	descriptor := fmt.Sprintf(
+		"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))",
+		i.Host,
+		sslPort,
+		serviceName,
+	)
+	uri := fmt.Sprintf("%s://%s:%s@%s", scheme, i.Username, password, descriptor)
+	jdbcURL := fmt.Sprintf("jdbc:oracle:thin:@%s", descriptor)
+
+	return map[string]string{
+		"uri":                 uri,
+		"jdbcUrl":             jdbcURL,
+		"username":            i.Username,
+		"password":            password,
+		"host":                i.Host,
+		"port":                strconv.FormatInt(sslPort, 10),
+		"protocol":            "tcps",
+		"service_name":        serviceName,
+		"sid":                 serviceName,
+		"db_name":             serviceName,
+		"name":                serviceName,
+		"ssl_required":        "true",
+		"ssl_server_dn_match": "true",
+		"ca_cert_bundle_url":  "https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem",
+	}, nil
 }
 
 func (u *RDSCredentialUtils) generateCredentials(

--- a/services/rds/credentials.go
+++ b/services/rds/credentials.go
@@ -141,8 +141,6 @@ func oracleCredentials(i *RDSInstance, password, scheme, serviceName string) (ma
 		"name":                serviceName,
 		"ssl_required":        "true",
 		"ssl_server_dn_match": "true",
-		// No ca_cert_bundle_url: the RDS GovCloud truststore host is not on the
-		// platform egress allowlist, so apps must vendor the CA bundle offline.
 	}, nil
 }
 

--- a/services/rds/credentials.go
+++ b/services/rds/credentials.go
@@ -69,6 +69,8 @@ func (u *RDSCredentialUtils) getCredentials(i *RDSInstance, password string) (ma
 	switch i.DbType {
 	case "postgres", "mysql":
 		dbScheme = i.DbType
+	case "oracle-se1", "oracle-se2":
+		dbScheme = "oracle"
 	default:
 		return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
 	}

--- a/services/rds/credentials_test.go
+++ b/services/rds/credentials_test.go
@@ -14,11 +14,11 @@ func TestFormatDBName(t *testing.T) {
 	i := &RDSInstance{
 		Database: dbIdentifier,
 	}
-	dbName1 := formatDBName(i.Database)
+	dbName1 := formatDBName(i.Database, i.DbType)
 	if dbName1 != dbIdentifier {
 		t.Fatalf("database name should be %s", dbIdentifier)
 	}
-	dbName2 := formatDBName(i.Database)
+	dbName2 := formatDBName(i.Database, i.DbType)
 	if dbName1 != dbName2 {
 		t.Fatalf("database names should be the same")
 	}

--- a/services/rds/credentials_test.go
+++ b/services/rds/credentials_test.go
@@ -24,6 +24,18 @@ func TestFormatDBName(t *testing.T) {
 	}
 }
 
+func TestFormatOracleDBName(t *testing.T) {
+	dbIdentifier := "db" + helpers.RandStrNoCaps(15)
+	i := &RDSInstance{
+		Database: dbIdentifier,
+		DbType: "oracle-se2",
+	}
+	dbName := formatDBName(i.Database, i.DbType)
+	if dbName != "ORCL" {
+		t.Fatalf("database name should be %s", "ORCL")
+	}
+}
+
 func TestGetCredentials(t *testing.T) {
 	testCases := map[string]struct {
 		credentialUtils CredentialUtils

--- a/services/rds/credentials_test.go
+++ b/services/rds/credentials_test.go
@@ -94,7 +94,6 @@ func TestGetCredentials(t *testing.T) {
 				"name":                "ORCL",
 				"ssl_required":        "true",
 				"ssl_server_dn_match": "true",
-				"ca_cert_bundle_url":  "https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem",
 			},
 		},
 		"unknown databse type": {
@@ -196,7 +195,6 @@ func TestOracleBindingDoesNotLeakAdminMarkers(t *testing.T) {
 		"sid",
 		"ssl_required",
 		"ssl_server_dn_match",
-		"ca_cert_bundle_url",
 	} {
 		if _, ok := creds[key]; !ok {
 			t.Errorf("oracle binding missing expected key %q", key)

--- a/services/rds/credentials_test.go
+++ b/services/rds/credentials_test.go
@@ -28,7 +28,7 @@ func TestFormatOracleDBName(t *testing.T) {
 	dbIdentifier := "db" + helpers.RandStrNoCaps(15)
 	i := &RDSInstance{
 		Database: dbIdentifier,
-		DbType: "oracle-se2",
+		DbType:   "oracle-se2",
 	}
 	dbName := formatDBName(i.Database, i.DbType)
 	if dbName != "ORCL" {
@@ -65,6 +65,29 @@ func TestGetCredentials(t *testing.T) {
 				"port":     strconv.FormatInt(5432, 10),
 				"db_name":  "db1",
 				"name":     "db1",
+			},
+		},
+		"oracle-se2": {
+			credentialUtils: &RDSCredentialUtils{},
+			rdsInstance: &RDSInstance{
+				DbType:   "oracle-se2",
+				Username: "user-1",
+				Instance: base.Instance{
+					Host: "host",
+					Port: 1521,
+				},
+				Database:        "db-1",
+				credentialUtils: &RDSCredentialUtils{},
+			},
+			password: "fake-pw",
+			expectedCreds: map[string]string{
+				"uri":      "oracle://user-1:fake-pw@host:1521/ORCL",
+				"username": "user-1",
+				"password": "fake-pw",
+				"host":     "host",
+				"port":     strconv.FormatInt(1521, 10),
+				"db_name":  "ORCL",
+				"name":     "ORCL",
 			},
 		},
 		"unknown databse type": {

--- a/services/rds/credentials_test.go
+++ b/services/rds/credentials_test.go
@@ -81,13 +81,20 @@ func TestGetCredentials(t *testing.T) {
 			},
 			password: "fake-pw",
 			expectedCreds: map[string]string{
-				"uri":      "oracle://user-1:fake-pw@host:1521/ORCL",
-				"username": "user-1",
-				"password": "fake-pw",
-				"host":     "host",
-				"port":     strconv.FormatInt(1521, 10),
-				"db_name":  "ORCL",
-				"name":     "ORCL",
+				"uri":                 `oracle://user-1:fake-pw@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host)(PORT=2484))(CONNECT_DATA=(SID=ORCL)))`,
+				"jdbcUrl":             `jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=host)(PORT=2484))(CONNECT_DATA=(SID=ORCL)))`,
+				"username":            "user-1",
+				"password":            "fake-pw",
+				"host":                "host",
+				"port":                strconv.FormatInt(2484, 10),
+				"protocol":            "tcps",
+				"service_name":        "ORCL",
+				"sid":                 "ORCL",
+				"db_name":             "ORCL",
+				"name":                "ORCL",
+				"ssl_required":        "true",
+				"ssl_server_dn_match": "true",
+				"ca_cert_bundle_url":  "https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem",
 			},
 		},
 		"unknown databse type": {
@@ -142,5 +149,61 @@ func TestGetCredentials(t *testing.T) {
 				t.Error(diff)
 			}
 		})
+	}
+}
+
+func TestOracleBindingDoesNotLeakAdminMarkers(t *testing.T) {
+	u := &RDSCredentialUtils{}
+	i := &RDSInstance{
+		DbType:   "oracle-se2",
+		Username: "user-1",
+		Instance: base.Instance{
+			Host: "host",
+			Port: 1521,
+		},
+		Database:        "db-1",
+		credentialUtils: &RDSCredentialUtils{},
+	}
+
+	creds, err := u.getCredentials(i, "fake-pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{
+		"master_username",
+		"master_password",
+		"master_user_password",
+		"admin",
+		"admin_username",
+		"admin_password",
+		"is_master",
+		"role",
+	} {
+		if _, ok := creds[key]; ok {
+			t.Errorf("oracle binding must not expose admin key %q", key)
+		}
+	}
+
+	for _, key := range []string{
+		"uri",
+		"jdbcUrl",
+		"username",
+		"password",
+		"host",
+		"port",
+		"service_name",
+		"sid",
+		"ssl_required",
+		"ssl_server_dn_match",
+		"ca_cert_bundle_url",
+	} {
+		if _, ok := creds[key]; !ok {
+			t.Errorf("oracle binding missing expected key %q", key)
+		}
+	}
+
+	if creds["ssl_required"] != "true" {
+		t.Errorf("oracle binding ssl_required = %q, want true", creds["ssl_required"])
 	}
 }

--- a/services/rds/mocks_test.go
+++ b/services/rds/mocks_test.go
@@ -81,6 +81,9 @@ type mockOptionGroupClient struct {
 	provisionOrModifyCalled      bool
 	provisionOrModifyCreated     bool
 	provisionOrModifyOptGroupErr error
+	provisionBaselineCalled      bool
+	provisionBaselineErr         error
+	baselineOptionGroupName      string
 	deleteOptionGroupErr         error
 	deletedOptionGroupName       string
 	isCustomOptionGroup          bool
@@ -97,6 +100,17 @@ func (m *mockOptionGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstanc
 		i.OptionGroupName = m.optionGroupName
 	}
 	return m.provisionOrModifyCreated, nil
+}
+
+func (m *mockOptionGroupClient) ProvisionBaselineOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error {
+	m.provisionBaselineCalled = true
+	if m.provisionBaselineErr != nil {
+		return m.provisionBaselineErr
+	}
+	if m.baselineOptionGroupName != "" {
+		i.OptionGroupName = m.baselineOptionGroupName
+	}
+	return nil
 }
 
 func (m *mockOptionGroupClient) CleanupCustomOptionGroups() error {

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -152,9 +152,8 @@ func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfig
 }
 
 // ensureOptionGroupWithOptions is the shared describe→(create if absent)→modify
-// sequence used by both the create-time baseline path and the upgrade-reconcile
-// path. Idempotent: a group that already exists is not recreated; the options are
-// (re)applied via ModifyOptionGroup. Returns whether it created the group.
+// sequence used by both the create-time baseline and upgrade-reconcile paths.
+// Idempotent; returns whether it created the group.
 func (o *awsOptionsGroupClient) ensureOptionGroupWithOptions(
 	groupName, engineName, majorVersion, dbName string,
 	opts []rdsTypes.OptionConfiguration,
@@ -191,23 +190,16 @@ func (o *awsOptionsGroupClient) ensureOptionGroupWithOptions(
 }
 
 // ProvisionBaselineOptionGroup creates + attaches a broker-managed option group at
-// CREATE time for engines that ship a baseline option set (Oracle SE2: the SSL
-// option that opens the TCPS listener for FedRAMP-Moderate TLS). Unlike
-// ProvisionOrModifyCustomOptionGroup (which only reconciles an already-attached
-// group on major-version upgrade), this runs on a brand-new instance. It is a
-// no-op for engines with no baseline options (postgres/mysql), so their create
-// path is unchanged.
-//
-// On success it sets i.OptionGroupName so the create worker attaches it via
-// CreateDBInstanceInput.OptionGroupName. Fails closed: any AWS error aborts the
-// provision rather than leaving an Oracle instance without its TLS listener.
+// create time for engines with a baseline option set (Oracle SE2: the SSL/TCPS
+// option). No-op for engines without one (postgres/mysql). On success it sets
+// i.OptionGroupName so the create worker attaches it. Fails closed.
 func (o *awsOptionsGroupClient) ProvisionBaselineOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error {
 	opts, err := oracleBaselineOptions(i)
 	if err != nil {
 		return fmt.Errorf("ProvisionBaselineOptionGroup: %w", err)
 	}
 	if len(opts) == 0 {
-		return nil // engine has no baseline option group (postgres/mysql)
+		return nil
 	}
 
 	majorVersion, err := o.getMajorEngineVersion(i)
@@ -264,8 +256,8 @@ func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstanc
 	createdOptionGroup, err := o.ensureOptionGroupWithOptions(
 		targetOptionGroupName, i.DbType, targetMajorVersion, formatDBName(i.Database, i.DbType), existingOptions, rdsTags)
 	if err != nil {
-		// Preserve the original contract: any error on this path returns
-		// created=false, even if the group was created before the modify failed.
+		// created=false on any error, even if the group was created before the
+		// modify failed (preserves the original contract).
 		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
 	}
 

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -54,7 +54,7 @@ func (o *awsOptionsGroupClient) IsBrokerOptionGroup(optionGroupName string) bool
 }
 
 func (o *awsOptionsGroupClient) getOptionGroupName(i *RDSInstance, majorEngineVersion string) string {
-	return o.optionGroupPrefix + formatDBName(i.Database) + "-option-" + formatDBVersion(majorEngineVersion)
+	return o.optionGroupPrefix + formatDBName(i.Database, i.DbType) + "-option-" + formatDBVersion(majorEngineVersion)
 }
 
 func (o *awsOptionsGroupClient) getMajorEngineVersion(i *RDSInstance) (string, error) {
@@ -197,7 +197,7 @@ func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstanc
 			OptionGroupName:        aws.String(targetOptionGroupName),
 			EngineName:             aws.String(i.DbType),
 			MajorEngineVersion:     aws.String(targetMajorVersion),
-			OptionGroupDescription: aws.String("aws broker option group for " + formatDBName(i.Database)),
+			OptionGroupDescription: aws.String("aws broker option group for " + formatDBName(i.Database, i.DbType)),
 			Tags:                   rdsTags,
 		})
 		if err != nil {

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -20,6 +20,7 @@ const defaultOptionGroupPrefix = "default:"
 
 type optionGroupClient interface {
 	ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error)
+	ProvisionBaselineOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error
 	CleanupCustomOptionGroups() error
 	DeleteOptionGroup(optionGroupName string) error
 	IsCustomOptionGroup(optionGroupName string) bool
@@ -150,6 +151,79 @@ func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfig
 	return optionConfigs
 }
 
+// ensureOptionGroupWithOptions is the shared describe→(create if absent)→modify
+// sequence used by both the create-time baseline path and the upgrade-reconcile
+// path. Idempotent: a group that already exists is not recreated; the options are
+// (re)applied via ModifyOptionGroup. Returns whether it created the group.
+func (o *awsOptionsGroupClient) ensureOptionGroupWithOptions(
+	groupName, engineName, majorVersion, dbName string,
+	opts []rdsTypes.OptionConfiguration,
+	rdsTags []rdsTypes.Tag,
+) (bool, error) {
+	existing, err := o.describeOptionGroup(groupName)
+	if err != nil {
+		return false, err
+	}
+	created := false
+	if existing == nil {
+		log.Printf("creating option group %s for %s %s", groupName, engineName, majorVersion)
+		if _, err := o.rds.CreateOptionGroup(o.ctx, &rds.CreateOptionGroupInput{
+			OptionGroupName:        aws.String(groupName),
+			EngineName:             aws.String(engineName),
+			MajorEngineVersion:     aws.String(majorVersion),
+			OptionGroupDescription: aws.String("aws broker option group for " + dbName),
+			Tags:                   rdsTags,
+		}); err != nil {
+			return false, fmt.Errorf("create option group: %w", err)
+		}
+		created = true
+	}
+	if len(opts) > 0 {
+		if _, err := o.rds.ModifyOptionGroup(o.ctx, &rds.ModifyOptionGroupInput{
+			OptionGroupName:  aws.String(groupName),
+			OptionsToInclude: opts,
+			ApplyImmediately: aws.Bool(true),
+		}); err != nil {
+			return created, fmt.Errorf("add options to option group: %w", err)
+		}
+	}
+	return created, nil
+}
+
+// ProvisionBaselineOptionGroup creates + attaches a broker-managed option group at
+// CREATE time for engines that ship a baseline option set (Oracle SE2: the SSL
+// option that opens the TCPS listener for FedRAMP-Moderate TLS). Unlike
+// ProvisionOrModifyCustomOptionGroup (which only reconciles an already-attached
+// group on major-version upgrade), this runs on a brand-new instance. It is a
+// no-op for engines with no baseline options (postgres/mysql), so their create
+// path is unchanged.
+//
+// On success it sets i.OptionGroupName so the create worker attaches it via
+// CreateDBInstanceInput.OptionGroupName. Fails closed: any AWS error aborts the
+// provision rather than leaving an Oracle instance without its TLS listener.
+func (o *awsOptionsGroupClient) ProvisionBaselineOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error {
+	opts, err := oracleBaselineOptions(i)
+	if err != nil {
+		return fmt.Errorf("ProvisionBaselineOptionGroup: %w", err)
+	}
+	if len(opts) == 0 {
+		return nil // engine has no baseline option group (postgres/mysql)
+	}
+
+	majorVersion, err := o.getMajorEngineVersion(i)
+	if err != nil {
+		return fmt.Errorf("ProvisionBaselineOptionGroup: %w", err)
+	}
+	groupName := o.getOptionGroupName(i, majorVersion)
+
+	if _, err := o.ensureOptionGroupWithOptions(groupName, i.DbType, majorVersion, formatDBName(i.Database, i.DbType), opts, rdsTags); err != nil {
+		return fmt.Errorf("ProvisionBaselineOptionGroup: %w", err)
+	}
+
+	i.OptionGroupName = groupName
+	return nil
+}
+
 // Ensures that an instance with a custom option group keeps a valid one for its target database version.
 // On a major version upgrade, we create a new option group with the new target version carrying the same options.
 func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error) {
@@ -185,37 +259,14 @@ func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstanc
 		return false, nil
 	}
 
-	targetOptionGroup, err := o.describeOptionGroup(targetOptionGroupName)
-	if err != nil {
-		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
-	}
-
-	createdOptionGroup := false
-	if targetOptionGroup == nil {
-		log.Printf("creating option group %s for %s %s", targetOptionGroupName, i.DbType, targetMajorVersion)
-		_, err = o.rds.CreateOptionGroup(o.ctx, &rds.CreateOptionGroupInput{
-			OptionGroupName:        aws.String(targetOptionGroupName),
-			EngineName:             aws.String(i.DbType),
-			MajorEngineVersion:     aws.String(targetMajorVersion),
-			OptionGroupDescription: aws.String("aws broker option group for " + formatDBName(i.Database, i.DbType)),
-			Tags:                   rdsTags,
-		})
-		if err != nil {
-			return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: error creating option group: %w", err)
-		}
-		createdOptionGroup = true
-	}
-
+	// Recreate the group for the new major version, carrying the same options.
 	existingOptions := optionsFromGroup(existingOptionGroup)
-	if len(existingOptions) > 0 {
-		_, err = o.rds.ModifyOptionGroup(o.ctx, &rds.ModifyOptionGroupInput{
-			OptionGroupName:  aws.String(targetOptionGroupName),
-			OptionsToInclude: existingOptions,
-			ApplyImmediately: aws.Bool(true),
-		})
-		if err != nil {
-			return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: error adding options to option group: %w", err)
-		}
+	createdOptionGroup, err := o.ensureOptionGroupWithOptions(
+		targetOptionGroupName, i.DbType, targetMajorVersion, formatDBName(i.Database, i.DbType), existingOptions, rdsTags)
+	if err != nil {
+		// Preserve the original contract: any error on this path returns
+		// created=false, even if the group was created before the modify failed.
+		return false, fmt.Errorf("ProvisionOrModifyCustomOptionGroup: %w", err)
 	}
 
 	i.OptionGroupName = targetOptionGroupName

--- a/services/rds/option_group.go
+++ b/services/rds/option_group.go
@@ -151,8 +151,17 @@ func optionsFromGroup(optionGroup *rdsTypes.OptionGroup) []rdsTypes.OptionConfig
 	return optionConfigs
 }
 
-// ensureOptionGroupWithOptions is the shared describe→(create if absent)→modify
-// sequence used by both the create-time baseline and upgrade-reconcile paths.
+// ensureOptionGroupWithOptions is the single shared describe→(create if
+// absent)→modify sequence. Both public entry points funnel their AWS calls
+// through here so there is one implementation of the create/modify mechanics:
+//   - ProvisionBaselineOptionGroup (create-time): supplies the engine baseline
+//     options for a brand-new group.
+//   - ProvisionOrModifyCustomOptionGroup (modify-time): supplies the options
+//     copied from an existing custom group when migrating it to a new major
+//     version.
+//
+// The two callers differ only in *when* they fire and *which* options they
+// pass; the group create/modify mechanics live here and are not duplicated.
 // Idempotent; returns whether it created the group.
 func (o *awsOptionsGroupClient) ensureOptionGroupWithOptions(
 	groupName, engineName, majorVersion, dbName string,
@@ -193,6 +202,10 @@ func (o *awsOptionsGroupClient) ensureOptionGroupWithOptions(
 // create time for engines with a baseline option set (Oracle SE2: the SSL/TCPS
 // option). No-op for engines without one (postgres/mysql). On success it sets
 // i.OptionGroupName so the create worker attaches it. Fails closed.
+//
+// Distinct from ProvisionOrModifyCustomOptionGroup: this is the *create-time*
+// path (there is no prior group; options come from the engine baseline). Both
+// share ensureOptionGroupWithOptions for the actual create/modify calls.
 func (o *awsOptionsGroupClient) ProvisionBaselineOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) error {
 	opts, err := oracleBaselineOptions(i)
 	if err != nil {
@@ -218,6 +231,11 @@ func (o *awsOptionsGroupClient) ProvisionBaselineOptionGroup(i *RDSInstance, rds
 
 // Ensures that an instance with a custom option group keeps a valid one for its target database version.
 // On a major version upgrade, we create a new option group with the new target version carrying the same options.
+//
+// Distinct from ProvisionBaselineOptionGroup: this is the *modify-time* path.
+// It only acts on instances that already carry a custom option group and only
+// when the major version changes, carrying the existing options forward. Both
+// share ensureOptionGroupWithOptions for the actual create/modify calls.
 func (o *awsOptionsGroupClient) ProvisionOrModifyCustomOptionGroup(i *RDSInstance, rdsTags []rdsTypes.Tag) (bool, error) {
 	// For now, we only manage an option group for instances that
 	// already have a custom one attached (which is captured during the reconcile step)

--- a/services/rds/oracle_tls.go
+++ b/services/rds/oracle_tls.go
@@ -1,0 +1,109 @@
+package rds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// oracle_tls.go — the RDS-side change that actually makes brokered Oracle
+// connections use TLS. The binding credentials (credentials.go) already publish a
+// TCPS connect descriptor on port 2484, but that only tells a client HOW to
+// connect over TLS; without the broker provisioning + attaching an Oracle SSL
+// option group, RDS never opens the TCPS listener and the TLS endpoint does not
+// exist. This file supplies that missing server-side piece for oracle-se2.
+//
+// Scope: TLS/encryption-in-transit only (SC-8 / SC-8(1) / SC-13). The broader
+// Oracle hardening (parameter groups, log exports, identifier validation) lives
+// elsewhere and is intentionally NOT included here.
+//
+// HONESTY / SCOPE NOTES:
+//   - RDS Oracle serves TLS on a SEPARATE TCPS listener port (2484) via the SSL
+//     option below — unlike postgres/mysql, which negotiate TLS on their standard
+//     port. This port divergence is an AWS/Oracle architecture fact.
+//   - The broker attaches this option group and expresses the SSL intent (port
+//     2484, the plan security group), but it CANNOT make the connection TLS-only:
+//     opening 2484 ingress and DENYING plaintext 1521 is an EC2 security-group
+//     change owned by the platform (cg-provision/Terraform), outside the broker's
+//     IAM. Leaving 1521 open alongside 2484 is an SC-8 assessor finding, so the
+//     plan is NOT customer-ready until the platform SG rule lands.
+//   - TLS version ceiling: RDS Oracle SSL supports TLS 1.2 only (no 1.3). 1.2 is
+//     acceptable for FedRAMP Moderate.
+//   - Cipher/CA compatibility: the default RDS CA is RSA (rds-ca-rsa2048-g1),
+//     compatible with the ECDHE_RSA cipher below. ECDSA-only ciphers would require
+//     the ECC CA and are rejected fail-closed before the AWS call.
+
+const (
+	// oracleSSLPort is the TCPS listener port RDS Oracle exposes for TLS.
+	oracleSSLPort int32 = 2484
+
+	// oracleSSLOptionName is the RDS Oracle option that turns on the TCPS listener.
+	oracleSSLOptionName = "SSL"
+
+	// oracleCACertFamily is the RDS CA family brokered Oracle instances use. An
+	// "rsa" CA is compatible with TLS_ECDHE_RSA_* suites; an ECDSA-only suite would
+	// need "ecc".
+	oracleCACertFamily = "rsa"
+)
+
+// oracleSSLOptionSettings are the SQLNET/FIPS settings applied to the SSL option.
+// These are the FedRAMP-Moderate posture: TLS 1.2, a FIPS-validated AEAD suite
+// compatible with the RSA CA, and FIPS mode on (writes fips.ora SSLFIPS_140=TRUE).
+var oracleSSLOptionSettings = []rdsTypes.OptionSetting{
+	// TLS 1.2 only. RDS Oracle does not support 1.3 via the SSL option.
+	{Name: aws.String("SQLNET.SSL_VERSION"), Value: aws.String("1.2")},
+	// FedRAMP-compliant + FIPS + RSA-CA-compatible AEAD suite.
+	{Name: aws.String("SQLNET.CIPHER_SUITE"), Value: aws.String("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")},
+	// Force the RDS Oracle crypto module into FIPS 140 mode (SC-13).
+	{Name: aws.String("FIPS.SSLFIPS_140"), Value: aws.String("TRUE")},
+}
+
+// isOracleEngine reports whether an engine string is a supported Oracle edition.
+func isOracleEngine(dbType string) bool {
+	return dbType == "oracle-se1" || dbType == "oracle-se2"
+}
+
+// oracleSSLCipherCACompatible is a cheap fail-closed guard: an ECDSA-only cipher on
+// the RSA CA would fail opaquely at AWS when the option group is associated. The
+// shipped cipher above is ECDHE_RSA (RSA-CA compatible); the guard protects against
+// a future edit that weakens/misconfigures it.
+func oracleSSLCipherCACompatible() error {
+	var cipher string
+	for _, s := range oracleSSLOptionSettings {
+		if aws.ToString(s.Name) == "SQLNET.CIPHER_SUITE" {
+			cipher = aws.ToString(s.Value)
+			break
+		}
+	}
+	if strings.Contains(cipher, "_ECDSA_") && strings.EqualFold(oracleCACertFamily, "rsa") {
+		return fmt.Errorf("oracle SSL: cipher %q is ECDSA-only but the CA family is %q (RSA); use an ECDHE_RSA cipher or an ECC CA", cipher, oracleCACertFamily)
+	}
+	return nil
+}
+
+// oracleBaselineOptions returns the option-group options a brokered Oracle instance
+// is provisioned with at CREATE time: the SSL/TCPS option that enables TLS. The SSL
+// listener is gated by the instance's security group. Returns nil for non-Oracle
+// engines (postgres/mysql have no baseline option group). Fails closed if the
+// cipher/CA guard trips.
+func oracleBaselineOptions(i *RDSInstance) ([]rdsTypes.OptionConfiguration, error) {
+	if i == nil || !isOracleEngine(i.DbType) {
+		return nil, nil
+	}
+	if err := oracleSSLCipherCACompatible(); err != nil {
+		return nil, err
+	}
+
+	ssl := rdsTypes.OptionConfiguration{
+		OptionName:     aws.String(oracleSSLOptionName),
+		Port:           aws.Int32(oracleSSLPort),
+		OptionSettings: oracleSSLOptionSettings,
+	}
+	// The SSL/TCPS listener is gated by the instance's security group.
+	if i.SecGroup != "" {
+		ssl.VpcSecurityGroupMemberships = []string{i.SecGroup}
+	}
+	return []rdsTypes.OptionConfiguration{ssl}, nil
+}

--- a/services/rds/oracle_tls.go
+++ b/services/rds/oracle_tls.go
@@ -8,67 +8,42 @@ import (
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
-// oracle_tls.go — the RDS-side change that actually makes brokered Oracle
-// connections use TLS. The binding credentials (credentials.go) already publish a
-// TCPS connect descriptor on port 2484, but that only tells a client HOW to
-// connect over TLS; without the broker provisioning + attaching an Oracle SSL
-// option group, RDS never opens the TCPS listener and the TLS endpoint does not
-// exist. This file supplies that missing server-side piece for oracle-se2.
+// oracle_tls.go — server-side TLS enablement for brokered Oracle. credentials.go
+// publishes a TCPS descriptor on 2484, but RDS only opens that listener when an
+// Oracle SSL option group is attached; this file provisions it (oracle-se2 only).
 //
-// Scope: TLS/encryption-in-transit only (SC-8 / SC-8(1) / SC-13). The broader
-// Oracle hardening (parameter groups, log exports, identifier validation) lives
-// elsewhere and is intentionally NOT included here.
+// Scope: encryption-in-transit only (SC-8 / SC-8(1) / SC-13).
 //
-// HONESTY / SCOPE NOTES:
-//   - RDS Oracle serves TLS on a SEPARATE TCPS listener port (2484) via the SSL
-//     option below — unlike postgres/mysql, which negotiate TLS on their standard
-//     port. This port divergence is an AWS/Oracle architecture fact.
-//   - The broker attaches this option group and expresses the SSL intent (port
-//     2484, the plan security group), but it CANNOT make the connection TLS-only:
-//     opening 2484 ingress and DENYING plaintext 1521 is an EC2 security-group
-//     change owned by the platform (cg-provision/Terraform), outside the broker's
-//     IAM. Leaving 1521 open alongside 2484 is an SC-8 assessor finding, so the
-//     plan is NOT customer-ready until the platform SG rule lands.
-//   - TLS version ceiling: RDS Oracle SSL supports TLS 1.2 only (no 1.3). 1.2 is
-//     acceptable for FedRAMP Moderate.
-//   - Cipher/CA compatibility: the default RDS CA is RSA (rds-ca-rsa2048-g1),
-//     compatible with the ECDHE_RSA cipher below. ECDSA-only ciphers would require
-//     the ECC CA and are rejected fail-closed before the AWS call.
+// Known gap: the broker attaches the SSL option and opens 2484, but cannot deny
+// plaintext 1521 — that security-group rule is owned by the platform
+// (cg-provision/Terraform), outside the broker's IAM. Until it lands, 1521 stays
+// open alongside 2484, which is an SC-8 assessor finding, so the plan is not
+// customer-ready.
 
 const (
-	// oracleSSLPort is the TCPS listener port RDS Oracle exposes for TLS.
-	oracleSSLPort int32 = 2484
+	oracleSSLPort       int32 = 2484
+	oracleSSLOptionName       = "SSL"
 
-	// oracleSSLOptionName is the RDS Oracle option that turns on the TCPS listener.
-	oracleSSLOptionName = "SSL"
-
-	// oracleCACertFamily is the RDS CA family brokered Oracle instances use. An
-	// "rsa" CA is compatible with TLS_ECDHE_RSA_* suites; an ECDSA-only suite would
-	// need "ecc".
+	// RDS default CA is RSA (rds-ca-rsa2048-g1); compatible with ECDHE_RSA
+	// ciphers. An ECDSA-only suite would require the "ecc" CA family.
 	oracleCACertFamily = "rsa"
 )
 
-// oracleSSLOptionSettings are the SQLNET/FIPS settings applied to the SSL option.
-// These are the FedRAMP-Moderate posture: TLS 1.2, a FIPS-validated AEAD suite
-// compatible with the RSA CA, and FIPS mode on (writes fips.ora SSLFIPS_140=TRUE).
+// FedRAMP-Moderate posture: TLS 1.2 (RDS Oracle has no 1.3), a FIPS-validated
+// RSA-CA-compatible AEAD suite, FIPS mode on.
 var oracleSSLOptionSettings = []rdsTypes.OptionSetting{
-	// TLS 1.2 only. RDS Oracle does not support 1.3 via the SSL option.
 	{Name: aws.String("SQLNET.SSL_VERSION"), Value: aws.String("1.2")},
-	// FedRAMP-compliant + FIPS + RSA-CA-compatible AEAD suite.
 	{Name: aws.String("SQLNET.CIPHER_SUITE"), Value: aws.String("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")},
-	// Force the RDS Oracle crypto module into FIPS 140 mode (SC-13).
 	{Name: aws.String("FIPS.SSLFIPS_140"), Value: aws.String("TRUE")},
 }
 
-// isOracleEngine reports whether an engine string is a supported Oracle edition.
 func isOracleEngine(dbType string) bool {
 	return dbType == "oracle-se1" || dbType == "oracle-se2"
 }
 
-// oracleSSLCipherCACompatible is a cheap fail-closed guard: an ECDSA-only cipher on
-// the RSA CA would fail opaquely at AWS when the option group is associated. The
-// shipped cipher above is ECDHE_RSA (RSA-CA compatible); the guard protects against
-// a future edit that weakens/misconfigures it.
+// oracleSSLCipherCACompatible fails closed on an ECDSA-only cipher over the RSA
+// CA (which would otherwise fail opaquely at AWS); guards against a future edit
+// weakening the shipped ECDHE_RSA suite.
 func oracleSSLCipherCACompatible() error {
 	var cipher string
 	for _, s := range oracleSSLOptionSettings {
@@ -83,11 +58,9 @@ func oracleSSLCipherCACompatible() error {
 	return nil
 }
 
-// oracleBaselineOptions returns the option-group options a brokered Oracle instance
-// is provisioned with at CREATE time: the SSL/TCPS option that enables TLS. The SSL
-// listener is gated by the instance's security group. Returns nil for non-Oracle
-// engines (postgres/mysql have no baseline option group). Fails closed if the
-// cipher/CA guard trips.
+// oracleBaselineOptions returns the create-time option-group options for a
+// brokered Oracle instance (the SSL/TCPS option). Returns nil for non-Oracle
+// engines. Fails closed if the cipher/CA guard trips.
 func oracleBaselineOptions(i *RDSInstance) ([]rdsTypes.OptionConfiguration, error) {
 	if i == nil || !isOracleEngine(i.DbType) {
 		return nil, nil
@@ -101,7 +74,6 @@ func oracleBaselineOptions(i *RDSInstance) ([]rdsTypes.OptionConfiguration, erro
 		Port:           aws.Int32(oracleSSLPort),
 		OptionSettings: oracleSSLOptionSettings,
 	}
-	// The SSL/TCPS listener is gated by the instance's security group.
 	if i.SecGroup != "" {
 		ssl.VpcSecurityGroupMemberships = []string{i.SecGroup}
 	}

--- a/services/rds/oracle_tls_test.go
+++ b/services/rds/oracle_tls_test.go
@@ -1,0 +1,150 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// oracle_tls_test.go — the SSL/TCPS option baseline is the RDS-side change that
+// makes brokered Oracle connections actually use TLS. These tests assert the
+// FedRAMP-Moderate posture is shipped and that the create-time provisioning path
+// creates + attaches the option group.
+
+func sslSettingsMap(opt rdsTypes.OptionConfiguration) map[string]string {
+	m := map[string]string{}
+	for _, s := range opt.OptionSettings {
+		m[aws.ToString(s.Name)] = aws.ToString(s.Value)
+	}
+	return m
+}
+
+func TestOracleBaselineOptionsBuildsSSL(t *testing.T) {
+	i := &RDSInstance{DbType: "oracle-se2", SecGroup: "sg-1"}
+	opts, err := oracleBaselineOptions(i)
+	if err != nil {
+		t.Fatalf("oracleBaselineOptions error: %v", err)
+	}
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 baseline option (SSL), got %d", len(opts))
+	}
+	ssl := opts[0]
+	if aws.ToString(ssl.OptionName) != "SSL" {
+		t.Errorf("option name = %q, want SSL", aws.ToString(ssl.OptionName))
+	}
+	if aws.ToInt32(ssl.Port) != 2484 {
+		t.Errorf("SSL option port = %d, want 2484", aws.ToInt32(ssl.Port))
+	}
+	if len(ssl.VpcSecurityGroupMemberships) != 1 || ssl.VpcSecurityGroupMemberships[0] != "sg-1" {
+		t.Errorf("SSL option must reference the instance SG, got %v", ssl.VpcSecurityGroupMemberships)
+	}
+}
+
+// TestOracleSSLBaselineIsFedRAMPCompliant is the CI gate for the SSL security
+// posture: TLS 1.2 + FIPS on + a FedRAMP/FIPS allowlisted cipher. A weakened
+// oracle_tls.go fails go test and never merges.
+func TestOracleSSLBaselineIsFedRAMPCompliant(t *testing.T) {
+	fedrampCiphers := map[string]struct{}{
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": {},
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": {},
+	}
+
+	opts, err := oracleBaselineOptions(&RDSInstance{DbType: "oracle-se2"})
+	if err != nil {
+		t.Fatalf("oracleBaselineOptions error: %v", err)
+	}
+	s := sslSettingsMap(opts[0])
+
+	if v := s["SQLNET.SSL_VERSION"]; v != "1.2" {
+		t.Errorf("SQLNET.SSL_VERSION=%q, require exactly \"1.2\" (FedRAMP floor; RDS Oracle ceiling)", v)
+	}
+	if v := s["FIPS.SSLFIPS_140"]; v != "TRUE" {
+		t.Errorf("FIPS.SSLFIPS_140=%q, require TRUE (SC-13)", v)
+	}
+	cipher, ok := s["SQLNET.CIPHER_SUITE"]
+	if !ok || cipher == "" {
+		t.Fatal("SQLNET.CIPHER_SUITE missing from SSL baseline")
+	}
+	if _, ok := fedrampCiphers[cipher]; !ok {
+		t.Errorf("cipher %q is not on the FedRAMP/FIPS allowlist", cipher)
+	}
+}
+
+// TestOracleBaselineOptionsNoOpForNonOracle: postgres/mysql have no baseline
+// option group, so their create path is unchanged (nil options).
+func TestOracleBaselineOptionsNoOpForNonOracle(t *testing.T) {
+	for _, eng := range []string{"postgres", "mysql", ""} {
+		opts, err := oracleBaselineOptions(&RDSInstance{DbType: eng})
+		if err != nil || opts != nil {
+			t.Errorf("%q oracleBaselineOptions = (%v,%v), want (nil,nil)", eng, opts, err)
+		}
+	}
+}
+
+// TestProvisionBaselineOptionGroup_Oracle exercises the create-time
+// describe→create→modify→attach sequence for an Oracle instance.
+func TestProvisionBaselineOptionGroup_Oracle(t *testing.T) {
+	optionGroupNotFound := &rdsTypes.OptionGroupNotFoundFault{}
+	mockRDS := &mockRDSClient{
+		// First describe (does the target group exist?) returns not-found so the
+		// group is created.
+		describeOptionGroupsErrs: []error{optionGroupNotFound},
+		dbEngineVersions: []rdsTypes.DBEngineVersion{
+			{MajorEngineVersion: aws.String("19")},
+		},
+	}
+	o := newTestOptionGroupClient(mockRDS)
+
+	i := &RDSInstance{
+		Database:  "db1",
+		DbType:    "oracle-se2",
+		DbVersion: "19.0.0.0.ru-2024-01.rur-2024-01.r1",
+		SecGroup:  "sg-1",
+	}
+
+	if err := o.ProvisionBaselineOptionGroup(i, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expectedName := "cg-aws-broker-ORCL-option-19"
+	if i.OptionGroupName != expectedName {
+		t.Errorf("expected OptionGroupName %q, got %q", expectedName, i.OptionGroupName)
+	}
+	if mockRDS.createOptionGroupInput == nil {
+		t.Fatal("expected CreateOptionGroup to be called")
+	}
+	if got := aws.ToString(mockRDS.createOptionGroupInput.EngineName); got != "oracle-se2" {
+		t.Errorf("expected EngineName oracle-se2, got %q", got)
+	}
+	if mockRDS.modifyOptionGroupInput == nil {
+		t.Fatal("expected ModifyOptionGroup to be called to add the SSL option")
+	}
+	var sslFound bool
+	for _, opt := range mockRDS.modifyOptionGroupInput.OptionsToInclude {
+		if aws.ToString(opt.OptionName) == "SSL" {
+			sslFound = true
+		}
+	}
+	if !sslFound {
+		t.Errorf("expected SSL option to be added, got %v", mockRDS.modifyOptionGroupInput.OptionsToInclude)
+	}
+}
+
+// TestProvisionBaselineOptionGroup_NoOpForNonOracle: postgres/mysql must not touch
+// option groups at create time.
+func TestProvisionBaselineOptionGroup_NoOpForNonOracle(t *testing.T) {
+	mockRDS := &mockRDSClient{}
+	o := newTestOptionGroupClient(mockRDS)
+
+	i := &RDSInstance{Database: "db1", DbType: "postgres", DbVersion: "16.13"}
+	if err := o.ProvisionBaselineOptionGroup(i, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if i.OptionGroupName != "" {
+		t.Errorf("expected no option group for postgres, got %q", i.OptionGroupName)
+	}
+	if mockRDS.createOptionGroupInput != nil {
+		t.Error("expected CreateOptionGroup not to be called for postgres")
+	}
+}

--- a/services/rds/oracle_tls_test.go
+++ b/services/rds/oracle_tls_test.go
@@ -7,11 +7,6 @@ import (
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
-// oracle_tls_test.go — the SSL/TCPS option baseline is the RDS-side change that
-// makes brokered Oracle connections actually use TLS. These tests assert the
-// FedRAMP-Moderate posture is shipped and that the create-time provisioning path
-// creates + attaches the option group.
-
 func sslSettingsMap(opt rdsTypes.OptionConfiguration) map[string]string {
 	m := map[string]string{}
 	for _, s := range opt.OptionSettings {
@@ -41,9 +36,8 @@ func TestOracleBaselineOptionsBuildsSSL(t *testing.T) {
 	}
 }
 
-// TestOracleSSLBaselineIsFedRAMPCompliant is the CI gate for the SSL security
-// posture: TLS 1.2 + FIPS on + a FedRAMP/FIPS allowlisted cipher. A weakened
-// oracle_tls.go fails go test and never merges.
+// TestOracleSSLBaselineIsFedRAMPCompliant gates the SSL posture: TLS 1.2 + FIPS
+// on + a FedRAMP/FIPS allowlisted cipher.
 func TestOracleSSLBaselineIsFedRAMPCompliant(t *testing.T) {
 	fedrampCiphers := map[string]struct{}{
 		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": {},
@@ -71,8 +65,7 @@ func TestOracleSSLBaselineIsFedRAMPCompliant(t *testing.T) {
 	}
 }
 
-// TestOracleBaselineOptionsNoOpForNonOracle: postgres/mysql have no baseline
-// option group, so their create path is unchanged (nil options).
+// TestOracleBaselineOptionsNoOpForNonOracle: postgres/mysql yield nil options.
 func TestOracleBaselineOptionsNoOpForNonOracle(t *testing.T) {
 	for _, eng := range []string{"postgres", "mysql", ""} {
 		opts, err := oracleBaselineOptions(&RDSInstance{DbType: eng})
@@ -87,8 +80,7 @@ func TestOracleBaselineOptionsNoOpForNonOracle(t *testing.T) {
 func TestProvisionBaselineOptionGroup_Oracle(t *testing.T) {
 	optionGroupNotFound := &rdsTypes.OptionGroupNotFoundFault{}
 	mockRDS := &mockRDSClient{
-		// First describe (does the target group exist?) returns not-found so the
-		// group is created.
+		// not-found → the group is created
 		describeOptionGroupsErrs: []error{optionGroupNotFound},
 		dbEngineVersions: []rdsTypes.DBEngineVersion{
 			{MajorEngineVersion: aws.String("19")},
@@ -131,8 +123,8 @@ func TestProvisionBaselineOptionGroup_Oracle(t *testing.T) {
 	}
 }
 
-// TestProvisionBaselineOptionGroup_NoOpForNonOracle: postgres/mysql must not touch
-// option groups at create time.
+// TestProvisionBaselineOptionGroup_NoOpForNonOracle: postgres/mysql must not
+// touch option groups at create time.
 func TestProvisionBaselineOptionGroup_NoOpForNonOracle(t *testing.T) {
 	mockRDS := &mockRDSClient{}
 	o := newTestOptionGroupClient(mockRDS)

--- a/services/rds/oracle_tls_test.go
+++ b/services/rds/oracle_tls_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/go-test/deep"
 )
 
 func sslSettingsMap(opt rdsTypes.OptionConfiguration) map[string]string {
@@ -21,18 +22,17 @@ func TestOracleBaselineOptionsBuildsSSL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("oracleBaselineOptions error: %v", err)
 	}
-	if len(opts) != 1 {
-		t.Fatalf("expected 1 baseline option (SSL), got %d", len(opts))
+
+	expected := []rdsTypes.OptionConfiguration{
+		{
+			OptionName:                  aws.String(oracleSSLOptionName),
+			Port:                        aws.Int32(oracleSSLPort),
+			OptionSettings:              oracleSSLOptionSettings,
+			VpcSecurityGroupMemberships: []string{"sg-1"},
+		},
 	}
-	ssl := opts[0]
-	if aws.ToString(ssl.OptionName) != "SSL" {
-		t.Errorf("option name = %q, want SSL", aws.ToString(ssl.OptionName))
-	}
-	if aws.ToInt32(ssl.Port) != 2484 {
-		t.Errorf("SSL option port = %d, want 2484", aws.ToInt32(ssl.Port))
-	}
-	if len(ssl.VpcSecurityGroupMemberships) != 1 || ssl.VpcSecurityGroupMemberships[0] != "sg-1" {
-		t.Errorf("SSL option must reference the instance SG, got %v", ssl.VpcSecurityGroupMemberships)
+	if diff := deep.Equal(opts, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -50,12 +50,20 @@ func TestOracleSSLBaselineIsFedRAMPCompliant(t *testing.T) {
 	}
 	s := sslSettingsMap(opts[0])
 
-	if v := s["SQLNET.SSL_VERSION"]; v != "1.2" {
-		t.Errorf("SQLNET.SSL_VERSION=%q, require exactly \"1.2\" (FedRAMP floor; RDS Oracle ceiling)", v)
+	// Exact-match settings: compare as a map so a failure prints the full diff.
+	fixed := map[string]string{
+		"SQLNET.SSL_VERSION": s["SQLNET.SSL_VERSION"],
+		"FIPS.SSLFIPS_140":   s["FIPS.SSLFIPS_140"],
 	}
-	if v := s["FIPS.SSLFIPS_140"]; v != "TRUE" {
-		t.Errorf("FIPS.SSLFIPS_140=%q, require TRUE (SC-13)", v)
+	wantFixed := map[string]string{
+		"SQLNET.SSL_VERSION": "1.2",  // FedRAMP floor; RDS Oracle ceiling
+		"FIPS.SSLFIPS_140":   "TRUE", // SC-13
 	}
+	if diff := deep.Equal(fixed, wantFixed); diff != nil {
+		t.Error(diff)
+	}
+
+	// Cipher is an allowlist membership check, not a single fixed value.
 	cipher, ok := s["SQLNET.CIPHER_SUITE"]
 	if !ok || cipher == "" {
 		t.Fatal("SQLNET.CIPHER_SUITE missing from SSL baseline")
@@ -69,8 +77,11 @@ func TestOracleSSLBaselineIsFedRAMPCompliant(t *testing.T) {
 func TestOracleBaselineOptionsNoOpForNonOracle(t *testing.T) {
 	for _, eng := range []string{"postgres", "mysql", ""} {
 		opts, err := oracleBaselineOptions(&RDSInstance{DbType: eng})
-		if err != nil || opts != nil {
-			t.Errorf("%q oracleBaselineOptions = (%v,%v), want (nil,nil)", eng, opts, err)
+		if err != nil {
+			t.Errorf("%q oracleBaselineOptions returned error %v, want nil", eng, err)
+		}
+		if diff := deep.Equal(opts, []rdsTypes.OptionConfiguration(nil)); diff != nil {
+			t.Errorf("%q: %v", eng, diff)
 		}
 	}
 }

--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -275,7 +275,7 @@ func (p *awsParameterGroupClient) createOrModifyCustomParameterGroup(
 		createInput := &rds.CreateDBParameterGroupInput{
 			DBParameterGroupFamily: aws.String(i.ParameterGroupFamily),
 			DBParameterGroupName:   aws.String(i.ParameterGroupName),
-			Description:            aws.String("aws broker parameter group for " + formatDBName(i.Database)),
+			Description:            aws.String("aws broker parameter group for " + formatDBName(i.Database, i.DbType)),
 			Tags:                   rdsTags,
 		}
 
@@ -606,7 +606,7 @@ func boolToParamvalue(b bool) string {
 func getParameterGroupName(i *RDSInstance, p *awsParameterGroupClient) string {
 	// formatDBName() should always return the same value for the same database name,
 	// so the parameter group name should remain consistent
-	return p.parameterGroupPrefix + formatDBName(i.Database) + "-version-" + formatDBVersion(i.DbVersion)
+	return p.parameterGroupPrefix + formatDBName(i.Database, i.DbType) + "-version-" + formatDBVersion(i.DbVersion)
 }
 
 func formatDBVersion(version string) string {


### PR DESCRIPTION
## Scope: Oracle TLS only

This PR is deliberately **narrow**. It adds the minimum needed to bring up an
Oracle SE2 RDS instance that serves **TLS (TCPS)** and to hand bound apps the
coordinates + trust anchor to connect over it. It does **not** attempt the full
Oracle STIG/hardening surface — that is intentionally out of scope here.

### Why so constrained

My intent (Peter's) is that small, single-purpose PRs are easier to review. 

Landing an incomplete STIG posture on main is a no-op — nothing provisions Oracle until someone explicitly does so on the CLI, so this won't end in staging or production.  The code here is what I'm running in `dev` to provision the instance I have under test.


### What this PR does

- **Server-side TLS enablement** (`services/rds/oracle_tls.go`,
  `option_group.go`, `create_worker.go`): provision + attach an Oracle **SSL
  option group** at create time so RDS opens the **TCPS listener on 2484**.
  FedRAMP-Moderate posture: TLS 1.2, FIPS mode on, an RSA-CA-compatible AEAD
  cipher; fails closed on a cipher/CA mismatch. No-op for postgres/mysql.
- **Binding credentials** (`services/rds/credentials.go`): emit a TCPS connect
  descriptor (port 2484, `PROTOCOL=TCPS`), plus `ssl_required` /
  `ssl_server_dn_match` to signal that server-cert verification is mandatory. The
  binding does **not** ship a `ca_cert_bundle_url`: the RDS GovCloud truststore
  host is not on the platform egress allowlist, so a bound app cannot fetch it at
  runtime — apps vendor the GovCloud RDS CA bundle offline instead (customer docs
  tracked separately).
- **Oracle DB name/identifier** handling (`formatDBName` → `ORCL`) and supporting
  tests.
- **CI/catalog plumbing** to make an Oracle SE2 plan buildable (catalog template,
  pipeline, rds_module engine default, config poll-duration assertions).

### Known gap (explicitly out of scope)

The broker opens **2484** but cannot **deny plaintext 1521** — that ingress rule
is an EC2 security-group change owned by the platform (cg-provision/Terraform),
outside the broker's IAM. Until that lands, 1521 remains open alongside 2484,
which is an SC-8 assessor finding. **The Oracle plan is therefore not
customer-ready** and must not be enabled in staging/production yet. This is
documented in `oracle_tls.go`.

**SC-8 enablement gate (traceability).** The plaintext-1521 closure is tracked
by:

- **aws-broker#541** — broker-side tracking of the "allow TCPS 2484 / deny
  plaintext 1521" requirement (SC-8).
- **cg-provision#2351** — refactor the Oracle SG rules to standalone
  `aws_security_group_rule` resources (adds 2484 + 1521); unblocks #2348.
- **cg-provision#2348** — remove the plaintext 1521 ingress rule (TLS-only); the
  actual SC-8 closure, gated on all Oracle consumers using 2484/TLS first.

The Oracle plan MUST NOT be enabled in staging/production until
**cg-provision#2348** lands.

### Relationship to #537

This PR overlaps #537 (the broad Oracle-19c STIG PR) on `option_group.go`,
`credentials.go`, and the catalog template. Both remain open and are
**coordinated through the merge-order / status board in #550** — reviewers
should sequence the two there rather than treat either as superseding the other.
#564 is the narrow encryption-in-transit slice; #537 carries the broader
hardening surface.

### Compliance

Scope is encryption-in-transit only: **SC-8 / SC-8(1) / SC-13**. Broader Oracle
hardening (parameter groups, log exports, etc.) is tracked separately.

### Verification

- `go build ./...`, `go vet ./services/rds/...` — pass
- `go test ./services/rds/... ./config/...` — pass
- `gofmt` — clean

### Rollback

Revert the PR. No production impact: Oracle is not enabled in staging/prod, and
this is inert until an Oracle instance is manually provisioned.

---

> Draft: signatures are being reconciled to the platform's required GnuPG format
> outside CI; do not merge until commit signatures show verified.

