### PR TITLE
Fix replica cleanup

### DIFF
--- a/services/rds/create_worker_test.go
+++ b/services/rds/create_worker_test.go
@@ -439,7 +439,7 @@ func TestPrepareCreateDbInstanceInput(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			test.dbInstance.setTags(test.plan, test.tags) //nolint:errcheck // test setup; setTags failure surfaces downstream in the test
+			test.dbInstance.setTags(test.plan, test.tags)
 			params, err := test.worker.prepareCreateDbInput(test.dbInstance, test.plan, test.password)
 			if err != nil && test.expectedErr == nil {
 				t.Errorf("expected error: %s, got: %s", test.expectedErr, err)

--- a/services/rds/delete_worker.go
+++ b/services/rds/delete_worker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/cloud-gov/aws-broker/asyncmessage"
 	"github.com/cloud-gov/aws-broker/base"
 	"github.com/cloud-gov/aws-broker/config"
@@ -58,65 +57,12 @@ func (w *DeleteWorker) Work(ctx context.Context, job *river.Job[DeleteArgs]) err
 	return w.asyncDeleteDB(ctx, job.Args.Instance)
 }
 
-func (w *DeleteWorker) waitForDbDeleted(ctx context.Context, operation base.Operation, i *RDSInstance, database string) error {
-	w.logger.Debug(fmt.Sprintf("Waiting for DB instance %s to be deleted", database))
-
-	// Create a waiter
-	waiter := rds.NewDBInstanceDeletedWaiter(w.rds, func(dawo *rds.DBInstanceDeletedWaiterOptions) {
-		dawo.MinDelay = w.settings.PollAwsMinDelay
-	})
-
-	// Define the waiting strategy
-	maxWaitTime := getPollAwsMaxWaitTime(i.AllocatedStorage, w.settings.PollAwsMaxDuration)
-
-	waiterInput := &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: &database,
-	}
-	err := waiter.Wait(ctx, waiterInput, maxWaitTime)
-
-	if err != nil {
-		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed waiting for database to be deleted: %s", err))
-		return fmt.Errorf("waitForDbReady: %w", err)
-	}
-
-	return nil
-}
-
-func (w *DeleteWorker) deleteDatabaseInstance(ctx context.Context, i *RDSInstance, operation base.Operation, database string) error {
-	params := prepareDeleteDbInput(database)
-	_, err := w.rds.DeleteDBInstance(ctx, params)
-	if err != nil {
-		if isDatabaseInstanceNotFoundError(err) {
-			w.logger.Debug(fmt.Sprintf("database %s was already deleted, continuing", database))
-			return nil
-		} else {
-			return fmt.Errorf("deleteDatabaseInstance: %w", err)
-		}
-	}
-
-	err = w.waitForDbDeleted(ctx, operation, i, database)
-	if err != nil {
-		return fmt.Errorf("deleteDatabaseInstance: %w", err)
-	}
-
-	return nil
-}
-
-func (w *DeleteWorker) deleteDatabaseReadReplica(ctx context.Context, i *RDSInstance, operation base.Operation) error {
-	err := w.deleteDatabaseInstance(ctx, i, operation, i.ReplicaDatabase)
-	if err != nil {
-		return fmt.Errorf("deleteDatabaseReadReplica: %w", err)
-	}
-	i.ReplicaDatabase = ""
-	return nil
-}
-
 func (w *DeleteWorker) asyncDeleteDB(ctx context.Context, i *RDSInstance) error {
 	operation := base.DeleteOp
 
 	if i.ReplicaDatabase != "" {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Deleting database replica")
-		err := w.deleteDatabaseReadReplica(ctx, i, operation)
+		err := deleteDatabaseReadReplica(ctx, w.db, w.settings, w.rds, w.logger, i, operation)
 		if err != nil {
 			asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to delete replica database: %s", err))
 			w.logger.Error("asyncDeleteDB: deleteDatabaseReadReplica error", "err", err)
@@ -125,7 +71,7 @@ func (w *DeleteWorker) asyncDeleteDB(ctx context.Context, i *RDSInstance) error 
 	}
 
 	asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceInProgress, "Deleting database")
-	err := w.deleteDatabaseInstance(ctx, i, operation, i.Database)
+	err := deleteDatabaseInstance(ctx, w.db, w.settings, w.rds, w.logger, i, operation, i.Database)
 	if err != nil {
 		asyncmessage.WriteAsyncJobMessageAndLogError(w.db, w.logger, i.ServiceID, i.Uuid, operation, base.InstanceNotGone, fmt.Sprintf("Failed to delete database: %s", err))
 		w.logger.Error("asyncDeleteDB: deleteDatabaseInstance error", "err", err)

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -376,6 +376,10 @@ func (d *dedicatedDBAdapter) reconcileDbState(ctx context.Context, i RDSInstance
 		reconciledInstance.AllocatedStorage = int64(*dbInstanceState.AllocatedStorage)
 	}
 
+	if len(dbInstanceState.ReadReplicaDBInstanceIdentifiers) == 0 && (reconciledInstance.ReplicaDatabase != "" || reconciledInstance.ReplicaDatabaseHost != "") {
+		reconciledInstance.removeReplicaDatabaseProperties()
+	}
+
 	return &reconciledInstance, nil
 }
 

--- a/services/rds/rds_test.go
+++ b/services/rds/rds_test.go
@@ -791,6 +791,30 @@ func TestReconcileDbState(t *testing.T) {
 			dbInstance: RDSInstance{},
 			expectErr:  true,
 		},
+		"remove replica properties": {
+			ctx: t.Context(),
+			dbAdapter: NewTestDedicatedDBAdapter(
+				t.Context(),
+				brokerDB,
+				&config.Settings{},
+				&mockRDSClient{
+					describeDbInstancesResults: []*rds.DescribeDBInstancesOutput{
+						{
+							DBInstances: []rdsTypes.DBInstance{
+								{}, // has no replica properties
+							},
+						},
+					},
+				},
+				&mockParameterGroupClient{},
+				&mockOptionGroupClient{},
+			),
+			dbInstance: RDSInstance{
+				ReplicaDatabase:     "replica",
+				ReplicaDatabaseHost: "host",
+			},
+			expectedInstance: &RDSInstance{},
+		},
 	}
 
 	for name, test := range testCases {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -181,7 +181,7 @@ func (i RDSInstance) modify(options Options, currentPlan *catalog.RDSPlan, newPl
 		modifiedInstance.DeleteReadReplica = true
 	}
 
-	modifiedInstance.setTags(newPlan, tags) //nolint:errcheck // decide fail-vs-best-effort on tagging failure
+	modifiedInstance.setTags(newPlan, tags)
 
 	return &modifiedInstance, nil
 }
@@ -234,7 +234,7 @@ func (i *RDSInstance) init(
 		return err
 	}
 
-	i.setTags(plan, tags) //nolint:errcheck // decide fail-vs-best-effort on tagging failure
+	i.setTags(plan, tags)
 
 	i.StorageType = plan.StorageType
 
@@ -318,7 +318,7 @@ func (i *RDSInstance) initMutex() {
 func (i *RDSInstance) setTags(
 	plan *catalog.RDSPlan,
 	tags map[string]string,
-) error {
+) {
 	i.initMutex()
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -332,7 +332,6 @@ func (i *RDSInstance) setTags(
 	for k, v := range tags {
 		i.Tags[k] = v
 	}
-	return nil
 }
 
 func (i *RDSInstance) getTags() map[string]string {

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -354,6 +354,11 @@ func (i *RDSInstance) setEnabledCloudwatchLogGroupExports(enabledLogGroups []str
 	return nil
 }
 
+func (i *RDSInstance) removeReplicaDatabaseProperties() {
+	i.ReplicaDatabase = ""
+	i.ReplicaDatabaseHost = ""
+}
+
 func (existing *PgQueryLoggingOptions) merge(updates *PgQueryLoggingOptions) *PgQueryLoggingOptions {
 	merged := *existing
 

--- a/services/rds/rdsinstance_test.go
+++ b/services/rds/rdsinstance_test.go
@@ -1099,7 +1099,7 @@ func TestSetTagsConcurrency(t *testing.T) {
 	updateInstanceTags := func(tags map[string]string, expectedTags map[string]string, wg *sync.WaitGroup) {
 		defer wg.Done()
 		i := &RDSInstance{}
-		i.setTags(plan, tags) //nolint:errcheck // test setup; setTags failure surfaces downstream in the test
+		i.setTags(plan, tags)
 
 		updatedTags := i.getTags()
 
@@ -1124,8 +1124,8 @@ func TestSetTagsInitializesMutex(t *testing.T) {
 		},
 	}
 
-	i := &RDSInstance{}                                // no mutex defined by default
-	i.setTags(plan, map[string]string{"foo2": "bar2"}) //nolint:errcheck // test setup; setTags failure surfaces downstream in the test
+	i := &RDSInstance{} // no mutex defined by default
+	i.setTags(plan, map[string]string{"foo2": "bar2"})
 
 	updatedTags := i.getTags()
 	expectedTags := map[string]string{
@@ -1181,7 +1181,7 @@ func TestRDSInstanceMarshalAndUnmarshal(t *testing.T) {
 		ReplicaDatabase:      "replica",
 		ReplicaDatabaseHost:  "host",
 	}
-	i.setTags(&catalog.RDSPlan{}, map[string]string{ //nolint:errcheck // test setup; setTags failure surfaces downstream in the test
+	i.setTags(&catalog.RDSPlan{}, map[string]string{
 		"foo": "bar",
 	})
 	output, err := json.Marshal(i)

--- a/services/rds/worker_utils.go
+++ b/services/rds/worker_utils.go
@@ -226,7 +226,7 @@ func deleteDatabaseReadReplica(
 	if err != nil {
 		return fmt.Errorf("deleteDatabaseReadReplica: %w", err)
 	}
-	i.ReplicaDatabase = ""
+	i.removeReplicaDatabaseProperties()
 	return nil
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- d8372cfe add logic to clean up database instance replica properties when reconciling database instances properties during modify instance flow
- 59b48dbd remove superfluous error return value from RDSInstance.setTags() function
- d9480289 add removeReplicaDatabaseProperties() for removing replica properties from database instance & refactor to remove duplicate code


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bugs in handling of replica properties when replica databases are being deleted or have been deleted and the instance state was not updated correctly to reflect the deletion