### PR TITLE
feat(catalog): add opt-in medium-oracle-se2-redundant (Multi-AZ) plan

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1301,6 +1301,39 @@ rds:
         environment: (( grab meta.environment ))
         client: "paas-cf"
         broker: "AWS broker"
+    - id: "7bbb10f9-ddd5-4269-b267-177a97a5b1b1"
+      name: &medium-oracle-se2-redundant-name "medium-oracle-se2-redundant"
+      description: "Multi-AZ RDS instance of Oracle SE2, minimum 2 core, minimum 4 GiB memory"
+      metadata:
+        bullets:
+          - *multi-az-rds
+          - *oracle-se2
+          - *minimum-2-cores
+          - *minimum-4-gib-memory
+          - *default-20-gb-storage
+          - *license-included
+        costs:
+          - amount:
+              usd: 236
+            unit: "MONTHLY"
+        displayName: *medium-oracle-se2-redundant-name
+      free: false
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      allocatedStorage: 20
+      dbType: oracle-se2
+      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
+      licenseModel: license-included
+      redundant: true
+      encrypted: true
+      storage_type: gp3
+      backup_retention_period: 14
+      securityGroup: (( grab meta.aws_broker.oracle_security_group ))
+      subnetGroup: (( grab meta.aws_broker.subnet_group ))
+      tags:
+        environment: (( grab meta.environment ))
+        client: "paas-cf"
+        broker: "AWS broker"
 
 redis:
   id: "cda65825-e357-4a93-a24b-9ab138d97815"

--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -1289,7 +1289,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       dbType: oracle-se2
-      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
+      dbVersion: &default-oracle-version "19.0.0.0.ru-2026-04.rur-2026-04.r1"
       licenseModel: license-included
       redundant: false
       encrypted: true
@@ -1322,7 +1322,7 @@ rds:
       instanceClass: db.t3.medium
       allocatedStorage: 20
       dbType: oracle-se2
-      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
+      dbVersion: *default-oracle-version
       licenseModel: license-included
       redundant: true
       encrypted: true

--- a/catalog-test.yml
+++ b/catalog-test.yml
@@ -285,3 +285,53 @@ rds:
         environment: "cf-env"
         client: "the client"
         service: "aws-broker"
+    - id: "da91e15c-98c9-46a9-b114-02b8d28062c8"
+      name: "medium-oracle-se2"
+      description: "Single-AZ RDS instance of Oracle SE2"
+      metadata:
+        bullets:
+          - "Single-AZ RDS instance"
+          - "Oracle Standard Edition 2"
+        displayName: "Dedicated Medium Oracle SE2"
+      free: false
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      dbType: oracle-se2
+      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
+      licenseModel: license-included
+      allocatedStorage: 20
+      redundant: false
+      plan_updateable: true
+      securityGroup: sg-123456
+      storage_type: gp3
+      backup_retention_period: 14
+      subnetGroup: subnet-group
+      tags:
+        environment: "cf-env"
+        client: "the client"
+        service: "aws-broker"
+    - id: "da91e15c-98c9-46a9-b114-02b8d28062c9"
+      name: "medium-oracle-se2-redundant"
+      description: "Multi-AZ RDS instance of Oracle SE2"
+      metadata:
+        bullets:
+          - "Multi-AZ RDS instance"
+          - "Oracle Standard Edition 2"
+        displayName: "Dedicated Medium Oracle SE2 (redundant)"
+      free: false
+      adapter: dedicated
+      instanceClass: db.t3.medium
+      dbType: oracle-se2
+      dbVersion: "19.0.0.0.ru-2026-04.rur-2026-04.r1"
+      licenseModel: license-included
+      allocatedStorage: 20
+      redundant: true
+      plan_updateable: true
+      securityGroup: sg-123456
+      storage_type: gp3
+      backup_retention_period: 14
+      subnetGroup: subnet-group
+      tags:
+        environment: "cf-env"
+        client: "the client"
+        service: "aws-broker"

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -14,6 +14,9 @@ var rdsMySQLTestPlanID = "da91e15c-98c9-46a9-b114-02b8d28062c7"
 var rdsMySQLValidVersion = "8.4"
 var rdsMySQLInvalidVersion = "5.6"
 
+var rdsOracleSE2TestPlanID = "da91e15c-98c9-46a9-b114-02b8d28062c8"
+var rdsOracleSE2RedundantTestPlanID = "da91e15c-98c9-46a9-b114-02b8d28062c9"
+
 // Helper function to call os.Getwd with error checking
 func checkedGetwd(t *testing.T) string {
 	wd, err := os.Getwd()
@@ -122,6 +125,41 @@ func TestRDSMySQLCheckVersion(t *testing.T) {
 
 	if validVersion {
 		t.Error("Invalid RDS version check failed.")
+	}
+}
+
+func TestRDSOracleSE2Plans(t *testing.T) {
+	wd := checkedGetwd(t)
+	path := filepath.Join(wd, "..")
+	catalog := InitCatalog(path)
+
+	// Non-redundant (Single-AZ) Oracle SE2 plan.
+	base, err := catalog.RdsService.FetchPlan(rdsOracleSE2TestPlanID)
+	if err != nil {
+		t.Fatal("Could not fetch plan " + rdsOracleSE2TestPlanID)
+	}
+	if base.DbType != "oracle-se2" {
+		t.Errorf("base Oracle plan DbType = %q, want oracle-se2", base.DbType)
+	}
+	if base.Redundant {
+		t.Error("base medium-oracle-se2 plan must be Single-AZ (Redundant=false)")
+	}
+
+	// Redundant (Multi-AZ) Oracle SE2 plan.
+	redundant, err := catalog.RdsService.FetchPlan(rdsOracleSE2RedundantTestPlanID)
+	if err != nil {
+		t.Fatal("Could not fetch plan " + rdsOracleSE2RedundantTestPlanID)
+	}
+	if redundant.DbType != "oracle-se2" {
+		t.Errorf("redundant Oracle plan DbType = %q, want oracle-se2", redundant.DbType)
+	}
+	if !redundant.Redundant {
+		t.Error("medium-oracle-se2-redundant plan must be Multi-AZ (Redundant=true)")
+	}
+	// Oracle SE2 is not ReadReplicaCapable on RDS; the redundant plan must not
+	// request a read replica (would otherwise trip the ReadReplica && Redundant path).
+	if redundant.ReadReplica {
+		t.Error("Oracle SE2 redundant plan must not enable read_replica (SE2 is not replica-capable)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in **`medium-oracle-se2-redundant`** (Multi-AZ) Oracle SE2 catalog plan, mirroring `medium-psql-redundant`. The base `medium-oracle-se2` plan stays Single-AZ; customers who need redo/device redundancy can elect the redundant tier rather than having ~2x cost forced on every instance.

## Why

DISA Oracle 19c STIG **SV-276000** requires redo-log redundancy (≥3 groups, ≥2 members/group). Member multiplexing is impossible on RDS (no OS access; redo on EBS), but the STIG exempts single members when RAID-backed — and RDS **Multi-AZ** (synchronous cross-AZ replication) is that equivalent. There was no Oracle plan a customer could select to get it. This adds one, aligning with how PostgreSQL/MySQL already model redundancy (`redundant:` → AWS `MultiAZ`).

The corrected SV-276000 check (baseline fork PR #3) stays strict; this plan is the customer-elected path that satisfies the control's intent, dispositioned as a shared-responsibility compensating control in cg-oracle-database-19c-stig-overlay#30.

## Change

New plan, identical class/license/storage to the base Oracle plan, only the redundancy axis differs:

| field | base `medium-oracle-se2` | new `medium-oracle-se2-redundant` |
| --- | --- | --- |
| `redundant` | `false` (Single-AZ) | **`true` (Multi-AZ)** |
| `instanceClass` | db.t3.medium | db.t3.medium |
| `licenseModel` | license-included | license-included |
| `storage_type` | gp3 | gp3 |
| `read_replica` | unset (false) | unset (false) |
| cost | $118/mo | ~$236/mo |

`read_replica` is intentionally left unset: AWS confirms Oracle SE2 is `ReadReplicaCapable=false`; SE2 Multi-AZ is a standby mirror, not a readable replica. The broker's `ReadReplica && !Redundant` guard is unaffected (`read_replica=false`).

## AWS validation (read-only, GovCloud dev)

`describe-orderable-db-instance-options --engine oracle-se2 --engine-version 19.0.0.0.ru-2026-04...` confirms for `db.t3.medium`:
- `license-included` + `gp3` → **`MultiAZCapable: true`** ✅
- `ReadReplicaCapable: false` (informs leaving read_replica off)

So this exact plan config is a valid orderable Multi-AZ target.

## Verification

- New plan reuses existing bullet anchors (`*multi-az-rds`, `*oracle-se2`, `*minimum-2-cores`, `*minimum-4-gib-memory`, `*default-20-gb-storage`, `*license-included`); both Oracle plan blocks parse and resolve correctly (`redundant` false/true respectively).
- `catalog-template.yml` is spruce-rendered to `catalog.yml` at build (`ci/build-manifest.sh`); this is a template-only change.
- Fresh plan UUID assigned.

## Decision record

Approach approved via multi-perspective consensus (7/7): keep the check strict, add an opt-in redundant tier (don't force Multi-AZ), disposition SV-276000 as a customer-responsibility compensating control (overlay#30).

## Related

- cloud-gov/oracle-database-19c-stig-baseline PR #3 (SV-276000 check correction, approved)
- cg-oracle-database-19c-stig-overlay#30 (SV-276000 compensating-control / CRM disposition)
- aws-broker#541 / #558