### PR TITLE
fix(rds): unprovisionable micro-psql-redundant, wrong storage text, autoscale divergence

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -24,7 +24,7 @@ rds:
           - &default-postgresql-v18 "Default PostgreSQL v18"
           - &minimum-1-core "minimum 1 core"
           - &minimum-1-gib-memory "minimum 1 GiB memory"
-          - &default-10-gb-storage "Default 10 GB storage"
+          - &default-20-gb-storage "Default 20 GB storage"
         displayName: *micro-psql-name
       free: true
       adapter: dedicated
@@ -57,10 +57,11 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-1-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *micro-psql-redundant-name
       free: false
       adapter: dedicated
+      allocatedStorage: 20
       instanceClass: db.t3.micro
       approvedMajorVersions: *approved_rds_pg_versions
       dbVersion: *default-pg-version
@@ -86,7 +87,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-1-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *micro-psql-replica-name
       free: false
       adapter: dedicated
@@ -116,7 +117,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-2-gib-memory "minimum 2 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-psql-name
       free: false
       adapter: dedicated
@@ -145,7 +146,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-2-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-psql-redundant-name
       free: false
       adapter: dedicated
@@ -175,7 +176,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-2-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-psql-replica-name
       free: false
       adapter: dedicated
@@ -205,7 +206,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-4-gib-memory "minimum 4 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-psql-name
       free: false
       adapter: dedicated
@@ -234,7 +235,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-4-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-psql-redundant-name
       free: false
       adapter: dedicated
@@ -264,7 +265,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-4-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-psql-replica-name
       free: false
       adapter: dedicated
@@ -294,7 +295,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - &minimum-8-gib-memory "minimum 8 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-psql-name
       free: false
       adapter: dedicated
@@ -323,7 +324,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-psql-redundant
       free: false
       adapter: dedicated
@@ -353,7 +354,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-psql-replica
       free: false
       adapter: dedicated
@@ -383,7 +384,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-psql-name
       free: false
       adapter: dedicated
@@ -412,7 +413,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-psql-redundant-name
       free: false
       adapter: dedicated
@@ -441,7 +442,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-psql-replica-name
       free: false
       adapter: dedicated
@@ -471,7 +472,7 @@ rds:
           - *default-postgresql-v18
           - &minimum-2-cores "minimum 2 cores"
           - &minimum-16-gib-memory "minimum 16 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-name
       free: false
       adapter: dedicated
@@ -500,7 +501,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-2-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-redundant-name
       free: false
       adapter: dedicated
@@ -530,7 +531,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-2-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-replica-name
       free: false
       adapter: dedicated
@@ -561,7 +562,7 @@ rds:
           - *default-postgresql-v18
           - &minimum-4-cores "minimum 4 cores"
           - &minimum-32-gib-memory "minimum 32 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *2xlarge-gp-psql-name
       free: false
       adapter: dedicated
@@ -590,7 +591,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-32-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *2xlarge-gp-psql-redundant-name
       free: false
       adapter: dedicated
@@ -620,7 +621,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-32-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *2xlarge-gp-psql-replica-name
       free: false
       adapter: dedicated
@@ -651,7 +652,7 @@ rds:
           - *default-postgresql-v18
           - &minimum-4-cores "minimum 4 graviton cores"
           - &minimum-16-gib-memory "minimum 16 GiB memory"
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-m6-name
       free: false
       adapter: dedicated
@@ -680,7 +681,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-m6-redundant-name
       free: false
       adapter: dedicated
@@ -710,7 +711,7 @@ rds:
           - *default-postgresql-v18
           - *minimum-4-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-psql-m6-replica-name
       free: false
       adapter: dedicated
@@ -741,7 +742,7 @@ rds:
           - &default-mysql-description "Default MySQL v8"
           - *minimum-1-core
           - *minimum-1-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *micro-mysql-name
       free: true
       adapter: dedicated
@@ -773,7 +774,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-1-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *micro-mysql-replica-name
       free: true
       adapter: dedicated
@@ -803,7 +804,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-1-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *micro-mysql-name
       free: true
       adapter: dedicated
@@ -832,7 +833,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-2-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-mysql-name
       free: true
       adapter: dedicated
@@ -861,7 +862,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-2-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-mysql-redundant-name
       free: false
       adapter: dedicated
@@ -891,7 +892,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-2-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *small-mysql-replica-name
       free: false
       adapter: dedicated
@@ -921,7 +922,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-4-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-mysql-name
       free: false
       adapter: dedicated
@@ -950,7 +951,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-4-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-mysql-redundant-name
       free: false
       adapter: dedicated
@@ -980,7 +981,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-4-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-mysql-replica-name
       free: false
       adapter: dedicated
@@ -1010,7 +1011,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-mysql-name
       free: false
       adapter: dedicated
@@ -1039,7 +1040,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-mysql-redundant-name
       free: false
       adapter: dedicated
@@ -1069,7 +1070,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *medium-gp-mysql-replica-name
       free: false
       adapter: dedicated
@@ -1099,7 +1100,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-mysql-name
       free: false
       adapter: dedicated
@@ -1128,7 +1129,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-mysql-redundant-name
       free: false
       adapter: dedicated
@@ -1158,7 +1159,7 @@ rds:
           - *default-mysql-description
           - *minimum-1-core
           - *minimum-8-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *large-gp-mysql-replica-name
       free: false
       adapter: dedicated
@@ -1188,7 +1189,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-mysql-name
       free: false
       adapter: dedicated
@@ -1217,7 +1218,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-mysql-redundant-name
       free: false
       adapter: dedicated
@@ -1247,7 +1248,7 @@ rds:
           - *default-mysql-description
           - *minimum-2-cores
           - *minimum-16-gib-memory
-          - *default-10-gb-storage
+          - *default-20-gb-storage
         displayName: *xlarge-gp-mysql-replica-name
       free: false
       adapter: dedicated

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -121,7 +121,24 @@ func (i RDSInstance) modify(options Options, currentPlan *catalog.RDSPlan, newPl
 	// instance setting unchanged (so a modify does not silently DISABLE an
 	// already-opted-in autoscaling policy). We intentionally do NOT fall back to
 	// a plan value — plans carry no autoscaling default.
+	//
+	// The max must exceed the instance's allocated storage as it will be AFTER
+	// this modify, because RDS requires MaxAllocatedStorage > AllocatedStorage.
+	// Options.Validate cannot make this check: it only sees the request, so it
+	// compares against a storage value supplied in the SAME request and has no
+	// view of the stored instance. Rejecting here rather than letting it through
+	// keeps the persisted row and the AWS parameter in agreement —
+	// prepareModifyDbInstanceInput omits MaxAllocatedStorage when it is not
+	// greater than AllocatedStorage, so accepting a too-low value would update
+	// the broker's record, skip the AWS call, and report success for a no-op.
 	if options.MaxAllocatedStorage > 0 {
+		if options.MaxAllocatedStorage <= modifiedInstance.AllocatedStorage {
+			return nil, fmt.Errorf(
+				"invalid max_storage %d; must be greater than the instance's storage %d to enable autoscaling",
+				options.MaxAllocatedStorage,
+				modifiedInstance.AllocatedStorage,
+			)
+		}
 		modifiedInstance.MaxAllocatedStorage = options.MaxAllocatedStorage
 	}
 

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -983,6 +983,86 @@ func TestModifyInstance(t *testing.T) {
 			settings:      &config.Settings{},
 			expectUpdates: true,
 		},
+		// Storage autoscaling (#540). max_storage must exceed the instance's
+		// CURRENT allocated storage, not just any storage supplied in the same
+		// request. Without this check the modify was accepted, persisted to the
+		// instance row, and then silently dropped in prepareModifyDbInstanceInput
+		// (which only sets the AWS parameter when Max > Allocated) — leaving the
+		// broker's record disagreeing with AWS and the customer seeing success
+		// for a no-op.
+		"rejects max_storage below the instance's current allocated storage": {
+			options: Options{
+				StorageType:         "gp3",
+				MaxAllocatedStorage: 50,
+			},
+			existingInstance: &RDSInstance{
+				AllocatedStorage: 100,
+				StorageType:      "gp3",
+			},
+			expectedInstance: nil,
+			currentPlan:      &catalog.RDSPlan{},
+			newPlan:          &catalog.RDSPlan{},
+			settings:         &config.Settings{},
+			expectErr:        true,
+		},
+		"rejects max_storage equal to the instance's current allocated storage": {
+			options: Options{
+				StorageType:         "gp3",
+				MaxAllocatedStorage: 100,
+			},
+			existingInstance: &RDSInstance{
+				AllocatedStorage: 100,
+				StorageType:      "gp3",
+			},
+			expectedInstance: nil,
+			currentPlan:      &catalog.RDSPlan{},
+			newPlan:          &catalog.RDSPlan{},
+			settings:         &config.Settings{},
+			expectErr:        true,
+		},
+		"accepts max_storage above the instance's current allocated storage": {
+			options: Options{
+				StorageType:         "gp3",
+				MaxAllocatedStorage: 200,
+			},
+			existingInstance: &RDSInstance{
+				AllocatedStorage: 100,
+				StorageType:      "gp3",
+			},
+			expectedInstance: &RDSInstance{
+				AllocatedStorage:    100,
+				MaxAllocatedStorage: 200,
+				StorageType:         "gp3",
+				Tags:                map[string]string{},
+			},
+			currentPlan:   &catalog.RDSPlan{},
+			newPlan:       &catalog.RDSPlan{},
+			settings:      &config.Settings{},
+			expectUpdates: true,
+		},
+		// A storage increase in the same request is compared against the NEW
+		// allocation, not the old one.
+		"accepts max_storage above a storage increase in the same request": {
+			options: Options{
+				StorageType:         "gp3",
+				AllocatedStorage:    150,
+				MaxAllocatedStorage: 200,
+			},
+			existingInstance: &RDSInstance{
+				AllocatedStorage: 100,
+				StorageType:      "gp3",
+			},
+			expectedInstance: &RDSInstance{
+				AllocatedStorage:    150,
+				MaxAllocatedStorage: 200,
+				StorageType:         "gp3",
+				Tags:                map[string]string{},
+			},
+			currentPlan:   &catalog.RDSPlan{},
+			newPlan:       &catalog.RDSPlan{},
+			settings:      &config.Settings{},
+			expectUpdates: true,
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Why this exists

Found while scoping #572 (extend storage autoscaling to pg/mysql). Three defects that are independent of #468's unresolved acceptance criteria, so they land on their own rather than waiting for that conversation. **#572 itself is deliberately not implemented here** — see the note at the bottom.

## 1. `micro-psql-redundant` was unprovisionable

It omitted `allocatedStorage` entirely — the only one of 43 RDS plans to do so.

Traced the before-state rather than assuming: `RDSInstance.init` falls back to `plan.AllocatedStorage` (0), and unlike the modify path there is **no create-path gp3 minimum guard**, so `prepareCreateDbInput` sends `CreateDBInstanceInput.AllocatedStorage = 0`. The plan is `storage_type: gp3`, minimum 20 GB. Set to 20, matching every other plan.

## 2. Every plan advertised "Default 10 GB storage" while allocating 20

The `&default-10-gb-storage` anchor is aliased by all 42 RDS plans, and every plan allocates 20 GB. Customer-facing metadata was simply wrong. Renamed to `&default-20-gb-storage`.

Verified by parsing the rendered catalog: 43 plans, all `allocatedStorage: 20`, zero claiming 10 GB, zero claiming 20 GB while not being 20.

## 3. ⚠️ BEHAVIOUR CHANGE — `max_storage` below current allocated storage now errors

Calling this a behaviour change, not a fix, because an input class that previously returned success now returns an error.

**Before:** a modify with `max_storage` ≤ the instance's **current** allocated storage passed `Options.Validate`, was written to `modifiedInstance`, then silently dropped by `prepareModifyDbInstanceInput` (which only sets the AWS parameter when Max > Allocated). The customer got **success for a no-op**, and the broker's record disagreed with what was sent to AWS.

`Options.Validate` cannot catch this — it receives only the request, so its existing check compares against a `storage` value supplied in the *same* request (guarded by `o.AllocatedStorage > 0`) and has no view of the stored instance. The check belongs in `RDSInstance.modify`, after the allocated-storage update, so it compares against the post-modify allocation.

**After:** rejected with `invalid max_storage N; must be greater than the instance's storage M to enable autoscaling`. A customer wanting a lower ceiling must raise `storage` in the same request or leave `max_storage` unset.

`max_storage: 0` remains a deliberate no-op leaving an existing policy untouched — unchanged, so **there is still no way to disable autoscaling once enabled**. Flagged, not fixed: that needs a product decision about whether #540's opt-in should also be opt-out-able.

## Tests

4 table cases added to `TestModifyInstance`: reject-below, reject-equal, accept-above, accept-above-a-same-request-increase. **Confirmed all four fail against unmodified production code** before the change, then pass after.

## Investigated and dismissed

`modify()` clears `StorageType` in-memory when `options.StorageType` is empty, which looked like a second divergence. It isn't — `prepareModifyDbInstanceInput` guards `if i.StorageType != ""` so the parameter is omitted, and only the `state` column is persisted (`broker.go:420`). My initial fixtures were wrong, not the code.

## Noted, not changed

`catalog-template.yml` has pre-existing duplicate YAML anchors (`&minimum-4-cores` at 562/652, `&micro-mysql-name` at 736/798). Legal YAML with later-wins semantics and present on `main`, so out of scope — but they break strict parsers (`pyyaml` refuses the file).

## Why #572 is not implemented here

The investigation found its criteria aren't implementable as written, and I'd rather flag that than guess:

- **#468 contradicts itself** — prose says "up to the new 3 TB limit", acceptance criteria say "hard cap of 2 TB".
- **"pg/mysql plan default 1 TB autoscaling" would reverse #562's review decision.** The `plan.MaxAllocatedStorage` → instance fallback was deleted at @markdboyd's request specifically so autoscaling could never be a plan default. Re-adding it re-opens the surprise-cost path just closed — that needs explicit re-agreement, not a follow-up PR.
- **Raising the cap 1024 → 2048 also doubles the *direct provisioning* ceiling.** `settings.MaxAllocatedStorage` gates both `storage` and `max_storage`. An asymmetric limit needs a second setting. And `MAX_ALLOCATED_STORAGE` is unset in every pipeline environment, so changing the Go default hits dev/staging/prod simultaneously.
- **Sandbox gating doesn't exist here.** `grep -i sandbox` → three prose comments, zero implementation. Plan visibility is controlled *outside* this repo by `SERVICES` allowlists in `ci/pipeline.yml`. Whether "sandbox" is a CF org, foundation, or deployment isn't discoverable from this repo.

I'll post that as a comment on #572 so the questions are tracked.

## Verification

`go build ./...` clean · `go test ./...` all packages pass · `gofmt` clean · `go vet` clean · pre-commit (incl. golangci-lint, gitleaks) passed · commit GPG-signed.

Base is `feat/oracle-19c-stig-brokered-rds` per the Oracle branching policy.

Refs #540, #572

---
🤖 AI-assisted (OpenCode). Human review required before merge.