### PR TITLE
feat(rds): add max_idle_time to Oracle 19c born-hardened baseline

### DIFF
--- a/docs/oracle19c/hardening-baseline.md
+++ b/docs/oracle19c/hardening-baseline.md
@@ -16,9 +16,10 @@ page documents the durable deltas and the controls they map to.
 | `remote_login_passwordfile` | `NONE` | pending-reboot | disable remote OS password-file auth |
 | `resource_limit` | `TRUE` | immediate | enforce profile resource limits |
 | `sql92_security` | `TRUE` | pending-reboot | SQL92 DML-predicate least privilege |
+| `max_idle_time` | `15` | immediate | terminate idle sessions after 15 min (SV-270497 / AC-12) |
 
 `pending-reboot` parameters take effect after a reboot; the broker surfaces
-pending-reboot state via the existing async/modify path. All six are base Oracle
+pending-reboot state via the existing async/modify path. All seven are base Oracle
 init parameters available in SE2 (none are EE-only), so the baseline fully applies.
 
 ## Log exports (`baselines/oracle19c/log_exports.yml`)

--- a/services/rds/baselines/oracle19c/parameters.yml
+++ b/services/rds/baselines/oracle19c/parameters.yml
@@ -62,6 +62,17 @@ parameters:
     apply_method: pending-reboot
     stig_intent: "SQL92 security semantics (least privilege on DML predicates)."
 
+  # Automatically terminate idle user sessions after an organization-defined
+  # number of minutes (SV-270497 / AC-12). The STIG assumes 15 minutes when the
+  # organization has not documented a value. max_idle_time is a DYNAMIC parameter
+  # (confirmed modifiable on the RDS oracle-se2-19 family in GovCloud
+  # us-gov-west-1: IsModifiable=true, ApplyType=dynamic, AllowedValues
+  # 0-2147483647), so it applies immediately.
+  - name: max_idle_time
+    value: "15"
+    apply_method: immediate
+    stig_intent: "Terminate idle sessions after 15 minutes (SRG-APP-000295 / AC-12)."
+
   # Limit the number of concurrent connections a login may hold (defense in depth).
   # Left commented — value is deployment-specific and must be sized against app
   # concurrency before enabling.

--- a/services/rds/baselines_test.go
+++ b/services/rds/baselines_test.go
@@ -54,6 +54,7 @@ func TestOracleParameterBaselineContent(t *testing.T) {
 		"remote_login_passwordfile": "NONE",
 		"resource_limit":            "TRUE",
 		"sql92_security":            "TRUE",
+		"max_idle_time":             "15",
 	}
 	for name, want := range wantHardened {
 		got, ok := byName[name]
@@ -68,6 +69,10 @@ func TestOracleParameterBaselineContent(t *testing.T) {
 	// audit_trail is a static parameter — must be pending-reboot.
 	if byName["audit_trail"].ApplyMethod != "pending-reboot" {
 		t.Errorf("audit_trail must be pending-reboot (static), got %q", byName["audit_trail"].ApplyMethod)
+	}
+	// max_idle_time is a dynamic parameter — must apply immediately.
+	if byName["max_idle_time"].ApplyMethod != "immediate" {
+		t.Errorf("max_idle_time must be immediate (dynamic), got %q", byName["max_idle_time"].ApplyMethod)
 	}
 }
 

--- a/services/rds/parameter_group_test.go
+++ b/services/rds/parameter_group_test.go
@@ -730,6 +730,7 @@ func TestGetNewParameters(t *testing.T) {
 					"remote_login_passwordfile": paramDetails{value: "NONE", applyMethod: "pending-reboot"},
 					"resource_limit":            paramDetails{value: "TRUE", applyMethod: "immediate"},
 					"sql92_security":            paramDetails{value: "TRUE", applyMethod: "pending-reboot"},
+					"max_idle_time":             paramDetails{value: "15", applyMethod: "immediate"},
 				},
 			},
 			parameterGroupAdapter: &awsParameterGroupClient{
@@ -2635,6 +2636,7 @@ func TestOracleBornHardenedParamsReachAWS(t *testing.T) {
 		"remote_login_passwordfile": {"NONE", rdsTypes.ApplyMethodPendingReboot},
 		"resource_limit":            {"TRUE", rdsTypes.ApplyMethodImmediate},
 		"sql92_security":            {"TRUE", rdsTypes.ApplyMethodPendingReboot},
+		"max_idle_time":             {"15", rdsTypes.ApplyMethodImmediate},
 	}
 	for name, w := range want {
 		p, ok := got[name]


### PR DESCRIPTION
Add max_idle_time=15 (immediate) to the broker-managed Oracle 19c parameter
group baseline, enforcing automatic idle-session termination (SV-270497 / AC-12;
SRG-APP-000295). The STIG assumes 15 minutes when the organization has not
documented a value.

max_idle_time is a DYNAMIC parameter (confirmed modifiable on the RDS
oracle-se2-19 family in GovCloud us-gov-west-1: IsModifiable=true,
ApplyType=dynamic, AllowedValues 0-2147483647), so it applies immediately with
no reboot. This is the platform-layer remediation companion to the overlay
disposition (cg-oracle-database-19c-stig-overlay PR #43), which verifies the
setting via GV$PARAMETER rather than shipping ALTER SYSTEM hardening SQL.

Update baseline assertions (baselines_test.go, parameter_group_test.go) and the
hardening-baseline doc to include the new parameter (six -> seven).

Verification: go build, go test ./services/rds/, go vet, gofmt all pass.

Co-authored-by: OpenCode Agent <peter.burkholder@gsa.gov>
