### PR TITLE
feat(rds): apply Oracle 19c STIG-hardened parameter group (#568)

### DIFF
--- a/services/rds/parameter_group.go
+++ b/services/rds/parameter_group.go
@@ -334,6 +334,12 @@ func (p *awsParameterGroupClient) needCustomParameters(i *RDSInstance) bool {
 		return true
 	}
 
+	// Oracle SE2 always gets a broker-managed parameter group: the STIG-hardened
+	// baseline in getNewParameters is applied by default, not gated on any option.
+	if i.DbType == "oracle-se2" {
+		return true
+	}
+
 	return false
 }
 
@@ -579,6 +585,50 @@ func (p *awsParameterGroupClient) getNewParameters(i *RDSInstance) (map[string]m
 				}
 			}
 
+		}
+	}
+
+	// Oracle 19c STIG-hardened parameter baseline, applied to every brokered
+	// oracle-se2 instance (needCustomParameters returns true for oracle-se2).
+	// Each parameter maps to a DISA Oracle Database 19c STIG control. Apply
+	// methods: Oracle static (spfile) parameters take "pending-reboot"; dynamic
+	// (session/system-alterable) parameters take "immediate". These are the
+	// documented Oracle classifications; confirm against RDS engine defaults on
+	// the first live apply (DescribeEngineDefaultParameters ApplyType).
+	if i.DbType == "oracle-se2" {
+		customRDSParameters["oracle-se2"] = map[string]paramDetails{
+			// SRG-APP-000091 (AU-12): enable database auditing (extended). Static.
+			"audit_trail": {
+				value:       "DB,EXTENDED",
+				applyMethod: "pending-reboot",
+			},
+			// V-270623 / AU-12: audit privileged SYS operations. Static.
+			"audit_sys_operations": {
+				value:       "TRUE",
+				applyMethod: "pending-reboot",
+			},
+			// V-270606 / IA-5: enforce case-sensitive passwords. Dynamic.
+			"sec_case_sensitive_logon": {
+				value:       "TRUE",
+				applyMethod: "immediate",
+			},
+			// V-270650 / IA-2: disable remote OS password-file authentication. Static.
+			"remote_login_passwordfile": {
+				value:       "NONE",
+				applyMethod: "pending-reboot",
+			},
+			// AC-10 / SRG-APP-000001: enforce profile resource limits (session
+			// caps, etc.). Dynamic.
+			"resource_limit": {
+				value:       "TRUE",
+				applyMethod: "immediate",
+			},
+			// AC-3 / SRG-APP-000033: SQL92 DML-predicate least-privilege semantics.
+			// Static.
+			"sql92_security": {
+				value:       "TRUE",
+				applyMethod: "pending-reboot",
+			},
 		}
 	}
 

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -261,6 +261,16 @@ func TestNeedCustomParameters(t *testing.T) {
 				settings: &config.Settings{},
 			},
 		},
+		"oracle-se2 always needs a custom (STIG-hardened) parameter group": {
+			dbInstance: &RDSInstance{
+				DbType:          "oracle-se2",
+				credentialUtils: &RDSCredentialUtils{},
+			},
+			expectedOk: true,
+			parameterGroupAdapter: &awsParameterGroupClient{
+				settings: &config.Settings{},
+			},
+		},
 	}
 
 	for name, test := range testCases {
@@ -1087,6 +1097,43 @@ func TestGetNewParameters(t *testing.T) {
 			expectedParams: map[string]map[string]paramDetails{
 				"postgres": {
 					"log_connections": {value: "all", applyMethod: "immediate"},
+				},
+			},
+			parameterGroupAdapter: &awsParameterGroupClient{
+				rds:      &mockRDSClient{},
+				settings: &config.Settings{},
+			},
+		},
+		"oracle-se2 STIG-hardened parameter baseline": {
+			dbInstance: &RDSInstance{
+				DbType: "oracle-se2",
+			},
+			expectedParams: map[string]map[string]paramDetails{
+				"oracle-se2": {
+					"audit_trail": paramDetails{
+						value:       "DB,EXTENDED",
+						applyMethod: "pending-reboot",
+					},
+					"audit_sys_operations": paramDetails{
+						value:       "TRUE",
+						applyMethod: "pending-reboot",
+					},
+					"sec_case_sensitive_logon": paramDetails{
+						value:       "TRUE",
+						applyMethod: "immediate",
+					},
+					"remote_login_passwordfile": paramDetails{
+						value:       "NONE",
+						applyMethod: "pending-reboot",
+					},
+					"resource_limit": paramDetails{
+						value:       "TRUE",
+						applyMethod: "immediate",
+					},
+					"sql92_security": paramDetails{
+						value:       "TRUE",
+						applyMethod: "pending-reboot",
+					},
 				},
 			},
 			parameterGroupAdapter: &awsParameterGroupClient{


### PR DESCRIPTION
## Summary

Brokered `oracle-se2` instances currently get the RDS **default** parameter group — none of the DISA Oracle 19c STIG init parameters are applied (#564 shipped the TLS option group only). This adds the STIG-hardened parameter baseline.

First atomic PR against **#568**.

## Change

Adds an `oracle-se2` branch to the existing per-engine parameter machinery in `services/rds/parameter_group.go`, mirroring the `mysql`/`postgres` blocks — **no new abstraction** (the `RDSBaseline` engine remains a tracked follow-up per ADR-0003 / #568):

- `needCustomParameters`: `oracle-se2` always gets a broker-managed parameter group (the hardened baseline is applied by default, not gated on an option).
- `getNewParameters`: applies the 6 STIG parameters, each mapped to its DISA control, with the correct Oracle apply-method:

| Parameter | Value | Apply | Control |
|---|---|---|---|
| `audit_trail` | `DB,EXTENDED` | pending-reboot (static) | AU-12 |
| `audit_sys_operations` | `TRUE` | pending-reboot (static) | AU-12 |
| `sec_case_sensitive_logon` | `TRUE` | immediate (dynamic) | IA-5 |
| `remote_login_passwordfile` | `NONE` | pending-reboot (static) | IA-2 |
| `resource_limit` | `TRUE` | immediate (dynamic) | AC-10 |
| `sql92_security` | `TRUE` | pending-reboot (static) | AC-3 |

It reuses the existing engine-agnostic reconcile/apply pipeline (existing-parameter merge, apply-method handling) unchanged — **no change to postgres/mysql behavior.**

## Why this approach (minimal branch, not the engine abstraction)

Decided via multi-model consensus (6/7): a minimal branch is atomic, low-risk (touches only the Oracle path), and keeps the ADR-0003 `RDSBaseline` engine viable as a dedicated follow-up refactor once there are 3 engines to collapse. Adopting the abstraction *and* adding Oracle in one PR would couple a compliance fix to a refactor of live pg/mysql code, violating the "atomic PRs" guidance.

## Verification

- `go build ./...`, `go vet ./services/rds/...`, `gofmt` clean.
- `go test ./services/rds/...` green — including new table-driven cases asserting `needCustomParameters(oracle-se2) == true` and each parameter's value + apply-method; **postgres/mysql tests unchanged.**
- golangci-lint / pre-commit clean; commit GPG-signed.

## Apply-method caveat (acceptance check)

Apply-methods use the documented Oracle static/dynamic classification. Static (`pending-reboot`) parameters take effect after a reboot; RDS surfaces pending-reboot state via the existing modify path. **Confirm each parameter's `ApplyType` against the live RDS engine defaults on the first dev apply** (`describe-engine-default-parameters --engine oracle-se2`) — if any classification differs, adjust the `applyMethod`. This is dev-signal until the live-RDS proof (aws-broker#558).

## Related

- #568 (remaining Oracle STIG hardening — atomic PRs)
- ADR-0003 (RDSBaseline engine — Proposed; this stays consistent with a future extraction)
- #564 (TLS option group), overlay baseline controls that check these params