### PR TITLE
test(config): fix PollAwsMaxDuration assertions (unbreak main)

### DIFF
--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -44,7 +44,7 @@ func TestSettings(t *testing.T) {
 		CfApiClientId:             "fake-client-id",
 		CfApiClientSecret:         "fake-client-secret",
 		PollAwsMinDelay:           30 * time.Second,
-		PollAwsMaxDuration:        3600 * time.Second,
+		PollAwsMaxDuration:        7200 * time.Second,
 		PollAwsMaxRetries:         60,
 		Port:                      "3000",
 	}
@@ -90,7 +90,7 @@ func TestSettingsPort(t *testing.T) {
 		CfApiClientId:             "fake-client-id",
 		CfApiClientSecret:         "fake-client-secret",
 		PollAwsMinDelay:           30 * time.Second,
-		PollAwsMaxDuration:        3600 * time.Second,
+		PollAwsMaxDuration:        7200 * time.Second,
 		PollAwsMaxRetries:         60,
 		Port:                      "5000",
 	}


### PR DESCRIPTION
Unbreaks `go test ./config/` on `main`: #563 (aa4a4c8) bumped the
`PollAwsMaxDuration` default to 7200s but left the `TestSettings` /
`TestSettingsPort` assertions at 3600s. Syncs them to 7200s.

Test-only; revert to roll back.
