### PR TITLE
ci: pin internal RDS Postgres to 16.13 (fix downgrade error)

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
           TF_VAR_rds_internal_db_size: 20
           TF_VAR_rds_internal_db_name: ((development-rds-internal-db-name))
           TF_VAR_rds_internal_db_engine: postgres
-          TF_VAR_rds_internal_db_engine_version: 16.8
+          TF_VAR_rds_internal_db_engine_version: 16.13
           TF_VAR_rds_internal_db_parameter_group_family: postgres16
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_internal_multi_az: false
@@ -756,7 +756,7 @@ jobs:
           TF_VAR_rds_internal_db_size: 20
           TF_VAR_rds_internal_db_name: ((staging-rds-internal-db-name))
           TF_VAR_rds_internal_db_engine: postgres
-          TF_VAR_rds_internal_db_engine_version: 16.8
+          TF_VAR_rds_internal_db_engine_version: 16.13
           TF_VAR_rds_internal_db_parameter_group_family: postgres16
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_internal_multi_az: false
@@ -1438,7 +1438,7 @@ jobs:
           TF_VAR_rds_internal_db_size: 20
           TF_VAR_rds_internal_db_name: ((prod-rds-internal-db-name))
           TF_VAR_rds_internal_db_engine: postgres
-          TF_VAR_rds_internal_db_engine_version: 16.8
+          TF_VAR_rds_internal_db_engine_version: 16.13
           TF_VAR_rds_internal_db_parameter_group_family: postgres16
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_internal_multi_az: true


### PR DESCRIPTION
Pins the broker's internal RDS Postgres to **16.13** (dev/staging/prod) to match
the minor version RDS auto-applied. The pipeline still specified 16.8, so
Terraform attempted a downgrade that RDS rejects (`InvalidParameterCombination:
Cannot find upgrade path from 16.13 to 16.8`). Same `postgres16` family; no
parameter-group change.

## Security Considerations

- No change to authentication, authorization, data handling, or attack surface.
- CI-only: edits `ci/pipeline.yml` engine-version variables; no application code.
- Applies a minor Postgres version RDS already installed (keeps current security
  patch level; no downgrade).
- Rollback: revert the PR.
